### PR TITLE
Added "cycle error log" jobs as default jobs to the installer

### DIFF
--- a/MaintenanceSolution.sql
+++ b/MaintenanceSolution.sql
@@ -7558,6 +7558,16 @@ BEGIN
          'cmd /q /c "For /F "tokens=1 delims=" %v In (''ForFiles /P "' + COALESCE(@OutputFileDirectory,@TokenLogDirectory,@LogDirectory) + '" /m *_*_*_*.txt /d -30 2^>^&1'') do if EXIST "' + COALESCE(@OutputFileDirectory,@TokenLogDirectory,@LogDirectory) + '"\%v echo del "' + COALESCE(@OutputFileDirectory,@TokenLogDirectory,@LogDirectory) + '"\%v& del "' + COALESCE(@OutputFileDirectory,@TokenLogDirectory,@LogDirectory) + '"\%v"',
          'OutputFileCleanup'
 
+  INSERT INTO @Jobs ([Name], CommandTSQL, DatabaseName)
+  SELECT 'sp_cycle_errorlog',
+         'EXECUTE dbo.sp_cycle_errorlog',
+         'master'
+
+  INSERT INTO @Jobs ([Name], CommandTSQL, DatabaseName)
+  SELECT 'sp_cycle_agent_errorlog',
+         'EXECUTE dbo.sp_cycle_agent_errorlog',
+         'master'
+
   IF @AmazonRDS = 1
   BEGIN
    UPDATE @Jobs
@@ -7568,7 +7578,7 @@ BEGIN
   BEGIN
    UPDATE @Jobs
    SET Selected = 1
-   WHERE [Name] IN('DatabaseIntegrityCheck - SYSTEM_DATABASES','DatabaseIntegrityCheck - USER_DATABASES','IndexOptimize - USER_DATABASES','CommandLog Cleanup','sp_delete_backuphistory','sp_purge_jobhistory')
+   WHERE [Name] IN('DatabaseIntegrityCheck - SYSTEM_DATABASES','DatabaseIntegrityCheck - USER_DATABASES','IndexOptimize - USER_DATABASES','CommandLog Cleanup','sp_delete_backuphistory','sp_purge_jobhistory','sp_cycle_errorlog','sp_cycle_agent_errorlog')
   END
   ELSE IF @HostPlatform = 'Windows'
   BEGIN


### PR DESCRIPTION
When the maintenance solution is installed, a set of jobs are created when desired. A couple of jobs are created to clean up job and backup history entries from the msdb.

One regular addition I make with clients is to cycle the SQL Server error log. Cycling the error log keeps each log file smaller and easier to read/parse.

As with all the jobs created, these would be without a schedule and it is up to the user to deal with that.

It's a truly small PR, but would help make sure that people are more aware of this feature and allow standardized roll-out with the maintenance solution as a whole.