### PR TITLE
Add an @Stats variable to backups to show progress in the console

### DIFF
--- a/MaintenanceSolution.sql
+++ b/MaintenanceSolution.sql
@@ -401,7 +401,8 @@ ALTER PROCEDURE [dbo].[DatabaseBackup]
 @DatabaseOrder nvarchar(max) = NULL,
 @DatabasesInParallel nvarchar(max) = 'N',
 @LogToTable nvarchar(max) = 'N',
-@Execute nvarchar(max) = 'Y'
+@Execute nvarchar(max) = 'Y',
+@Stats int = null
 
 AS
 
@@ -656,6 +657,7 @@ BEGIN
   SET @Parameters = @Parameters + ', @DatabasesInParallel = ' + ISNULL('''' + REPLACE(@DatabasesInParallel,'''','''''') + '''','NULL')
   SET @Parameters = @Parameters + ', @LogToTable = ' + ISNULL('''' + REPLACE(@LogToTable,'''','''''') + '''','NULL')
   SET @Parameters = @Parameters + ', @Execute = ' + ISNULL('''' + REPLACE(@Execute,'''','''''') + '''','NULL')
+  SET @Parameters = @Parameters + ', @Stats = ' + ISNULL(CAST(@Stats AS nvarchar), 'NULL')
 
   SET @StartMessage = 'Date and time: ' + CONVERT(nvarchar,@StartTime,120)
   RAISERROR(@StartMessage,10,1) WITH NOWAIT
@@ -1726,6 +1728,13 @@ BEGIN
     SET @Error = @@ERROR
   END
 
+  IF ISNULL(@Stats, 1) NOT BETWEEN 1 AND 100
+  BEGIN;
+    SET @ErrorMessage = 'The value for the parameter @stats is not supported.' + CHAR(13) + CHAR(10) + ' '
+    RAISERROR(@ErrorMessage,16,1) WITH NOWAIT;
+    SET @Error = @@ERROR
+  END;
+
   IF @Error <> 0
   BEGIN
     SET @ErrorMessage = 'The documentation is available at https://ola.hallengren.com/sql-server-backup.html.' + CHAR(13) + CHAR(10) + ' '
@@ -1733,6 +1742,7 @@ BEGIN
     SET @ReturnCode = @Error
     GOTO Logging
   END
+
 
   ----------------------------------------------------------------------------------------------------
   --// Check that selected databases and availability groups exist                                //--
@@ -2931,6 +2941,7 @@ BEGIN
           IF @Encrypt = 'Y' AND @ServerAsymmetricKey IS NOT NULL SET @CurrentCommand03 = @CurrentCommand03 + 'SERVER ASYMMETRIC KEY = ' + QUOTENAME(@ServerAsymmetricKey)
           IF @Encrypt = 'Y' SET @CurrentCommand03 = @CurrentCommand03 + ')'
           IF @URL IS NOT NULL AND @Credential IS NOT NULL SET @CurrentCommand03 = @CurrentCommand03 + ', CREDENTIAL = N''' + REPLACE(@Credential,'''','''''') + ''''
+          IF @Stats IS NOT NULL SET @CurrentCommand03 = @CurrentCommand03 + ', STATS = ' + CAST(@Stats AS nvarchar)
         END
 
         IF @BackupSoftware = 'LITESPEED'
@@ -3152,6 +3163,7 @@ BEGIN
             SET @CurrentCommand04 = @CurrentCommand04 + ' WITH '
             IF @CheckSum = 'Y' SET @CurrentCommand04 = @CurrentCommand04 + 'CHECKSUM'
             IF @CheckSum = 'N' SET @CurrentCommand04 = @CurrentCommand04 + 'NO_CHECKSUM'
+            IF @Stats IS NOT NULL SET @CurrentCommand04 = @CurrentCommand04 + ', STATS = ' + CAST(@Stats AS nvarchar)
             IF @URL IS NOT NULL AND @Credential IS NOT NULL SET @CurrentCommand04 = @CurrentCommand04 + ', CREDENTIAL = N''' + REPLACE(@Credential,'''','''''') + ''''
           END
 


### PR DESCRIPTION
When doing an adhoc backup its often helpful to output progress statistics with the `STATS` option.  I have added an `@Stats` parameter to the `dbo.DatabaseBackup` command to facilitate this.

Note:
- By default it is set to `NULL` which is interpreted as "off" (existing behaviour is retained)
- It only accepts values between 1 and 100 (as well as `NULL` obviously) and will throw an error if this range is exceeded
- It has been added to both the `BACKUP` and `RESTORE VERIFYONLY` commands.