### PR TITLE
Update DatabaseIntegrityCheck.sql

### DIFF
--- a/DatabaseIntegrityCheck.sql
+++ b/DatabaseIntegrityCheck.sql
@@ -914,7 +914,7 @@ BEGIN
   IF @DatabaseOrder IN('DATABASE_SIZE_ASC','DATABASE_SIZE_DESC')
   BEGIN
     UPDATE tmpDatabases
-    SET DatabaseSize = (SELECT SUM(size) FROM sys.master_files WHERE [type] = 0 AND database_id = DB_ID(tmpDatabases.DatabaseName))
+    SET DatabaseSize = (SELECT SUM(cast(size as bigint)) FROM sys.master_files WHERE [type] = 0 AND database_id = DB_ID(tmpDatabases.DatabaseName))
     FROM @tmpDatabases tmpDatabases
   END
 


### PR DESCRIPTION
fixed int overflow error. Our databases are too huge. one of them's size is 6324639544 :) (SELECT SUM(cast(size as bigint)) FROM sys.master_files WHERE [type] = 0 and database_id=24)

**Executed script detail:**
EXECUTE dbo.DatabaseIntegrityCheck
@Databases = 'ALL_DATABASES',
@LogToTable = 'Y',  
@NoIndex='Y',
@PhysicalOnly='Y',
@DatabasesInParallel='Y',
@DatabaseOrder ='DATABASE_SIZE_ASC',
@Execute='N'

**Head of output:**
Date and time: 2019-08-20 10:49:52
Server: xxxxxServerNamexxxxx
Version: 12.0.6024.0
Edition: Enterprise Edition: Core-based Licensing (64-bit)
Platform: Windows
Procedure: [SQLAdmin].[dbo].[DatabaseIntegrityCheck]
Parameters: @Databases = 'ALL_DATABASES', @CheckCommands = 'CHECKDB', @PhysicalOnly = 'Y', @NoIndex = 'Y', @ExtendedLogicalChecks = 'N', @TabLock = 'N', @FileGroups = NULL, @Objects = NULL, @MaxDOP = NULL, @AvailabilityGroups = NULL, @AvailabilityGroupReplicas = 'ALL', @Updateability = 'ALL', @TimeLimit = NULL, @LockTimeout = NULL, @LockMessageSeverity = 16, @DatabaseOrder = 'DATABASE_SIZE_ASC', @DatabasesInParallel = 'Y', @LogToTable = 'Y', @Execute = 'N'
Version: 2019-06-14 00:05:34
Source: https://ola.hallengren.com

**Error Detail:**
Msg 8115, Level 16, State 2, Procedure DatabaseIntegrityCheck, Line 958 [Batch Start Line 0]
Arithmetic overflow error converting expression to data type int.

