### PR TITLE
Add support for resuming index operations on Sql Azure

### DIFF
--- a/IndexOptimize.sql
+++ b/IndexOptimize.sql
@@ -2088,7 +2088,7 @@ BEGIN
             SELECT CASE WHEN @Resumable = 'Y' AND @CurrentIndexType IN(1,2) AND @CurrentIsComputed = 0 AND @CurrentIsTimestamp = 0 THEN 'RESUMABLE = ON' ELSE 'RESUMABLE = OFF' END
           END
 
-          IF (@Version >= 14 OR SERVERPROPERTY('EngineEdition') IN (5,8)) AND @CurrentAction = 'INDEX_REBUILD_ONLINE' AND @CurrentResumableIndexOperation = 0 AND @Resumable = 'Y'  AND @CurrentIndexType IN(1,2) AND @CurrentIsComputed = 0 AND @CurrentIsTimestamp = 0 AND @TimeLimit IS NOT NULL
+          IF (@Version >= 14 OR SERVERPROPERTY('EngineEdition') IN (5,8)) AND @CurrentAction = 'INDEX_REBUILD_ONLINE' AND @Resumable = 'Y'  AND @CurrentIndexType IN(1,2) AND @CurrentIsComputed = 0 AND @CurrentIsTimestamp = 0 AND @TimeLimit IS NOT NULL
           BEGIN
             INSERT INTO @CurrentAlterIndexWithClauseArguments (Argument)
             SELECT 'MAX_DURATION = ' + CAST(DATEDIFF(MINUTE,SYSDATETIME(),DATEADD(SECOND,@TimeLimit,@StartTime)) AS nvarchar(max))


### PR DESCRIPTION
When using @TimeLimit on an @Resumable = 1 operation on Sql Azure, the previous operation is not resumed due to not meeting the @Version >= 14 condition for sys.index_resumable_operations, causing this error on next execution:
`Cannot perform this operation on 'object' with ID 1586104691 as one or more indexes are currently in resumable index rebuild state. Please refer to sys.index_resumable_operations for more details.`

The sys.index_resumable_operations feature is supported on Azure Sql Database and was added to the condition.
