### PR TITLE
Introduce Linux-Compatable Output File Cleanup Job

### DIFF
--- a/MaintenanceSolution.sql
+++ b/MaintenanceSolution.sql
@@ -1,4 +1,4 @@
-﻿/*
+/*
 
 SQL Server Maintenance Solution - SQL Server 2008, SQL Server 2008 R2, SQL Server 2012, SQL Server 2014, SQL Server 2016, SQL Server 2017, and SQL Server 2019
 
@@ -8979,12 +8979,24 @@ BEGIN
          'DELETE FROM [dbo].[CommandLog]' + CHAR(13) + CHAR(10) + 'WHERE StartTime < DATEADD(dd,-30,GETDATE())',
          @DatabaseName,
          'CommandLogCleanup'
-
-  INSERT INTO @Jobs ([Name], CommandCmdExec, OutputFileNamePart01)
-  SELECT 'Output File Cleanup',
+  
+  IF @HostPlatform = 'Linux' AND @Version >= 14.032573
+  BEGIN
+    -- Compatable with SQL Server 2017 CU18+.  Slower than the cmd version, but works all platforms.
+    INSERT INTO @Jobs ([Name], CommandTSQL, DatabaseName, OutputFileNamePart01)
+    SELECT 'Output File Cleanup',
+           'DECLARE @files TABLE (id int identity(1,1), full_filesystem_path nvarchar(2000) NOT NULL)' + CHAR(13) + CHAR(10) + 'DECLARE @file_path nvarchar(2000)' + CHAR(13) + CHAR(10) + 'INSERT INTO @files(full_filesystem_path)' + CHAR(13) + CHAR(10) + 'SELECT full_filesystem_path FROM sys.dm_os_enumerate_filesystem(''' + COALESCE(@OutputFileDirectory,@TokenLogDirectory,@LogDirectory) + ''',''*_*_*_*.txt'') WHERE last_write_time < DATEADD(DAY,-30,GETDATE()) AND is_directory = 0' + CHAR(13) + CHAR(10) + 'DECLARE @rMax int = @@ROWCOUNT' + CHAR(13) + CHAR(10) + 'DECLARE @r int = 1' + CHAR(13) + CHAR(10) + 'WHILE (@r<=@rMax)' + CHAR(13) + CHAR(10) + 'BEGIN' + CHAR(13) + CHAR(10) + '	SELECT @file_path = full_filesystem_path FROM @files WHERE id = @r' + CHAR(13) + CHAR(10) + CHAR(9) + 'EXEC sys.xp_delete_files @file_path' + CHAR(13) + CHAR(10) + CHAR(9) + 'SET @r = @r + 1' + CHAR(13) + CHAR(10) + 'END',
+           NULL,
+           'OutputFileCleanup'
+  END
+  ELSE IF @HostPlatform = 'Windows'
+  BEGIN
+    INSERT INTO @Jobs ([Name], CommandCmdExec, OutputFileNamePart01)
+    SELECT 'Output File Cleanup',
          'cmd /q /c "For /F "tokens=1 delims=" %v In (''ForFiles /P "' + COALESCE(@OutputFileDirectory,@TokenLogDirectory,@LogDirectory) + '" /m *_*_*_*.txt /d -30 2^>^&1'') do if EXIST "' + COALESCE(@OutputFileDirectory,@TokenLogDirectory,@LogDirectory) + '"\%v echo del "' + COALESCE(@OutputFileDirectory,@TokenLogDirectory,@LogDirectory) + '"\%v& del "' + COALESCE(@OutputFileDirectory,@TokenLogDirectory,@LogDirectory) + '"\%v"',
          'OutputFileCleanup'
-
+  END
+  
   IF @AmazonRDS = 1
   BEGIN
    UPDATE @Jobs


### PR DESCRIPTION
Introduces a version of the Output File Cleanup job that is written in T-SQL and is compatible with SQL Server 2017 CU18+ on all platforms.

It relies upon master.sys.xp_delete_files (the plural version) that was introduced with SQL Server 2019 and back-ported to SQL Server 2017 with CU18.  master.sys.dm_os_enumerate_filesystem is also used, but that was introduced with SQL Server 2017 so it doesn't impact compatability as much as xp_delete_files.

Due to the loop it is slower than the cmd version so that version will continue to be used on Windows hosts.