### PR TITLE
Excluded columnstore indexes

### DIFF
--- a/IndexOptimize.sql
+++ b/IndexOptimize.sql
@@ -1608,7 +1608,7 @@ BEGIN
 
           SET @CurrentCommand = @CurrentCommand + ' WHERE objects.[type] IN(''U'',''V'')'
                                                     + CASE WHEN @MSShippedObjects = 'N' THEN ' AND objects.is_ms_shipped = 0' ELSE '' END
-                                                    + ' AND indexes.[type] IN(1,2,3,4,5,6,7)'
+                                                    + ' AND indexes.[type] IN(1,2,3,4,7)'
                                                     + ' AND indexes.is_disabled = 0 AND indexes.is_hypothetical = 0'
         END
 


### PR DESCRIPTION
Excluded columnstore indexes, since sys.dm_db_index_physical_stats is not valid for these anyway. For now, use another mechanism for maintaining columnstores.