### PR TITLE
fix issue 658 and 700

### DIFF
--- a/DatabaseBackup.sql
+++ b/DatabaseBackup.sql
@@ -3354,7 +3354,7 @@ BEGIN
 
           SET @CurrentCommandType = 'xp_create_subdir'
 
-          SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_create_subdir N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''' IF @ReturnCode <> 0 RAISERROR(''Error creating directory.'', 16, 1)'
+          SET @CurrentCommand = 'DECLARE @t TABLE (msg NVARCHAR(MAX)) DECLARE @returncode INT INSERT INTO @t (msg) DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_create_subdir N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''' IF @ReturnCode <> 0 RAISERROR(''Error creating directory.'', 16, 1)'
 
           EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
           SET @Error = @@ERROR
@@ -3706,8 +3706,14 @@ BEGIN
           SET @CurrentDatabaseContext = 'master'
 
           SET @CurrentCommandType = 'emc_run_backup'
-
-          SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.emc_run_backup '''
+		  /* 
+		   Fix for error
+		   Error: Msg 0, Sev 0, State 1: Unknown token received from SQL Server [SQLSTATE HY000]
+		   String data, right truncation [SQLSTATE 01004]
+		   Msg 16389, Sev 16, State 1: The connection is no longer usable because the server response for a previously executed statement was incorrectly formatted. [SQLSTATE 08S01]
+		   https://github.com/olahallengren/sql-server-maintenance-solution/issues/658		  
+		  */
+          SET @CurrentCommand = 'DECLARE @t TABLE (msg NVARCHAR(MAX)) DECLARE @returncode INT INSERT INTO @t (msg) EXECUTE @ReturnCode = dbo.emc_run_backup '''
 
           SET @CurrentCommand += ' -c ' + CASE WHEN @CurrentAvailabilityGroup IS NOT NULL THEN @Cluster ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar) END
 
@@ -4082,4 +4088,3 @@ BEGIN
 
 END
 GO
-


### PR DESCRIPTION
Fix error on logging information on SQL agent job using data domain boost

"Msg 0, Sev 0, State 1: Unknown token received from SQL Server [SQLSTATE HY000]
String data, right truncation [SQLSTATE 01004]
Msg 16389, Sev 16, State 1: The connection is no longer usable because the server response for a previously executed statement was incorrectly formatted. [SQLSTATE 08S01]"