### PR TITLE
Logic if there are ColumnStore Index on the table

### DIFF
--- a/IndexOptimize.sql
+++ b/IndexOptimize.sql
@@ -1,4 +1,4 @@
-﻿SET ANSI_NULLS ON
+SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
 GO
@@ -1573,7 +1573,7 @@ BEGIN
 
                                                     + ', CASE WHEN indexes.[type] = 1 AND EXISTS(SELECT * FROM sys.columns columns WHERE columns.[object_id] = objects.object_id  AND columns.is_filestream = 1) THEN 1 ELSE 0 END AS IsFileStream'
 
-                                                    + ', CASE WHEN EXISTS(SELECT * FROM sys.indexes indexes WHERE indexes.[object_id] = objects.object_id AND [type] IN(5,6)) THEN 1 ELSE 0 END AS IsColumnStore'
+                                                    + ', CASE WHEN EXISTS(SELECT * FROM sys.indexes indexes5 WHERE indexes.[object_id] = objects.object_id and indexes5.[object_id] = objects.object_id and indexes5.[index_id] = indexes.[index_id] AND [type] IN(5,6)) THEN 1 ELSE 0 END AS IsColumnStore'
 
                                                     + ', CASE WHEN EXISTS(SELECT * FROM sys.index_columns index_columns INNER JOIN sys.columns columns ON index_columns.object_id = columns.object_id AND index_columns.column_id = columns.column_id WHERE (index_columns.key_ordinal > 0 OR index_columns.partition_ordinal > 0) AND columns.is_computed = 1 AND index_columns.object_id = indexes.object_id AND index_columns.index_id = indexes.index_id) THEN 1 ELSE 0 END AS IsComputed'
 
@@ -2433,4 +2433,3 @@ BEGIN
 END
 
 GO
-


### PR DESCRIPTION
If there is ColumnStore Index on the table, then the logic on line 1576 was marking the Non-ColumnStore indexes as ColumnStore Indexes, hence these Indexes were not picked up for Online Rebuild. The change proposed here fixes that.