### PR TITLE
Change the default for @NoInformationalMessages to 'N' in DatabaseIntegrityCheck

### DIFF
--- a/CommandExecute.sql
+++ b/CommandExecute.sql
@@ -36,7 +36,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-01-12 17:39:05                                                               //--
+  --// Version: 2025-01-12 18:00:47                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/DatabaseBackup.sql
+++ b/DatabaseBackup.sql
@@ -88,7 +88,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-01-12 17:39:05                                                               //--
+  --// Version: 2025-01-12 18:00:47                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/DatabaseIntegrityCheck.sql
+++ b/DatabaseIntegrityCheck.sql
@@ -15,7 +15,7 @@ ALTER PROCEDURE [dbo].[DatabaseIntegrityCheck]
 @DataPurity nvarchar(max) = 'N',
 @NoIndex nvarchar(max) = 'N',
 @ExtendedLogicalChecks nvarchar(max) = 'N',
-@NoInformationalMessages nvarchar(max) = 'Y',
+@NoInformationalMessages nvarchar(max) = 'N',
 @TabLock nvarchar(max) = 'N',
 @FileGroups nvarchar(max) = NULL,
 @Objects nvarchar(max) = NULL,
@@ -40,7 +40,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-01-12 17:39:05                                                               //--
+  --// Version: 2025-01-12 18:00:47                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/IndexOptimize.sql
+++ b/IndexOptimize.sql
@@ -53,7 +53,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-01-12 17:39:05                                                               //--
+  --// Version: 2025-01-12 18:00:47                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/MaintenanceSolution.sql
+++ b/MaintenanceSolution.sql
@@ -10,7 +10,7 @@ License: https://ola.hallengren.com/license.html
 
 GitHub: https://github.com/olahallengren/sql-server-maintenance-solution
 
-Version: 2025-01-12 17:39:05
+Version: 2025-01-12 18:00:47
 
 You can contact me by e-mail at ola@hallengren.com.
 
@@ -137,7 +137,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-01-12 17:39:05                                                               //--
+  --// Version: 2025-01-12 18:00:47                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON
@@ -481,7 +481,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-01-12 17:39:05                                                               //--
+  --// Version: 2025-01-12 18:00:47                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON
@@ -4658,7 +4658,7 @@ ALTER PROCEDURE [dbo].[DatabaseIntegrityCheck]
 @DataPurity nvarchar(max) = 'N',
 @NoIndex nvarchar(max) = 'N',
 @ExtendedLogicalChecks nvarchar(max) = 'N',
-@NoInformationalMessages nvarchar(max) = 'Y',
+@NoInformationalMessages nvarchar(max) = 'N',
 @TabLock nvarchar(max) = 'N',
 @FileGroups nvarchar(max) = NULL,
 @Objects nvarchar(max) = NULL,
@@ -4683,7 +4683,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-01-12 17:39:05                                                               //--
+  --// Version: 2025-01-12 18:00:47                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON
@@ -6579,7 +6579,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-01-12 17:39:05                                                               //--
+  --// Version: 2025-01-12 18:00:47                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON


### PR DESCRIPTION
This change is to align the default for DatabaseIntegrityCheck with the default for the DBCC CHECKDB command.