### PR TITLE
Add support for file group backup

### DIFF
--- a/CommandExecute.sql
+++ b/CommandExecute.sql
@@ -36,7 +36,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-08 12:16:23                                                               //--
+  --// Version: 2025-06-08 20:41:55                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/CommandExecute.sql
+++ b/CommandExecute.sql
@@ -36,7 +36,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-05-24 16:07:41                                                               //--
+  --// Version: 2025-06-07 21:41:06                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/CommandExecute.sql
+++ b/CommandExecute.sql
@@ -36,7 +36,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-08 20:41:55                                                               //--
+  --// Version: 2025-06-08 22:57:39                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/CommandExecute.sql
+++ b/CommandExecute.sql
@@ -36,7 +36,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-08 22:57:39                                                               //--
+  --// Version: 2025-07-08 19:42:27                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/CommandExecute.sql
+++ b/CommandExecute.sql
@@ -36,7 +36,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-07-08 19:42:27                                                               //--
+  --// Version: 2025-07-20 01:19:05                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/CommandExecute.sql
+++ b/CommandExecute.sql
@@ -36,7 +36,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-07 21:41:06                                                               //--
+  --// Version: 2025-06-08 12:16:23                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/DatabaseBackup.sql
+++ b/DatabaseBackup.sql
@@ -92,7 +92,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-08 22:57:39                                                               //--
+  --// Version: 2025-07-08 19:42:27                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON
@@ -181,6 +181,7 @@ BEGIN
   DECLARE @CurrentFGID int
   DECLARE @CurrentFileGroupID int
   DECLARE @CurrentFileGroupName nvarchar(max)
+  DECLARE @CurrentFileGroupType nvarchar(max)
   DECLARE @CurrentFileGroupExists bit
 
   DECLARE @Errors TABLE (ID int IDENTITY PRIMARY KEY,
@@ -229,6 +230,7 @@ BEGIN
   DECLARE @tmpFileGroups TABLE (ID int IDENTITY,
                                 FileGroupID int,
                                 FileGroupName nvarchar(max),
+                                [Type] nvarchar(max),
                                 StartPosition int,
                                 [Order] int,
                                 Selected bit,
@@ -2545,12 +2547,6 @@ BEGIN
     SELECT 'The value for the parameter @DatabasesInParallel is not supported.', 16, 2
   END
 
-  IF @DatabasesInParallel = 'Y' AND @FileGroups IS NOT NULL
-  BEGIN
-    INSERT INTO @Errors ([Message], Severity, [State])
-    SELECT 'The value for the parameter @DatabasesInParallel is not supported. This option is not supported with file group backup.', 16, 3
-  END
-
   ----------------------------------------------------------------------------------------------------
 
   IF @LogToTable NOT IN('Y','N') OR @LogToTable IS NULL
@@ -2902,9 +2898,9 @@ BEGIN
     -- Select filegroups
     IF @FileGroups IS NOT NULL
     BEGIN
-      SET @CurrentCommand = 'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED; SELECT data_space_id AS FileGroupID, name AS FileGroupName, 0 AS [Order], 0 AS Selected, 0 AS Completed FROM ' + QUOTENAME(@CurrentDatabaseName) + '.sys.filegroups filegroups WHERE [type] <> ''FX'' ORDER BY CASE WHEN filegroups.name = ''PRIMARY'' THEN 1 ELSE 0 END DESC, filegroups.name ASC'
+      SET @CurrentCommand = 'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED; SELECT data_space_id AS FileGroupID, name AS FileGroupName, [type], 0 AS [Order], 0 AS Selected, 0 AS Completed FROM ' + QUOTENAME(@CurrentDatabaseName) + '.sys.filegroups filegroups ORDER BY CASE WHEN filegroups.name = ''PRIMARY'' THEN 1 ELSE 0 END DESC, filegroups.name ASC'
 
-      INSERT INTO @tmpFileGroups (FileGroupID, FileGroupName, [Order], Selected, Completed)
+      INSERT INTO @tmpFileGroups (FileGroupID, FileGroupName, [Type], [Order], Selected, Completed)
       EXECUTE sp_executesql @statement = @CurrentCommand
       SET @Error = @@ERROR
       IF @Error <> 0 SET @ReturnCode = @Error
@@ -3196,6 +3192,19 @@ BEGIN
       RAISERROR('%s',10,1,@DatabaseMessage) WITH NOWAIT
     END
 
+    IF EXISTS (SELECT * FROM @tmpFileGroups WHERE [Type] = 'FX')
+    BEGIN
+      IF (EXISTS (SELECT * FROM @tmpFileGroups WHERE [Type] = 'FX' AND Selected = 1)
+      AND NOT EXISTS (SELECT * FROM @tmpFileGroups WHERE FileGroupName = 'PRIMARY' AND Selected = 1))
+      OR (EXISTS (SELECT * FROM @tmpFileGroups WHERE FileGroupName = 'PRIMARY' AND Selected = 1)
+      AND NOT EXISTS (SELECT * FROM @tmpFileGroups WHERE [Type] = 'FX' AND Selected = 1))
+      BEGIN
+        SET @ErrorMessage = + 'The primary and memory-optimized filegroups must be backed up together.'
+        RAISERROR(@ErrorMessage,16,1) WITH NOWAIT
+        SET @Error = @@ERROR
+      END
+    END
+
     RAISERROR(@EmptyLine,10,1) WITH NOWAIT
 
     IF @CurrentDatabaseState = 'ONLINE'
@@ -3216,7 +3225,7 @@ BEGIN
     AND NOT (@CurrentBackupType = 'LOG' AND @LogSizeSinceLastLogBackup IS NOT NULL AND @TimeSinceLastLogBackup IS NOT NULL AND NOT(@CurrentLogSizeSinceLastLogBackup >= @LogSizeSinceLastLogBackup OR @CurrentLogSizeSinceLastLogBackup IS NULL OR DATEDIFF(SECOND,@CurrentLastLogBackup,SYSDATETIME()) >= @TimeSinceLastLogBackup OR @CurrentLastLogBackup IS NULL))
     AND NOT (@CurrentBackupType = 'LOG' AND @Updateability = 'READ_ONLY' AND @BackupSoftware = 'DATA_DOMAIN_BOOST')
     AND NOT (@CurrentBackupType = 'DIFF' AND @MinDatabaseSizeForDifferentialBackup IS NOT NULL AND (COALESCE(CAST(@CurrentAllocatedExtentPageCount AS bigint) * 8192, CAST(@CurrentDatabaseSize AS bigint) * 8192) < CAST(@MinDatabaseSizeForDifferentialBackup AS bigint) * 1024 * 1024))
-    AND NOT (@FileGroups IS NOT NULL AND @CurrentDatabaseName IN ('master','msdb','model'))
+    AND @Error = 0
     BEGIN
 
       WHILE (1 = 1)
@@ -3226,7 +3235,8 @@ BEGIN
         BEGIN
           SELECT TOP 1 @CurrentFGID = ID,
                        @CurrentFileGroupID = FileGroupID,
-                       @CurrentFileGroupName = FileGroupName
+                       @CurrentFileGroupName = FileGroupName,
+                       @CurrentFileGroupType = [Type]
           FROM @tmpFileGroups
           WHERE Selected = 1
           AND Completed = 0
@@ -3239,7 +3249,7 @@ BEGIN
 
           -- Does the filegroup exist?
           SET @CurrentCommand = ''
-          SET @CurrentCommand = @CurrentCommand + 'IF EXISTS(SELECT * FROM ' + QUOTENAME(@CurrentDatabaseName) + '.sys.filegroups filegroups WHERE [type] <> ''FX'' AND filegroups.data_space_id = @ParamFileGroupID AND filegroups.[name] = @ParamFileGroupName) BEGIN SET @ParamFileGroupExists = 1 END'
+          SET @CurrentCommand = @CurrentCommand + 'IF EXISTS(SELECT * FROM ' + QUOTENAME(@CurrentDatabaseName) + '.sys.filegroups filegroups WHERE filegroups.data_space_id = @ParamFileGroupID AND filegroups.[name] = @ParamFileGroupName) BEGIN SET @ParamFileGroupExists = 1 END'
 
           EXECUTE sp_executesql @statement = @CurrentCommand, @params = N'@ParamFileGroupID int, @ParamFileGroupName sysname, @ParamFileGroupExists bit OUTPUT', @ParamFileGroupID = @CurrentFileGroupID, @ParamFileGroupName = @CurrentFileGroupName, @ParamFileGroupExists = @CurrentFileGroupExists OUTPUT
           SET @Error = @@ERROR
@@ -3256,687 +3266,583 @@ BEGIN
           END
         END
 
-        IF @CurrentFileGroupExists = 1 OR @CurrentFileGroupExists IS NULL
+        IF @CurrentBackupType = 'LOG' AND (@CleanupTime IS NOT NULL OR @MirrorCleanupTime IS NOT NULL)
         BEGIN
+          SELECT @CurrentLatestBackup = MAX(backup_start_date)
+          FROM msdb.dbo.backupset
+          WHERE ([type] IN('D','I')
+          OR ([type] = 'L' AND last_lsn < @CurrentDifferentialBaseLSN))
+          AND is_damaged = 0
+          AND [database_name] = @CurrentDatabaseName
+        END
 
-          IF @CurrentBackupType = 'LOG' AND (@CleanupTime IS NOT NULL OR @MirrorCleanupTime IS NOT NULL)
-          BEGIN
-            SELECT @CurrentLatestBackup = MAX(backup_start_date)
-            FROM msdb.dbo.backupset
-            WHERE ([type] IN('D','I')
-            OR ([type] = 'L' AND last_lsn < @CurrentDifferentialBaseLSN))
-            AND is_damaged = 0
-            AND [database_name] = @CurrentDatabaseName
-          END
+        SET @CurrentDate = SYSDATETIME()
+        SET @CurrentDateUTC = SYSUTCDATETIME()
 
-          SET @CurrentDate = SYSDATETIME()
-          SET @CurrentDateUTC = SYSUTCDATETIME()
+        INSERT INTO @CurrentCleanupDates (CleanupDate)
+        SELECT @CurrentDate
 
+        IF @CurrentBackupType = 'LOG'
+        BEGIN
           INSERT INTO @CurrentCleanupDates (CleanupDate)
-          SELECT @CurrentDate
+          SELECT @CurrentLatestBackup
+        END
 
-          IF @CurrentBackupType = 'LOG'
+        SELECT @CurrentDirectoryStructure = CASE
+        WHEN @CurrentAvailabilityGroup IS NOT NULL THEN @AvailabilityGroupDirectoryStructure
+        ELSE @DirectoryStructure
+        END
+
+        IF @CurrentDirectoryStructure IS NOT NULL
+        BEGIN
+        -- Directory structure - remove tokens that are not needed
+          IF @CurrentFileGroupName IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}','')
+          IF @ReadWriteFileGroups = 'N' SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Partial}','')
+          IF @CopyOnly = 'N' SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{CopyOnly}','')
+          IF @Cluster IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}','')
+          IF @CurrentAvailabilityGroup IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}','')
+          IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}','')
+          IF @@SERVICENAME IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServiceName}','')
+          IF @Description IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Description}','')
+          IF @BackupSetName IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupSetName}','')
+
+          IF @Directory IS NULL AND @MirrorDirectory IS NULL AND @URL IS NULL AND @DefaultDirectory LIKE '%' + '.' + @@SERVICENAME + @DirectorySeparator + 'MSSQL' + @DirectorySeparator + 'Backup'
           BEGIN
-            INSERT INTO @CurrentCleanupDates (CleanupDate)
-            SELECT @CurrentLatestBackup
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServerName}','')
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}','')
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}','')
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}','')
           END
-
-          SELECT @CurrentDirectoryStructure = CASE
-          WHEN @CurrentAvailabilityGroup IS NOT NULL THEN @AvailabilityGroupDirectoryStructure
-          ELSE @DirectoryStructure
-          END
-
-          IF @CurrentDirectoryStructure IS NOT NULL
-          BEGIN
-          -- Directory structure - remove tokens that are not needed
-            IF @CurrentFileGroupName IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}','')
-            IF @ReadWriteFileGroups = 'N' SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Partial}','')
-            IF @CopyOnly = 'N' SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{CopyOnly}','')
-            IF @Cluster IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}','')
-            IF @CurrentAvailabilityGroup IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}','')
-            IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}','')
-            IF @@SERVICENAME IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServiceName}','')
-            IF @Description IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Description}','')
-            IF @BackupSetName IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupSetName}','')
-
-            IF @Directory IS NULL AND @MirrorDirectory IS NULL AND @URL IS NULL AND @DefaultDirectory LIKE '%' + '.' + @@SERVICENAME + @DirectorySeparator + 'MSSQL' + @DirectorySeparator + 'Backup'
-            BEGIN
-              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServerName}','')
-              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}','')
-              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}','')
-              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}','')
-            END
-
-            WHILE (@Updated = 1 OR @Updated IS NULL)
-            BEGIN
-              SET @Updated = 0
-
-              IF CHARINDEX('\',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'\','{DirectorySeparator}')
-                SET @Updated = 1
-              END
-
-              IF CHARINDEX('/',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'/','{DirectorySeparator}')
-                SET @Updated = 1
-              END
-
-              IF CHARINDEX('__',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'__','_')
-                SET @Updated = 1
-              END
-
-              IF CHARINDEX('--',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'--','-')
-                SET @Updated = 1
-              END
-
-              IF CHARINDEX('{DirectorySeparator}{DirectorySeparator}',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}{DirectorySeparator}','{DirectorySeparator}')
-                SET @Updated = 1
-              END
-
-              IF CHARINDEX('{DirectorySeparator}$',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}$','{DirectorySeparator}')
-                SET @Updated = 1
-              END
-              IF CHARINDEX('${DirectorySeparator}',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'${DirectorySeparator}','{DirectorySeparator}')
-                SET @Updated = 1
-              END
-
-              IF CHARINDEX('{DirectorySeparator}_',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}_','{DirectorySeparator}')
-                SET @Updated = 1
-              END
-              IF CHARINDEX('_{DirectorySeparator}',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'_{DirectorySeparator}','{DirectorySeparator}')
-                SET @Updated = 1
-              END
-
-              IF CHARINDEX('{DirectorySeparator}-',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}-','{DirectorySeparator}')
-                SET @Updated = 1
-              END
-              IF CHARINDEX('-{DirectorySeparator}',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'-{DirectorySeparator}','{DirectorySeparator}')
-                SET @Updated = 1
-              END
-
-              IF CHARINDEX('_$',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'_$','_')
-                SET @Updated = 1
-              END
-              IF CHARINDEX('$_',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'$_','_')
-                SET @Updated = 1
-              END
-
-              IF CHARINDEX('-$',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'-$','-')
-                SET @Updated = 1
-              END
-              IF CHARINDEX('$-',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'$-','-')
-                SET @Updated = 1
-              END
-
-              IF LEFT(@CurrentDirectoryStructure,1) = '_'
-              BEGIN
-                SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-                SET @Updated = 1
-              END
-              IF RIGHT(@CurrentDirectoryStructure,1) = '_'
-              BEGIN
-                SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-                SET @Updated = 1
-              END
-
-              IF LEFT(@CurrentDirectoryStructure,1) = '-'
-              BEGIN
-                SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-                SET @Updated = 1
-              END
-              IF RIGHT(@CurrentDirectoryStructure,1) = '-'
-              BEGIN
-                SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-                SET @Updated = 1
-              END
-
-              IF LEFT(@CurrentDirectoryStructure,1) = '$'
-              BEGIN
-                SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-                SET @Updated = 1
-              END
-              IF RIGHT(@CurrentDirectoryStructure,1) = '$'
-              BEGIN
-                SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-                SET @Updated = 1
-              END
-
-              IF LEFT(@CurrentDirectoryStructure,20) = '{DirectorySeparator}'
-              BEGIN
-                SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 20)
-                SET @Updated = 1
-              END
-              IF RIGHT(@CurrentDirectoryStructure,20) = '{DirectorySeparator}'
-              BEGIN
-                SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 20)
-                SET @Updated = 1
-              END
-            END
-
-            SET @Updated = NULL
-
-            -- Directory structure - replace tokens with real values
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}',@DirectorySeparator)
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServerName}',CASE WHEN SERVERPROPERTY('EngineEdition') = 8 THEN LEFT(CAST(SERVERPROPERTY('ServerName') AS nvarchar(max)),CHARINDEX('.',CAST(SERVERPROPERTY('ServerName') AS nvarchar(max))) - 1) ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar(max)) END)
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}',ISNULL(CAST(SERVERPROPERTY('InstanceName') AS nvarchar(max)),''))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServiceName}',ISNULL(@@SERVICENAME,''))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}',ISNULL(@Cluster,''))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}',ISNULL(@CurrentAvailabilityGroup,''))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DatabaseName}',@CurrentDatabaseNameFS)
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}',ISNULL(@CurrentFileGroupName,''))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupType}',@CurrentBackupType)
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Partial}','PARTIAL')
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{CopyOnly}','COPY_ONLY')
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Description}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@Description,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupSetName}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@BackupSetName,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Year}',CAST(DATEPART(YEAR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Month}',RIGHT('0' + CAST(DATEPART(MONTH,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Day}',RIGHT('0' + CAST(DATEPART(DAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Week}',RIGHT('0' + CAST(DATEPART(WEEK,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Weekday}',DATENAME(WEEKDAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Hour}',RIGHT('0' + CAST(DATEPART(HOUR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Minute}',RIGHT('0' + CAST(DATEPART(MINUTE,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Second}',RIGHT('0' + CAST(DATEPART(SECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Millisecond}',RIGHT('00' + CAST(DATEPART(MILLISECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),3))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Microsecond}',RIGHT('00000' + CAST(DATEPART(MICROSECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),6))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{MajorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMajorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4)))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{MinorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMinorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3)))
-          END
-
-          IF @DirectoryStructureCase IS NOT NULL
-          BEGIN
-            SET @CurrentDirectoryStructure = CASE WHEN @DirectoryStructureCase = 'LOWER' THEN LOWER(@CurrentDirectoryStructure)
-                                                  WHEN @DirectoryStructureCase = 'UPPER' THEN UPPER(@CurrentDirectoryStructure) END
-          END
-
-          INSERT INTO @CurrentDirectories (ID, DirectoryPath, Mirror, DirectoryNumber, CreateCompleted, CleanupCompleted)
-          SELECT ROW_NUMBER() OVER (ORDER BY ID),
-                 DirectoryPath + CASE WHEN DirectoryPath = 'NUL' THEN '' WHEN @CurrentDirectoryStructure IS NOT NULL THEN @DirectorySeparator + @CurrentDirectoryStructure ELSE '' END,
-                 Mirror,
-                 ROW_NUMBER() OVER (PARTITION BY Mirror ORDER BY ID ASC),
-                 0,
-                 0
-          FROM @Directories
-          ORDER BY ID ASC
-
-          INSERT INTO @CurrentURLs (ID, DirectoryPath, Mirror, DirectoryNumber)
-          SELECT ROW_NUMBER() OVER (ORDER BY ID),
-                 DirectoryPath + CASE WHEN @CurrentDirectoryStructure IS NOT NULL THEN @DirectorySeparator + @CurrentDirectoryStructure ELSE '' END,
-                 Mirror,
-                 ROW_NUMBER() OVER (PARTITION BY Mirror ORDER BY ID ASC)
-          FROM @URLs
-          ORDER BY ID ASC
-
-          SELECT @CurrentDatabaseFileName = CASE
-          WHEN @CurrentAvailabilityGroup IS NOT NULL THEN @AvailabilityGroupFileName
-          ELSE @FileName
-          END
-
-          -- File name - remove tokens that are not needed
-          IF @CurrentFileGroupName IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}','')
-          IF @ReadWriteFileGroups = 'N' SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Partial}','')
-          IF @CopyOnly = 'N' SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{CopyOnly}','')
-          IF @Cluster IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ClusterName}','')
-          IF @CurrentAvailabilityGroup IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{AvailabilityGroupName}','')
-          IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{InstanceName}','')
-          IF @@SERVICENAME IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServiceName}','')
-          IF @Description IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Description}','')
-          IF @BackupSetName IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupSetName}','')
-          IF @CurrentNumberOfFiles = 1 SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileNumber}','')
-          IF @CurrentNumberOfFiles = 1 SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{NumberOfFiles}','')
 
           WHILE (@Updated = 1 OR @Updated IS NULL)
           BEGIN
             SET @Updated = 0
 
-            IF CHARINDEX('__',@CurrentDatabaseFileName) > 0
+            IF CHARINDEX('\',@CurrentDirectoryStructure) > 0
             BEGIN
-              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'__','_')
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'\','{DirectorySeparator}')
               SET @Updated = 1
             END
 
-            IF CHARINDEX('--',@CurrentDatabaseFileName) > 0
+            IF CHARINDEX('/',@CurrentDirectoryStructure) > 0
             BEGIN
-              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'--','-')
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'/','{DirectorySeparator}')
               SET @Updated = 1
             END
 
-            IF CHARINDEX('_$',@CurrentDatabaseFileName) > 0
+            IF CHARINDEX('__',@CurrentDirectoryStructure) > 0
             BEGIN
-              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'_$','_')
-              SET @Updated = 1
-            END
-            IF CHARINDEX('$_',@CurrentDatabaseFileName) > 0
-            BEGIN
-              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'$_','_')
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'__','_')
               SET @Updated = 1
             END
 
-            IF CHARINDEX('-$',@CurrentDatabaseFileName) > 0
+            IF CHARINDEX('--',@CurrentDirectoryStructure) > 0
             BEGIN
-              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'-$','-')
-              SET @Updated = 1
-            END
-            IF CHARINDEX('$-',@CurrentDatabaseFileName) > 0
-            BEGIN
-              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'$-','-')
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'--','-')
               SET @Updated = 1
             END
 
-            IF CHARINDEX('_.',@CurrentDatabaseFileName) > 0
+            IF CHARINDEX('{DirectorySeparator}{DirectorySeparator}',@CurrentDirectoryStructure) > 0
             BEGIN
-              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'_.','.')
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}{DirectorySeparator}','{DirectorySeparator}')
               SET @Updated = 1
             END
 
-            IF CHARINDEX('-.',@CurrentDatabaseFileName) > 0
+            IF CHARINDEX('{DirectorySeparator}$',@CurrentDirectoryStructure) > 0
             BEGIN
-              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'-.','.')
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}$','{DirectorySeparator}')
+              SET @Updated = 1
+            END
+            IF CHARINDEX('${DirectorySeparator}',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'${DirectorySeparator}','{DirectorySeparator}')
               SET @Updated = 1
             END
 
-            IF CHARINDEX('of.',@CurrentDatabaseFileName) > 0
+            IF CHARINDEX('{DirectorySeparator}_',@CurrentDirectoryStructure) > 0
             BEGIN
-              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'of.','.')
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}_','{DirectorySeparator}')
+              SET @Updated = 1
+            END
+            IF CHARINDEX('_{DirectorySeparator}',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'_{DirectorySeparator}','{DirectorySeparator}')
               SET @Updated = 1
             END
 
-            IF LEFT(@CurrentDatabaseFileName,1) = '_'
+            IF CHARINDEX('{DirectorySeparator}-',@CurrentDirectoryStructure) > 0
             BEGIN
-              SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}-','{DirectorySeparator}')
               SET @Updated = 1
             END
-            IF RIGHT(@CurrentDatabaseFileName,1) = '_'
+            IF CHARINDEX('-{DirectorySeparator}',@CurrentDirectoryStructure) > 0
             BEGIN
-              SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
-              SET @Updated = 1
-            END
-
-            IF LEFT(@CurrentDatabaseFileName,1) = '-'
-            BEGIN
-              SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
-              SET @Updated = 1
-            END
-            IF RIGHT(@CurrentDatabaseFileName,1) = '-'
-            BEGIN
-              SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'-{DirectorySeparator}','{DirectorySeparator}')
               SET @Updated = 1
             END
 
-            IF LEFT(@CurrentDatabaseFileName,1) = '$'
+            IF CHARINDEX('_$',@CurrentDirectoryStructure) > 0
             BEGIN
-              SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'_$','_')
               SET @Updated = 1
             END
-            IF RIGHT(@CurrentDatabaseFileName,1) = '$'
+            IF CHARINDEX('$_',@CurrentDirectoryStructure) > 0
             BEGIN
-              SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'$_','_')
+              SET @Updated = 1
+            END
+
+            IF CHARINDEX('-$',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'-$','-')
+              SET @Updated = 1
+            END
+            IF CHARINDEX('$-',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'$-','-')
+              SET @Updated = 1
+            END
+
+            IF LEFT(@CurrentDirectoryStructure,1) = '_'
+            BEGIN
+              SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+            IF RIGHT(@CurrentDirectoryStructure,1) = '_'
+            BEGIN
+              SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+
+            IF LEFT(@CurrentDirectoryStructure,1) = '-'
+            BEGIN
+              SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+            IF RIGHT(@CurrentDirectoryStructure,1) = '-'
+            BEGIN
+              SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+
+            IF LEFT(@CurrentDirectoryStructure,1) = '$'
+            BEGIN
+              SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+            IF RIGHT(@CurrentDirectoryStructure,1) = '$'
+            BEGIN
+              SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+
+            IF LEFT(@CurrentDirectoryStructure,20) = '{DirectorySeparator}'
+            BEGIN
+              SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 20)
+              SET @Updated = 1
+            END
+            IF RIGHT(@CurrentDirectoryStructure,20) = '{DirectorySeparator}'
+            BEGIN
+              SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 20)
               SET @Updated = 1
             END
           END
 
           SET @Updated = NULL
 
-          SELECT @CurrentFileExtension = CASE
-          WHEN @CurrentBackupType = 'FULL' THEN @FileExtensionFull
-          WHEN @CurrentBackupType = 'DIFF' THEN @FileExtensionDiff
-          WHEN @CurrentBackupType = 'LOG' THEN @FileExtensionLog
-          END
+          -- Directory structure - replace tokens with real values
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}',@DirectorySeparator)
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServerName}',CASE WHEN SERVERPROPERTY('EngineEdition') = 8 THEN LEFT(CAST(SERVERPROPERTY('ServerName') AS nvarchar(max)),CHARINDEX('.',CAST(SERVERPROPERTY('ServerName') AS nvarchar(max))) - 1) ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar(max)) END)
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}',ISNULL(CAST(SERVERPROPERTY('InstanceName') AS nvarchar(max)),''))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServiceName}',ISNULL(@@SERVICENAME,''))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}',ISNULL(@Cluster,''))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}',ISNULL(@CurrentAvailabilityGroup,''))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DatabaseName}',@CurrentDatabaseNameFS)
 
-          -- File name - replace tokens with real values
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServerName}',CASE WHEN SERVERPROPERTY('EngineEdition') = 8 THEN LEFT(CAST(SERVERPROPERTY('ServerName') AS nvarchar(max)),CHARINDEX('.',CAST(SERVERPROPERTY('ServerName') AS nvarchar(max))) - 1) ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar(max)) END)
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{InstanceName}',ISNULL(CAST(SERVERPROPERTY('InstanceName') AS nvarchar(max)),''))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServiceName}',ISNULL(@@SERVICENAME,''))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ClusterName}',ISNULL(@Cluster,''))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{AvailabilityGroupName}',ISNULL(@CurrentAvailabilityGroup,''))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}',ISNULL(@CurrentFileGroupName,''))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupType}',@CurrentBackupType)
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Partial}','PARTIAL')
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{CopyOnly}','COPY_ONLY')
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Description}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@Description,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupSetName}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@BackupSetName,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Year}',CAST(DATEPART(YEAR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Month}',RIGHT('0' + CAST(DATEPART(MONTH,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Day}',RIGHT('0' + CAST(DATEPART(DAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Week}',RIGHT('0' + CAST(DATEPART(WEEK,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Weekday}',DATENAME(WEEKDAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Hour}',RIGHT('0' + CAST(DATEPART(HOUR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Minute}',RIGHT('0' + CAST(DATEPART(MINUTE,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Second}',RIGHT('0' + CAST(DATEPART(SECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Millisecond}',RIGHT('00' + CAST(DATEPART(MILLISECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),3))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Microsecond}',RIGHT('00000' + CAST(DATEPART(MICROSECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),6))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{NumberOfFiles}',@CurrentNumberOfFiles)
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileExtension}',@CurrentFileExtension)
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{MajorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMajorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4)))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{MinorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMinorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3)))
-
-          SELECT @CurrentMaxFilePathLength = CASE
-          WHEN EXISTS (SELECT * FROM @CurrentDirectories) THEN (SELECT MAX(LEN(DirectoryPath + @DirectorySeparator)) FROM @CurrentDirectories)
-          WHEN EXISTS (SELECT * FROM @CurrentURLs) THEN (SELECT MAX(LEN(DirectoryPath + @DirectorySeparator)) FROM @CurrentURLs)
-          END
-          + LEN(REPLACE(REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',@CurrentDatabaseNameFS), '{FileNumber}', CASE WHEN @CurrentNumberOfFiles >= 1 AND @CurrentNumberOfFiles <= 9 THEN '1' WHEN @CurrentNumberOfFiles >= 10 THEN '01' END))
-
-          -- The maximum length of a backup device is 259 characters
-          IF @CurrentMaxFilePathLength > 259
+          IF @CurrentFileGroupName = 'PRIMARY' AND EXISTS (SELECT * FROM @tmpFileGroups WHERE [type] = 'FX' AND Selected = 1)
           BEGIN
-            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',LEFT(@CurrentDatabaseNameFS,CASE WHEN (LEN(@CurrentDatabaseNameFS) + 259 - @CurrentMaxFilePathLength - 3) < 20 THEN 20 ELSE (LEN(@CurrentDatabaseNameFS) + 259 - @CurrentMaxFilePathLength - 3) END) + '...')
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}',ISNULL(@CurrentFileGroupName + '_' + (SELECT FileGroupName FROM @tmpFileGroups WHERE [type] = 'FX' AND Selected = 1),''))
           END
           ELSE
           BEGIN
-            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',@CurrentDatabaseNameFS)
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}',ISNULL(@CurrentFileGroupName,''))
           END
 
-          IF @FileNameCase IS NOT NULL
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupType}',@CurrentBackupType)
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Partial}','PARTIAL')
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{CopyOnly}','COPY_ONLY')
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Description}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@Description,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupSetName}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@BackupSetName,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Year}',CAST(DATEPART(YEAR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Month}',RIGHT('0' + CAST(DATEPART(MONTH,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Day}',RIGHT('0' + CAST(DATEPART(DAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Week}',RIGHT('0' + CAST(DATEPART(WEEK,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Weekday}',DATENAME(WEEKDAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Hour}',RIGHT('0' + CAST(DATEPART(HOUR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Minute}',RIGHT('0' + CAST(DATEPART(MINUTE,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Second}',RIGHT('0' + CAST(DATEPART(SECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Millisecond}',RIGHT('00' + CAST(DATEPART(MILLISECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),3))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Microsecond}',RIGHT('00000' + CAST(DATEPART(MICROSECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),6))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{MajorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMajorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4)))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{MinorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMinorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3)))
+        END
+
+        IF @DirectoryStructureCase IS NOT NULL
+        BEGIN
+          SET @CurrentDirectoryStructure = CASE WHEN @DirectoryStructureCase = 'LOWER' THEN LOWER(@CurrentDirectoryStructure)
+                                                WHEN @DirectoryStructureCase = 'UPPER' THEN UPPER(@CurrentDirectoryStructure) END
+        END
+
+        INSERT INTO @CurrentDirectories (ID, DirectoryPath, Mirror, DirectoryNumber, CreateCompleted, CleanupCompleted)
+        SELECT ROW_NUMBER() OVER (ORDER BY ID),
+               DirectoryPath + CASE WHEN DirectoryPath = 'NUL' THEN '' WHEN @CurrentDirectoryStructure IS NOT NULL THEN @DirectorySeparator + @CurrentDirectoryStructure ELSE '' END,
+               Mirror,
+               ROW_NUMBER() OVER (PARTITION BY Mirror ORDER BY ID ASC),
+               0,
+               0
+        FROM @Directories
+        ORDER BY ID ASC
+
+        INSERT INTO @CurrentURLs (ID, DirectoryPath, Mirror, DirectoryNumber)
+        SELECT ROW_NUMBER() OVER (ORDER BY ID),
+               DirectoryPath + CASE WHEN @CurrentDirectoryStructure IS NOT NULL THEN @DirectorySeparator + @CurrentDirectoryStructure ELSE '' END,
+               Mirror,
+               ROW_NUMBER() OVER (PARTITION BY Mirror ORDER BY ID ASC)
+        FROM @URLs
+        ORDER BY ID ASC
+
+        SELECT @CurrentDatabaseFileName = CASE
+        WHEN @CurrentAvailabilityGroup IS NOT NULL THEN @AvailabilityGroupFileName
+        ELSE @FileName
+        END
+
+        -- File name - remove tokens that are not needed
+        IF @CurrentFileGroupName IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}','')
+        IF @ReadWriteFileGroups = 'N' SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Partial}','')
+        IF @CopyOnly = 'N' SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{CopyOnly}','')
+        IF @Cluster IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ClusterName}','')
+        IF @CurrentAvailabilityGroup IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{AvailabilityGroupName}','')
+        IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{InstanceName}','')
+        IF @@SERVICENAME IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServiceName}','')
+        IF @Description IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Description}','')
+        IF @BackupSetName IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupSetName}','')
+        IF @CurrentNumberOfFiles = 1 SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileNumber}','')
+        IF @CurrentNumberOfFiles = 1 SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{NumberOfFiles}','')
+
+        WHILE (@Updated = 1 OR @Updated IS NULL)
+        BEGIN
+          SET @Updated = 0
+
+          IF CHARINDEX('__',@CurrentDatabaseFileName) > 0
           BEGIN
-            SET @CurrentDatabaseFileName = CASE WHEN @FileNameCase = 'LOWER' THEN LOWER(@CurrentDatabaseFileName)
-                                                WHEN @FileNameCase = 'UPPER' THEN UPPER(@CurrentDatabaseFileName) END
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'__','_')
+            SET @Updated = 1
           END
 
-          IF EXISTS (SELECT * FROM @CurrentDirectories WHERE Mirror = 0)
+          IF CHARINDEX('--',@CurrentDatabaseFileName) > 0
           BEGIN
-            SET @CurrentFileNumber = 0
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'--','-')
+            SET @Updated = 1
+          END
 
-            WHILE @CurrentFileNumber < @CurrentNumberOfFiles
+          IF CHARINDEX('_$',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'_$','_')
+            SET @Updated = 1
+          END
+          IF CHARINDEX('$_',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'$_','_')
+            SET @Updated = 1
+          END
+
+          IF CHARINDEX('-$',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'-$','-')
+            SET @Updated = 1
+          END
+          IF CHARINDEX('$-',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'$-','-')
+            SET @Updated = 1
+          END
+
+          IF CHARINDEX('_.',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'_.','.')
+            SET @Updated = 1
+          END
+
+          IF CHARINDEX('-.',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'-.','.')
+            SET @Updated = 1
+          END
+
+          IF CHARINDEX('of.',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'of.','.')
+            SET @Updated = 1
+          END
+
+          IF LEFT(@CurrentDatabaseFileName,1) = '_'
+          BEGIN
+            SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+          IF RIGHT(@CurrentDatabaseFileName,1) = '_'
+          BEGIN
+            SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+
+          IF LEFT(@CurrentDatabaseFileName,1) = '-'
+          BEGIN
+            SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+          IF RIGHT(@CurrentDatabaseFileName,1) = '-'
+          BEGIN
+            SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+
+          IF LEFT(@CurrentDatabaseFileName,1) = '$'
+          BEGIN
+            SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+          IF RIGHT(@CurrentDatabaseFileName,1) = '$'
+          BEGIN
+            SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+        END
+
+        SET @Updated = NULL
+
+        SELECT @CurrentFileExtension = CASE
+        WHEN @CurrentBackupType = 'FULL' THEN @FileExtensionFull
+        WHEN @CurrentBackupType = 'DIFF' THEN @FileExtensionDiff
+        WHEN @CurrentBackupType = 'LOG' THEN @FileExtensionLog
+        END
+
+        -- File name - replace tokens with real values
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServerName}',CASE WHEN SERVERPROPERTY('EngineEdition') = 8 THEN LEFT(CAST(SERVERPROPERTY('ServerName') AS nvarchar(max)),CHARINDEX('.',CAST(SERVERPROPERTY('ServerName') AS nvarchar(max))) - 1) ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar(max)) END)
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{InstanceName}',ISNULL(CAST(SERVERPROPERTY('InstanceName') AS nvarchar(max)),''))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServiceName}',ISNULL(@@SERVICENAME,''))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ClusterName}',ISNULL(@Cluster,''))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{AvailabilityGroupName}',ISNULL(@CurrentAvailabilityGroup,''))
+
+        IF @CurrentFileGroupName = 'PRIMARY' AND EXISTS (SELECT * FROM @tmpFileGroups WHERE [type] = 'FX' AND Selected = 1)
+        BEGIN
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}',ISNULL(@CurrentFileGroupName + '_' + (SELECT FileGroupName FROM @tmpFileGroups WHERE [type] = 'FX' AND Selected = 1),''))
+        END
+        ELSE
+        BEGIN
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}',ISNULL(@CurrentFileGroupName,''))
+        END
+
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupType}',@CurrentBackupType)
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Partial}','PARTIAL')
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{CopyOnly}','COPY_ONLY')
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Description}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@Description,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupSetName}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@BackupSetName,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Year}',CAST(DATEPART(YEAR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Month}',RIGHT('0' + CAST(DATEPART(MONTH,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Day}',RIGHT('0' + CAST(DATEPART(DAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Week}',RIGHT('0' + CAST(DATEPART(WEEK,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Weekday}',DATENAME(WEEKDAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Hour}',RIGHT('0' + CAST(DATEPART(HOUR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Minute}',RIGHT('0' + CAST(DATEPART(MINUTE,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Second}',RIGHT('0' + CAST(DATEPART(SECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Millisecond}',RIGHT('00' + CAST(DATEPART(MILLISECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),3))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Microsecond}',RIGHT('00000' + CAST(DATEPART(MICROSECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),6))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{NumberOfFiles}',@CurrentNumberOfFiles)
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileExtension}',@CurrentFileExtension)
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{MajorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMajorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4)))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{MinorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMinorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3)))
+
+        SELECT @CurrentMaxFilePathLength = CASE
+        WHEN EXISTS (SELECT * FROM @CurrentDirectories) THEN (SELECT MAX(LEN(DirectoryPath + @DirectorySeparator)) FROM @CurrentDirectories)
+        WHEN EXISTS (SELECT * FROM @CurrentURLs) THEN (SELECT MAX(LEN(DirectoryPath + @DirectorySeparator)) FROM @CurrentURLs)
+        END
+        + LEN(REPLACE(REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',@CurrentDatabaseNameFS), '{FileNumber}', CASE WHEN @CurrentNumberOfFiles >= 1 AND @CurrentNumberOfFiles <= 9 THEN '1' WHEN @CurrentNumberOfFiles >= 10 THEN '01' END))
+
+        -- The maximum length of a backup device is 259 characters
+        IF @CurrentMaxFilePathLength > 259
+        BEGIN
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',LEFT(@CurrentDatabaseNameFS,CASE WHEN (LEN(@CurrentDatabaseNameFS) + 259 - @CurrentMaxFilePathLength - 3) < 20 THEN 20 ELSE (LEN(@CurrentDatabaseNameFS) + 259 - @CurrentMaxFilePathLength - 3) END) + '...')
+        END
+        ELSE
+        BEGIN
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',@CurrentDatabaseNameFS)
+        END
+
+        IF @FileNameCase IS NOT NULL
+        BEGIN
+          SET @CurrentDatabaseFileName = CASE WHEN @FileNameCase = 'LOWER' THEN LOWER(@CurrentDatabaseFileName)
+                                              WHEN @FileNameCase = 'UPPER' THEN UPPER(@CurrentDatabaseFileName) END
+        END
+
+        IF EXISTS (SELECT * FROM @CurrentDirectories WHERE Mirror = 0)
+        BEGIN
+          SET @CurrentFileNumber = 0
+
+          WHILE @CurrentFileNumber < @CurrentNumberOfFiles
+          BEGIN
+            SET @CurrentFileNumber = @CurrentFileNumber + 1
+
+            SELECT @CurrentDirectoryPath = DirectoryPath
+            FROM @CurrentDirectories
+            WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 0) + 1
+            AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 0)
+            AND Mirror = 0
+
+            SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles >= 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) END)
+
+            IF @CurrentDirectoryPath = 'NUL'
             BEGIN
-              SET @CurrentFileNumber = @CurrentFileNumber + 1
-
-              SELECT @CurrentDirectoryPath = DirectoryPath
-              FROM @CurrentDirectories
-              WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 0) + 1
-              AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 0)
-              AND Mirror = 0
-
-              SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles >= 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) END)
-
-              IF @CurrentDirectoryPath = 'NUL'
-              BEGIN
-                SET @CurrentFilePath = 'NUL'
-              END
-              ELSE
-              BEGIN
-                SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
-              END
-
-              INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
-              SELECT 'DISK', @CurrentFilePath, 0
-
-              SET @CurrentDirectoryPath = NULL
-              SET @CurrentFileName = NULL
-              SET @CurrentFilePath = NULL
+              SET @CurrentFilePath = 'NUL'
             END
-
-            INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
-            SELECT 0, 0
-          END
-
-          IF EXISTS (SELECT * FROM @CurrentDirectories WHERE Mirror = 1)
-          BEGIN
-            SET @CurrentFileNumber = 0
-
-            WHILE @CurrentFileNumber < @CurrentNumberOfFiles
+            ELSE
             BEGIN
-              SET @CurrentFileNumber = @CurrentFileNumber + 1
-
-              SELECT @CurrentDirectoryPath = DirectoryPath
-              FROM @CurrentDirectories
-              WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 1) + 1
-              AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 1)
-              AND Mirror = 1
-
-              SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
-
               SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
-
-              INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
-              SELECT 'DISK', @CurrentFilePath, 1
-
-              SET @CurrentDirectoryPath = NULL
-              SET @CurrentFileName = NULL
-              SET @CurrentFilePath = NULL
             END
 
-            INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
-            SELECT 1, 0
+            INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
+            SELECT 'DISK', @CurrentFilePath, 0
+
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentFileName = NULL
+            SET @CurrentFilePath = NULL
           END
 
-          IF EXISTS (SELECT * FROM @CurrentURLs WHERE Mirror = 0)
+          INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
+          SELECT 0, 0
+        END
+
+        IF EXISTS (SELECT * FROM @CurrentDirectories WHERE Mirror = 1)
+        BEGIN
+          SET @CurrentFileNumber = 0
+
+          WHILE @CurrentFileNumber < @CurrentNumberOfFiles
           BEGIN
-            SET @CurrentFileNumber = 0
+            SET @CurrentFileNumber = @CurrentFileNumber + 1
 
-            WHILE @CurrentFileNumber < @CurrentNumberOfFiles
+            SELECT @CurrentDirectoryPath = DirectoryPath
+            FROM @CurrentDirectories
+            WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 1) + 1
+            AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 1)
+            AND Mirror = 1
+
+            SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
+
+            SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
+
+            INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
+            SELECT 'DISK', @CurrentFilePath, 1
+
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentFileName = NULL
+            SET @CurrentFilePath = NULL
+          END
+
+          INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
+          SELECT 1, 0
+        END
+
+        IF EXISTS (SELECT * FROM @CurrentURLs WHERE Mirror = 0)
+        BEGIN
+          SET @CurrentFileNumber = 0
+
+          WHILE @CurrentFileNumber < @CurrentNumberOfFiles
+          BEGIN
+            SET @CurrentFileNumber = @CurrentFileNumber + 1
+
+            SELECT @CurrentDirectoryPath = DirectoryPath
+            FROM @CurrentURLs
+            WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0) + 1
+            AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0)
+            AND Mirror = 0
+
+            SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
+
+            SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
+
+            INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
+            SELECT 'URL', @CurrentFilePath, 0
+
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentFileName = NULL
+            SET @CurrentFilePath = NULL
+          END
+
+          INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
+          SELECT 0, 0
+        END
+
+        IF EXISTS (SELECT * FROM @CurrentURLs WHERE Mirror = 1)
+        BEGIN
+          SET @CurrentFileNumber = 0
+
+          WHILE @CurrentFileNumber < @CurrentNumberOfFiles
+          BEGIN
+            SET @CurrentFileNumber = @CurrentFileNumber + 1
+
+            SELECT @CurrentDirectoryPath = DirectoryPath
+            FROM @CurrentURLs
+            WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0) + 1
+            AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0)
+            AND Mirror = 1
+
+            SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
+
+            SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
+
+            INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
+            SELECT 'URL', @CurrentFilePath, 1
+
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentFileName = NULL
+            SET @CurrentFilePath = NULL
+          END
+
+          INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
+          SELECT 1, 0
+        END
+
+        -- Create directory
+        IF @HostPlatform = 'Windows'
+        AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
+        AND NOT EXISTS(SELECT * FROM @CurrentDirectories WHERE DirectoryPath = 'NUL' OR DirectoryPath IN(SELECT DirectoryPath FROM @Directories))
+        BEGIN
+          WHILE (1 = 1)
+          BEGIN
+            SELECT TOP 1 @CurrentDirectoryID = ID,
+                         @CurrentDirectoryPath = DirectoryPath
+            FROM @CurrentDirectories
+            WHERE CreateCompleted = 0
+            ORDER BY ID ASC
+
+            IF @@ROWCOUNT = 0
             BEGIN
-              SET @CurrentFileNumber = @CurrentFileNumber + 1
-
-              SELECT @CurrentDirectoryPath = DirectoryPath
-              FROM @CurrentURLs
-              WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0) + 1
-              AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0)
-              AND Mirror = 0
-
-              SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
-
-              SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
-
-              INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
-              SELECT 'URL', @CurrentFilePath, 0
-
-              SET @CurrentDirectoryPath = NULL
-              SET @CurrentFileName = NULL
-              SET @CurrentFilePath = NULL
+              BREAK
             END
 
-            INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
-            SELECT 0, 0
-          END
-
-          IF EXISTS (SELECT * FROM @CurrentURLs WHERE Mirror = 1)
-          BEGIN
-            SET @CurrentFileNumber = 0
-
-            WHILE @CurrentFileNumber < @CurrentNumberOfFiles
+            IF @DirectoryCheck = 'Y'
             BEGIN
-              SET @CurrentFileNumber = @CurrentFileNumber + 1
-
-              SELECT @CurrentDirectoryPath = DirectoryPath
-              FROM @CurrentURLs
-              WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0) + 1
-              AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0)
-              AND Mirror = 1
-
-              SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
-
-              SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
-
-              INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
-              SELECT 'URL', @CurrentFilePath, 1
-
-              SET @CurrentDirectoryPath = NULL
-              SET @CurrentFileName = NULL
-              SET @CurrentFilePath = NULL
+              INSERT INTO @DirectoryInfo (FileExists, FileIsADirectory, ParentDirectoryExists)
+              EXECUTE [master].dbo.xp_fileexist @CurrentDirectoryPath
             END
 
-            INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
-            SELECT 1, 0
-          END
-
-          -- Create directory
-          IF @HostPlatform = 'Windows'
-          AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
-          AND NOT EXISTS(SELECT * FROM @CurrentDirectories WHERE DirectoryPath = 'NUL' OR DirectoryPath IN(SELECT DirectoryPath FROM @Directories))
-          BEGIN
-            WHILE (1 = 1)
+            IF NOT EXISTS (SELECT * FROM @DirectoryInfo WHERE FileExists = 0 AND FileIsADirectory = 1 AND ParentDirectoryExists = 1)
             BEGIN
-              SELECT TOP 1 @CurrentDirectoryID = ID,
-                           @CurrentDirectoryPath = DirectoryPath
-              FROM @CurrentDirectories
-              WHERE CreateCompleted = 0
-              ORDER BY ID ASC
+              SET @CurrentDatabaseContext = 'master'
 
-              IF @@ROWCOUNT = 0
-              BEGIN
-                BREAK
-              END
+              SET @CurrentCommandType = 'xp_create_subdir'
 
-              IF @DirectoryCheck = 'Y'
-              BEGIN
-                INSERT INTO @DirectoryInfo (FileExists, FileIsADirectory, ParentDirectoryExists)
-                EXECUTE [master].dbo.xp_fileexist @CurrentDirectoryPath
-              END
-
-              IF NOT EXISTS (SELECT * FROM @DirectoryInfo WHERE FileExists = 0 AND FileIsADirectory = 1 AND ParentDirectoryExists = 1)
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'xp_create_subdir'
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_create_subdir N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''' IF @ReturnCode <> 0 RAISERROR(''Error creating directory.'', 16, 1)'
-
-                EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
-                SET @Error = @@ERROR
-                IF @Error <> 0 SET @CurrentCommandOutput = @Error
-                IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
-
-                UPDATE @CurrentDirectories
-                SET CreateCompleted = 1,
-                    CreateOutput = @CurrentCommandOutput
-                WHERE ID = @CurrentDirectoryID
-              END
-              ELSE
-              BEGIN
-                UPDATE @CurrentDirectories
-                SET CreateCompleted = 1,
-                    CreateOutput = 0
-                WHERE ID = @CurrentDirectoryID
-              END
-
-              SET @CurrentDirectoryID = NULL
-              SET @CurrentDirectoryPath = NULL
-
-              SET @CurrentDatabaseContext = NULL
-              SET @CurrentCommand = NULL
-              SET @CurrentCommandOutput = NULL
-              SET @CurrentCommandType = NULL
-
-              DELETE FROM @DirectoryInfo
-            END
-          END
-
-          IF @CleanupMode = 'BEFORE_BACKUP'
-          BEGIN
-            INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
-            SELECT DATEADD(hh,-(@CleanupTime),SYSDATETIME()), 0
-
-            IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 0 OR Mirror IS NULL) AND CleanupDate IS NULL)
-            BEGIN
-              UPDATE @CurrentDirectories
-              SET CleanupDate = (SELECT MIN(CleanupDate)
-                                 FROM @CurrentCleanupDates
-                                 WHERE (Mirror = 0 OR Mirror IS NULL)),
-                  CleanupMode = 'BEFORE_BACKUP'
-              WHERE Mirror = 0
-            END
-          END
-
-          IF @MirrorCleanupMode = 'BEFORE_BACKUP'
-          BEGIN
-            INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
-            SELECT DATEADD(hh,-(@MirrorCleanupTime),SYSDATETIME()), 1
-
-            IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 1 OR Mirror IS NULL) AND CleanupDate IS NULL)
-            BEGIN
-              UPDATE @CurrentDirectories
-              SET CleanupDate = (SELECT MIN(CleanupDate)
-                                 FROM @CurrentCleanupDates
-                                 WHERE (Mirror = 1 OR Mirror IS NULL)),
-                  CleanupMode = 'BEFORE_BACKUP'
-              WHERE Mirror = 1
-            END
-          END
-
-          -- Delete old backup files, before backup
-          IF (NOT EXISTS (SELECT * FROM @CurrentDirectories WHERE CreateOutput <> 0 OR CreateOutput IS NULL) OR @HostPlatform = 'Linux')
-          AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
-          AND @CurrentBackupType = @BackupType
-          BEGIN
-            WHILE (1 = 1)
-            BEGIN
-              SELECT TOP 1 @CurrentDirectoryID = ID,
-                           @CurrentDirectoryPath = DirectoryPath,
-                           @CurrentCleanupDate = CleanupDate
-              FROM @CurrentDirectories
-              WHERE CleanupDate IS NOT NULL
-              AND CleanupMode = 'BEFORE_BACKUP'
-              AND CleanupCompleted = 0
-              ORDER BY ID ASC
-
-              IF @@ROWCOUNT = 0
-              BEGIN
-                BREAK
-              END
-
-              IF @BackupSoftware IS NULL
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'xp_delete_file'
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_delete_file 0, N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + @CurrentFileExtension + ''', ''' + CONVERT(nvarchar(19),@CurrentCleanupDate,126) + ''' IF @ReturnCode <> 0 RAISERROR(''Error deleting files.'', 16, 1)'
-              END
-
-              IF @BackupSoftware = 'LITESPEED'
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'xp_slssqlmaint'
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_slssqlmaint N''-MAINTDEL -DELFOLDER "' + REPLACE(@CurrentDirectoryPath,'''','''''') + '" -DELEXTENSION "' + @CurrentFileExtension + '" -DELUNIT "' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + '" -DELUNITTYPE "minutes" -DELUSEAGE'' IF @ReturnCode <> 0 RAISERROR(''Error deleting LiteSpeed backup files.'', 16, 1)'
-              END
-
-              IF @BackupSoftware = 'SQLBACKUP'
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'sqbutility'
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqbutility 1032, N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''', N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + CASE WHEN @CurrentBackupType = 'FULL' THEN 'D' WHEN @CurrentBackupType = 'DIFF' THEN 'I' WHEN @CurrentBackupType = 'LOG' THEN 'L' END + ''', ''' + CAST(DATEDIFF(hh,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'h'', ' + ISNULL('''' + REPLACE(@EncryptionKey,'''','''''') + '''','NULL') + ' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLBackup backup files.'', 16, 1)'
-              END
-
-              IF @BackupSoftware = 'SQLSAFE'
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'xp_ss_delete'
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_delete @filename = N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + '\*.' + @CurrentFileExtension + ''', @age = ''' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'Minutes'' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLsafe backup files.'', 16, 1)'
-              END
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_create_subdir N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''' IF @ReturnCode <> 0 RAISERROR(''Error creating directory.'', 16, 1)'
 
               EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
               SET @Error = @@ERROR
@@ -3944,164 +3850,486 @@ BEGIN
               IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
 
               UPDATE @CurrentDirectories
-              SET CleanupCompleted = 1,
-                  CleanupOutput = @CurrentCommandOutput
+              SET CreateCompleted = 1,
+                  CreateOutput = @CurrentCommandOutput
               WHERE ID = @CurrentDirectoryID
-
-              SET @CurrentDirectoryID = NULL
-              SET @CurrentDirectoryPath = NULL
-              SET @CurrentCleanupDate = NULL
-
-              SET @CurrentDatabaseContext = NULL
-              SET @CurrentCommand = NULL
-              SET @CurrentCommandOutput = NULL
-              SET @CurrentCommandType = NULL
             END
-          END
+            ELSE
+            BEGIN
+              UPDATE @CurrentDirectories
+              SET CreateCompleted = 1,
+                  CreateOutput = 0
+              WHERE ID = @CurrentDirectoryID
+            END
 
-          -- Perform a backup
-          IF NOT EXISTS (SELECT * FROM @CurrentDirectories WHERE DirectoryPath <> 'NUL' AND DirectoryPath NOT IN(SELECT DirectoryPath FROM @Directories) AND (CreateOutput <> 0 OR CreateOutput IS NULL))
-          OR @HostPlatform = 'Linux'
+            SET @CurrentDirectoryID = NULL
+            SET @CurrentDirectoryPath = NULL
+
+            SET @CurrentDatabaseContext = NULL
+            SET @CurrentCommand = NULL
+            SET @CurrentCommandOutput = NULL
+            SET @CurrentCommandType = NULL
+
+            DELETE FROM @DirectoryInfo
+          END
+        END
+
+        IF @CleanupMode = 'BEFORE_BACKUP'
+        BEGIN
+          INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
+          SELECT DATEADD(hh,-(@CleanupTime),SYSDATETIME()), 0
+
+          IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 0 OR Mirror IS NULL) AND CleanupDate IS NULL)
           BEGIN
+            UPDATE @CurrentDirectories
+            SET CleanupDate = (SELECT MIN(CleanupDate)
+                               FROM @CurrentCleanupDates
+                               WHERE (Mirror = 0 OR Mirror IS NULL)),
+                CleanupMode = 'BEFORE_BACKUP'
+            WHERE Mirror = 0
+          END
+        END
+
+        IF @MirrorCleanupMode = 'BEFORE_BACKUP'
+        BEGIN
+          INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
+          SELECT DATEADD(hh,-(@MirrorCleanupTime),SYSDATETIME()), 1
+
+          IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 1 OR Mirror IS NULL) AND CleanupDate IS NULL)
+          BEGIN
+            UPDATE @CurrentDirectories
+            SET CleanupDate = (SELECT MIN(CleanupDate)
+                               FROM @CurrentCleanupDates
+                               WHERE (Mirror = 1 OR Mirror IS NULL)),
+                CleanupMode = 'BEFORE_BACKUP'
+            WHERE Mirror = 1
+          END
+        END
+
+        -- Delete old backup files, before backup
+        IF (NOT EXISTS (SELECT * FROM @CurrentDirectories WHERE CreateOutput <> 0 OR CreateOutput IS NULL) OR @HostPlatform = 'Linux')
+        AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
+        AND @CurrentBackupType = @BackupType
+        BEGIN
+          WHILE (1 = 1)
+          BEGIN
+            SELECT TOP 1 @CurrentDirectoryID = ID,
+                         @CurrentDirectoryPath = DirectoryPath,
+                         @CurrentCleanupDate = CleanupDate
+            FROM @CurrentDirectories
+            WHERE CleanupDate IS NOT NULL
+            AND CleanupMode = 'BEFORE_BACKUP'
+            AND CleanupCompleted = 0
+            ORDER BY ID ASC
+
+            IF @@ROWCOUNT = 0
+            BEGIN
+              BREAK
+            END
+
             IF @BackupSoftware IS NULL
             BEGIN
               SET @CurrentDatabaseContext = 'master'
 
-              SELECT @CurrentCommandType = CASE
-              WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP_DATABASE'
-              WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP_LOG'
-              END
+              SET @CurrentCommandType = 'xp_delete_file'
 
-              SELECT @CurrentCommand = CASE
-              WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP DATABASE ' + QUOTENAME(@CurrentDatabaseName)
-              WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP LOG ' + QUOTENAME(@CurrentDatabaseName)
-              END
-
-              IF @FileGroups IS NOT NULL SET @CurrentCommand += ' FILEGROUP = ''' + @CurrentFileGroupName + ''''
-
-              IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' READ_WRITE_FILEGROUPS'
-
-              SET @CurrentCommand += ' TO'
-
-              SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
-              FROM @CurrentFiles
-              WHERE Mirror = 0
-              ORDER BY FilePath ASC
-
-              IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
-              BEGIN
-                SET @CurrentCommand += ' MIRROR TO'
-
-                SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
-                FROM @CurrentFiles
-                WHERE Mirror = 1
-                ORDER BY FilePath ASC
-              END
-
-              SET @CurrentCommand += ' WITH '
-              IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
-              IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
-
-              IF @Version >= 10
-              BEGIN
-                SET @CurrentCommand += CASE WHEN @Compress = 'Y' AND (@CurrentIsEncrypted = 0 OR (@CurrentIsEncrypted = 1 AND ((@Version >= 13 AND @CurrentMaxTransferSize >= 65537) OR @Version >= 15.0404316 OR SERVERPROPERTY('EngineEdition') = 8))) THEN ', COMPRESSION' ELSE ', NO_COMPRESSION' END
-              END
-
-              IF @Compress = 'Y' AND @CompressionAlgorithm IS NOT NULL
-              BEGIN
-                SET @CurrentCommand += ' (ALGORITHM = ' + @CompressionAlgorithm + CASE WHEN @CompressionLevel IS NOT NULL THEN ', LEVEL = ' + @CompressionLevel ELSE '' END + ')'
-              END
-
-              IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
-
-              IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
-              BEGIN
-                SET @CurrentCommand += ', FORMAT'
-              END
-
-              IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
-              IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
-              IF @Init = 'Y' SET @CurrentCommand += ', INIT'
-              IF @Format = 'Y' SET @CurrentCommand += ', FORMAT'
-              IF @BlockSize IS NOT NULL SET @CurrentCommand += ', BLOCKSIZE = ' + CAST(@BlockSize AS nvarchar)
-              IF @BufferCount IS NOT NULL SET @CurrentCommand += ', BUFFERCOUNT = ' + CAST(@BufferCount AS nvarchar)
-              IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', MAXTRANSFERSIZE = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
-              IF @Description IS NOT NULL SET @CurrentCommand += ', DESCRIPTION = N''' + REPLACE(@Description,'''','''''') + ''''
-              IF @BackupSetName IS NOT NULL SET @CurrentCommand += ', NAME = N''' + REPLACE(@BackupSetName,'''','''''') + ''''
-              IF @Stats IS NOT NULL SET @CurrentCommand += ', STATS = ' + CAST(@Stats AS nvarchar)
-              IF @BackupOptions IS NOT NULL SET @CurrentCommand += ', BACKUP_OPTIONS = N''' + REPLACE(@BackupOptions,'''','''''') + ''''
-              IF @Encrypt = 'Y' SET @CurrentCommand += ', ENCRYPTION (ALGORITHM = ' + UPPER(@EncryptionAlgorithm) + ', '
-              IF @Encrypt = 'Y' AND @ServerCertificate IS NOT NULL SET @CurrentCommand += 'SERVER CERTIFICATE = ' + QUOTENAME(@ServerCertificate)
-              IF @Encrypt = 'Y' AND @ServerAsymmetricKey IS NOT NULL SET @CurrentCommand += 'SERVER ASYMMETRIC KEY = ' + QUOTENAME(@ServerAsymmetricKey)
-              IF @Encrypt = 'Y' SET @CurrentCommand += ')'
-              IF @URL IS NOT NULL AND @Credential IS NOT NULL SET @CurrentCommand += ', CREDENTIAL = N''' + REPLACE(@Credential,'''','''''') + ''''
-              IF @ExpireDate IS NOT NULL SET @CurrentCommand += ', EXPIREDATE = ''' + CONVERT(nvarchar, @ExpireDate, 21) + ''''
-              IF @RetainDays IS NOT NULL SET @CurrentCommand += ', RETAINDAYS = ' + CAST(@RetainDays AS nvarchar)
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_delete_file 0, N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + @CurrentFileExtension + ''', ''' + CONVERT(nvarchar(19),@CurrentCleanupDate,126) + ''' IF @ReturnCode <> 0 RAISERROR(''Error deleting files.'', 16, 1)'
             END
 
             IF @BackupSoftware = 'LITESPEED'
             BEGIN
               SET @CurrentDatabaseContext = 'master'
 
-              SELECT @CurrentCommandType = CASE
-              WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'xp_backup_database'
-              WHEN @CurrentBackupType = 'LOG' THEN 'xp_backup_log'
-              END
+              SET @CurrentCommandType = 'xp_slssqlmaint'
 
-              SELECT @CurrentCommand = CASE
-              WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_backup_database @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
-              WHEN @CurrentBackupType = 'LOG' THEN 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_backup_log @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
-              END
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_slssqlmaint N''-MAINTDEL -DELFOLDER "' + REPLACE(@CurrentDirectoryPath,'''','''''') + '" -DELEXTENSION "' + @CurrentFileExtension + '" -DELUNIT "' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + '" -DELUNITTYPE "minutes" -DELUSEAGE'' IF @ReturnCode <> 0 RAISERROR(''Error deleting LiteSpeed backup files.'', 16, 1)'
+            END
 
-              SELECT @CurrentCommand += ', @filename = N''' + REPLACE(FilePath,'''','''''') + ''''
+            IF @BackupSoftware = 'SQLBACKUP'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'sqbutility'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqbutility 1032, N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''', N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + CASE WHEN @CurrentBackupType = 'FULL' THEN 'D' WHEN @CurrentBackupType = 'DIFF' THEN 'I' WHEN @CurrentBackupType = 'LOG' THEN 'L' END + ''', ''' + CAST(DATEDIFF(hh,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'h'', ' + ISNULL('''' + REPLACE(@EncryptionKey,'''','''''') + '''','NULL') + ' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLBackup backup files.'', 16, 1)'
+            END
+
+            IF @BackupSoftware = 'SQLSAFE'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_ss_delete'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_delete @filename = N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + '\*.' + @CurrentFileExtension + ''', @age = ''' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'Minutes'' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLsafe backup files.'', 16, 1)'
+            END
+
+            EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
+            SET @Error = @@ERROR
+            IF @Error <> 0 SET @CurrentCommandOutput = @Error
+            IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
+
+            UPDATE @CurrentDirectories
+            SET CleanupCompleted = 1,
+                CleanupOutput = @CurrentCommandOutput
+            WHERE ID = @CurrentDirectoryID
+
+            SET @CurrentDirectoryID = NULL
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentCleanupDate = NULL
+
+            SET @CurrentDatabaseContext = NULL
+            SET @CurrentCommand = NULL
+            SET @CurrentCommandOutput = NULL
+            SET @CurrentCommandType = NULL
+          END
+        END
+
+        -- Perform a backup
+        IF NOT EXISTS (SELECT * FROM @CurrentDirectories WHERE DirectoryPath <> 'NUL' AND DirectoryPath NOT IN(SELECT DirectoryPath FROM @Directories) AND (CreateOutput <> 0 OR CreateOutput IS NULL))
+        OR @HostPlatform = 'Linux'
+        BEGIN
+          IF @BackupSoftware IS NULL
+          BEGIN
+            SET @CurrentDatabaseContext = 'master'
+
+            SELECT @CurrentCommandType = CASE
+            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP_DATABASE'
+            WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP_LOG'
+            END
+
+            SELECT @CurrentCommand = CASE
+            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP DATABASE ' + QUOTENAME(@CurrentDatabaseName)
+            WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP LOG ' + QUOTENAME(@CurrentDatabaseName)
+            END
+
+            IF @FileGroups IS NOT NULL SET @CurrentCommand += ' FILEGROUP = ''' + @CurrentFileGroupName + ''''
+
+            IF @CurrentFileGroupName = 'PRIMARY' AND EXISTS (SELECT * FROM @tmpFileGroups WHERE [type] = 'FX' AND Selected = 1)
+            BEGIN
+              SET @CurrentCommand += ', FILEGROUP = ''' + (SELECT FileGroupName FROM @tmpFileGroups WHERE [type] = 'FX') + ''''
+            END
+
+            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' READ_WRITE_FILEGROUPS'
+
+            SET @CurrentCommand += ' TO'
+
+            SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
+            FROM @CurrentFiles
+            WHERE Mirror = 0
+            ORDER BY FilePath ASC
+
+            IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
+            BEGIN
+              SET @CurrentCommand += ' MIRROR TO'
+
+              SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
               FROM @CurrentFiles
-              WHERE Mirror = 0
+              WHERE Mirror = 1
+              ORDER BY FilePath ASC
+            END
+
+            SET @CurrentCommand += ' WITH '
+            IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
+            IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+
+            IF @Version >= 10
+            BEGIN
+              SET @CurrentCommand += CASE WHEN @Compress = 'Y' AND (@CurrentIsEncrypted = 0 OR (@CurrentIsEncrypted = 1 AND ((@Version >= 13 AND @CurrentMaxTransferSize >= 65537) OR @Version >= 15.0404316 OR SERVERPROPERTY('EngineEdition') = 8))) THEN ', COMPRESSION' ELSE ', NO_COMPRESSION' END
+            END
+
+            IF @Compress = 'Y' AND @CompressionAlgorithm IS NOT NULL
+            BEGIN
+              SET @CurrentCommand += ' (ALGORITHM = ' + @CompressionAlgorithm + CASE WHEN @CompressionLevel IS NOT NULL THEN ', LEVEL = ' + @CompressionLevel ELSE '' END + ')'
+            END
+
+            IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
+
+            IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
+            BEGIN
+              SET @CurrentCommand += ', FORMAT'
+            END
+
+            IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
+            IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
+            IF @Init = 'Y' SET @CurrentCommand += ', INIT'
+            IF @Format = 'Y' SET @CurrentCommand += ', FORMAT'
+            IF @BlockSize IS NOT NULL SET @CurrentCommand += ', BLOCKSIZE = ' + CAST(@BlockSize AS nvarchar)
+            IF @BufferCount IS NOT NULL SET @CurrentCommand += ', BUFFERCOUNT = ' + CAST(@BufferCount AS nvarchar)
+            IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', MAXTRANSFERSIZE = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
+            IF @Description IS NOT NULL SET @CurrentCommand += ', DESCRIPTION = N''' + REPLACE(@Description,'''','''''') + ''''
+            IF @BackupSetName IS NOT NULL SET @CurrentCommand += ', NAME = N''' + REPLACE(@BackupSetName,'''','''''') + ''''
+            IF @Stats IS NOT NULL SET @CurrentCommand += ', STATS = ' + CAST(@Stats AS nvarchar)
+            IF @BackupOptions IS NOT NULL SET @CurrentCommand += ', BACKUP_OPTIONS = N''' + REPLACE(@BackupOptions,'''','''''') + ''''
+            IF @Encrypt = 'Y' SET @CurrentCommand += ', ENCRYPTION (ALGORITHM = ' + UPPER(@EncryptionAlgorithm) + ', '
+            IF @Encrypt = 'Y' AND @ServerCertificate IS NOT NULL SET @CurrentCommand += 'SERVER CERTIFICATE = ' + QUOTENAME(@ServerCertificate)
+            IF @Encrypt = 'Y' AND @ServerAsymmetricKey IS NOT NULL SET @CurrentCommand += 'SERVER ASYMMETRIC KEY = ' + QUOTENAME(@ServerAsymmetricKey)
+            IF @Encrypt = 'Y' SET @CurrentCommand += ')'
+            IF @URL IS NOT NULL AND @Credential IS NOT NULL SET @CurrentCommand += ', CREDENTIAL = N''' + REPLACE(@Credential,'''','''''') + ''''
+            IF @ExpireDate IS NOT NULL SET @CurrentCommand += ', EXPIREDATE = ''' + CONVERT(nvarchar, @ExpireDate, 21) + ''''
+            IF @RetainDays IS NOT NULL SET @CurrentCommand += ', RETAINDAYS = ' + CAST(@RetainDays AS nvarchar)
+          END
+
+          IF @BackupSoftware = 'LITESPEED'
+          BEGIN
+            SET @CurrentDatabaseContext = 'master'
+
+            SELECT @CurrentCommandType = CASE
+            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'xp_backup_database'
+            WHEN @CurrentBackupType = 'LOG' THEN 'xp_backup_log'
+            END
+
+            SELECT @CurrentCommand = CASE
+            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_backup_database @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
+            WHEN @CurrentBackupType = 'LOG' THEN 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_backup_log @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
+            END
+
+            SELECT @CurrentCommand += ', @filename = N''' + REPLACE(FilePath,'''','''''') + ''''
+            FROM @CurrentFiles
+            WHERE Mirror = 0
+            ORDER BY FilePath ASC
+
+            IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
+            BEGIN
+              SELECT @CurrentCommand += ', @mirror = N''' + REPLACE(FilePath,'''','''''') + ''''
+              FROM @CurrentFiles
+              WHERE Mirror = 1
+              ORDER BY FilePath ASC
+            END
+
+            SET @CurrentCommand += ', @with = '''
+            IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
+            IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+            IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
+            IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
+            IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
+            IF @BlockSize IS NOT NULL SET @CurrentCommand += ', BLOCKSIZE = ' + CAST(@BlockSize AS nvarchar)
+            SET @CurrentCommand += ''''
+            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ', @read_write_filegroups = 1'
+            IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', @compressionlevel = ' + CAST(@CompressionLevelNumeric AS nvarchar)
+            IF @AdaptiveCompression IS NOT NULL SET @CurrentCommand += ', @adaptivecompression = ''' + CASE WHEN @AdaptiveCompression = 'SIZE' THEN 'Size' WHEN @AdaptiveCompression = 'SPEED' THEN 'Speed' END + ''''
+            IF @BufferCount IS NOT NULL SET @CurrentCommand += ', @buffercount = ' + CAST(@BufferCount AS nvarchar)
+            IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', @maxtransfersize = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
+            IF @Threads IS NOT NULL SET @CurrentCommand += ', @threads = ' + CAST(@Threads AS nvarchar)
+            IF @Init = 'Y' SET @CurrentCommand += ', @init = 1'
+            IF @Format = 'Y' SET @CurrentCommand += ', @format = 1'
+            IF @Throttle IS NOT NULL SET @CurrentCommand += ', @throttle = ' + CAST(@Throttle AS nvarchar)
+            IF @Description IS NOT NULL SET @CurrentCommand += ', @desc = N''' + REPLACE(@Description,'''','''''') + ''''
+            IF @ObjectLevelRecoveryMap = 'Y' SET @CurrentCommand += ', @olrmap = 1'
+            IF @ExpireDate IS NOT NULL SET @CurrentCommand += ', @expiration = ''' + CONVERT(nvarchar, @ExpireDate, 21) + ''''
+            IF @RetainDays IS NOT NULL SET @CurrentCommand += ', @retaindays = ' + CAST(@RetainDays AS nvarchar)
+
+            IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', @cryptlevel = ' + CASE
+            WHEN @EncryptionAlgorithm = 'RC2_40' THEN '0'
+            WHEN @EncryptionAlgorithm = 'RC2_56' THEN '1'
+            WHEN @EncryptionAlgorithm = 'RC2_112' THEN '2'
+            WHEN @EncryptionAlgorithm = 'RC2_128' THEN '3'
+            WHEN @EncryptionAlgorithm = 'TRIPLE_DES_3KEY' THEN '4'
+            WHEN @EncryptionAlgorithm = 'RC4_128' THEN '5'
+            WHEN @EncryptionAlgorithm = 'AES_128' THEN '6'
+            WHEN @EncryptionAlgorithm = 'AES_192' THEN '7'
+            WHEN @EncryptionAlgorithm = 'AES_256' THEN '8'
+            END
+
+            IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptionkey = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+            SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing LiteSpeed backup.'', 16, 1)'
+          END
+
+          IF @BackupSoftware = 'SQLBACKUP'
+          BEGIN
+            SET @CurrentDatabaseContext = 'master'
+
+            SET @CurrentCommandType = 'sqlbackup'
+
+            SELECT @CurrentCommand = CASE
+            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP DATABASE ' + QUOTENAME(@CurrentDatabaseName)
+            WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP LOG ' + QUOTENAME(@CurrentDatabaseName)
+            END
+
+            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' READ_WRITE_FILEGROUPS'
+
+            SET @CurrentCommand += ' TO'
+
+            SELECT @CurrentCommand += ' DISK = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
+            FROM @CurrentFiles
+            WHERE Mirror = 0
+            ORDER BY FilePath ASC
+
+            SET @CurrentCommand += ' WITH '
+
+            IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
+            BEGIN
+              SET @CurrentCommand += ' MIRRORFILE' + ' = N''' + REPLACE((SELECT FilePath FROM @CurrentFiles WHERE Mirror = 1),'''','''''') + ''', '
+            END
+
+            IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
+            IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+            IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
+            IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
+            IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
+            IF @Init = 'Y' SET @CurrentCommand += ', INIT'
+            IF @Format = 'Y' SET @CurrentCommand += ', FORMAT'
+            IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', COMPRESSION = ' + CAST(@CompressionLevelNumeric AS nvarchar)
+            IF @Threads IS NOT NULL SET @CurrentCommand += ', THREADCOUNT = ' + CAST(@Threads AS nvarchar)
+            IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', MAXTRANSFERSIZE = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
+            IF @Description IS NOT NULL SET @CurrentCommand += ', DESCRIPTION = N''' + REPLACE(@Description,'''','''''') + ''''
+
+            IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', KEYSIZE = ' + CASE
+            WHEN @EncryptionAlgorithm = 'AES_128' THEN '128'
+            WHEN @EncryptionAlgorithm = 'AES_256' THEN '256'
+            END
+
+            IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', PASSWORD = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqlbackup N''-SQL "' + REPLACE(@CurrentCommand,'''','''''') + '"''' + ' IF @ReturnCode <> 0 RAISERROR(''Error performing SQLBackup backup.'', 16, 1)'
+          END
+
+          IF @BackupSoftware = 'SQLSAFE'
+          BEGIN
+            SET @CurrentDatabaseContext = 'master'
+
+            SET @CurrentCommandType = 'xp_ss_backup'
+
+            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_backup @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
+
+            SELECT @CurrentCommand += ', ' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) = 1 THEN '@filename' ELSE '@backupfile' END + ' = N''' + REPLACE(FilePath,'''','''''') + ''''
+            FROM @CurrentFiles
+            WHERE Mirror = 0
+            ORDER BY FilePath ASC
+
+            SELECT @CurrentCommand += ', @mirrorfile = N''' + REPLACE(FilePath,'''','''''') + ''''
+            FROM @CurrentFiles
+            WHERE Mirror = 1
+            ORDER BY FilePath ASC
+
+            SET @CurrentCommand += ', @backuptype = ' + CASE WHEN @CurrentBackupType = 'FULL' THEN '''Full''' WHEN @CurrentBackupType = 'DIFF' THEN '''Differential''' WHEN @CurrentBackupType = 'LOG' THEN '''Log''' END
+            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ', @readwritefilegroups = 1'
+            SET @CurrentCommand += ', @checksum = ' + CASE WHEN @Checksum = 'Y' THEN '1' WHEN @Checksum = 'N' THEN '0' END
+            SET @CurrentCommand += ', @copyonly = ' + CASE WHEN @CopyOnly = 'Y' THEN '1' WHEN @CopyOnly = 'N' THEN '0' END
+            IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', @compressionlevel = ' + CAST(@CompressionLevelNumeric AS nvarchar)
+            IF @Threads IS NOT NULL SET @CurrentCommand += ', @threads = ' + CAST(@Threads AS nvarchar)
+            IF @Init = 'Y' SET @CurrentCommand += ', @overwrite = 1'
+            IF @Description IS NOT NULL SET @CurrentCommand += ', @desc = N''' + REPLACE(@Description,'''','''''') + ''''
+
+            IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', @encryptiontype = N''' + CASE
+            WHEN @EncryptionAlgorithm = 'AES_128' THEN 'AES128'
+            WHEN @EncryptionAlgorithm = 'AES_256' THEN 'AES256'
+            END + ''''
+
+            IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptedbackuppassword = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+            SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing SQLsafe backup.'', 16, 1)'
+          END
+
+          IF @BackupSoftware = 'DATA_DOMAIN_BOOST'
+          BEGIN
+            SET @CurrentDatabaseContext = 'master'
+
+            SET @CurrentCommandType = 'emc_run_backup'
+
+            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.emc_run_backup '''
+
+            SET @CurrentCommand += ' -c ' + CASE WHEN @Cluster IS NOT NULL AND @CurrentAvailabilityGroup IS NOT NULL THEN @Cluster ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar) END
+
+            SET @CurrentCommand += ' -l ' + CASE
+            WHEN @CurrentBackupType = 'FULL' THEN 'full'
+            WHEN @CurrentBackupType = 'DIFF' THEN 'diff'
+            WHEN @CurrentBackupType = 'LOG' THEN 'incr'
+            END
+
+            IF @NoRecovery = 'Y' SET @CurrentCommand += ' -H'
+
+            IF @CleanupTime IS NOT NULL SET @CurrentCommand += ' -y +' + CAST(@CleanupTime/24 + CASE WHEN @CleanupTime%24 > 0 THEN 1 ELSE 0 END AS nvarchar) + 'd'
+
+            IF @Checksum = 'Y' SET @CurrentCommand += ' -k'
+
+            SET @CurrentCommand += ' -S ' + CAST(@CurrentNumberOfFiles AS nvarchar)
+
+            IF @Description IS NOT NULL SET @CurrentCommand += ' -b "' + REPLACE(@Description,'''','''''') + '"'
+
+            IF @BufferCount IS NOT NULL SET @CurrentCommand += ' -O "BUFFERCOUNT=' + CAST(@BufferCount AS nvarchar) + '"'
+
+            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' -O "READ_WRITE_FILEGROUPS"'
+
+            IF @DataDomainBoostHost IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_HOST=' + REPLACE(@DataDomainBoostHost,'''','''''') + '"'
+            IF @DataDomainBoostUser IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_USER=' + REPLACE(@DataDomainBoostUser,'''','''''') + '"'
+            IF @DataDomainBoostDevicePath IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DEVICE_PATH=' + REPLACE(@DataDomainBoostDevicePath,'''','''''') + '"'
+            IF @DataDomainBoostLockboxPath IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_LOCKBOX_PATH=' + REPLACE(@DataDomainBoostLockboxPath,'''','''''') + '"'
+            SET @CurrentCommand += ' -a "NSR_SKIP_NON_BACKUPABLE_STATE_DB=TRUE"'
+            SET @CurrentCommand += ' -a "BACKUP_PROMOTION=NONE"'
+            IF @CopyOnly = 'Y' SET @CurrentCommand += ' -a "NSR_COPY_ONLY=TRUE"'
+            IF @BackupSetName IS NOT NULL SET @CurrentCommand += ' -N "' + REPLACE(@BackupSetName,'''','''''') + '"'
+
+            IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentCommand += ' "MSSQL'
+            IF SERVERPROPERTY('InstanceName') IS NOT NULL SET @CurrentCommand += ' "MSSQL$' + CAST(SERVERPROPERTY('InstanceName') AS nvarchar)
+            SET @CurrentCommand += ':' + REPLACE(REPLACE(@CurrentDatabaseName,'''',''''''),'.','\.') + '"'
+
+            SET @CurrentCommand += ''''
+
+            SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing Data Domain Boost backup.'', 16, 1)'
+          END
+
+          EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
+          SET @Error = @@ERROR
+          IF @Error <> 0 SET @CurrentCommandOutput = @Error
+          IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
+          SET @CurrentBackupOutput = @CurrentCommandOutput
+        END
+
+        -- Verify the backup
+        IF @CurrentBackupOutput = 0 AND @Verify = 'Y'
+        BEGIN
+          WHILE (1 = 1)
+          BEGIN
+            SELECT TOP 1 @CurrentBackupSetID = ID,
+                         @CurrentIsMirror = Mirror
+            FROM @CurrentBackupSet
+            WHERE VerifyCompleted = 0
+            ORDER BY ID ASC
+
+            IF @@ROWCOUNT = 0
+            BEGIN
+              BREAK
+            END
+
+            IF @BackupSoftware IS NULL
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'RESTORE_VERIFYONLY'
+
+              SET @CurrentCommand = 'RESTORE VERIFYONLY FROM'
+
+              SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
+              FROM @CurrentFiles
+              WHERE Mirror = @CurrentIsMirror
               ORDER BY FilePath ASC
 
-              IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
-              BEGIN
-                SELECT @CurrentCommand += ', @mirror = N''' + REPLACE(FilePath,'''','''''') + ''''
-                FROM @CurrentFiles
-                WHERE Mirror = 1
-                ORDER BY FilePath ASC
-              END
+              SET @CurrentCommand += ' WITH '
+              IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
+              IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+              IF @Stats IS NOT NULL SET @CurrentCommand += ', STATS = ' + CAST(@Stats AS nvarchar)
+              IF @BackupOptions IS NOT NULL SET @CurrentCommand += ', RESTORE_OPTIONS = N''' + REPLACE(@BackupOptions,'''','''''') + ''''
+              IF @URL IS NOT NULL AND @Credential IS NOT NULL SET @CurrentCommand += ', CREDENTIAL = N''' + REPLACE(@Credential,'''','''''') + ''''
+            END
+
+            IF @BackupSoftware = 'LITESPEED'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_restore_verifyonly'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_restore_verifyonly'
+
+              SELECT @CurrentCommand += ' @filename = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
+              FROM @CurrentFiles
+              WHERE Mirror = @CurrentIsMirror
+              ORDER BY FilePath ASC
 
               SET @CurrentCommand += ', @with = '''
               IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
               IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
-              IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
-              IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
-              IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
-              IF @BlockSize IS NOT NULL SET @CurrentCommand += ', BLOCKSIZE = ' + CAST(@BlockSize AS nvarchar)
               SET @CurrentCommand += ''''
-              IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ', @read_write_filegroups = 1'
-              IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', @compressionlevel = ' + CAST(@CompressionLevelNumeric AS nvarchar)
-              IF @AdaptiveCompression IS NOT NULL SET @CurrentCommand += ', @adaptivecompression = ''' + CASE WHEN @AdaptiveCompression = 'SIZE' THEN 'Size' WHEN @AdaptiveCompression = 'SPEED' THEN 'Speed' END + ''''
-              IF @BufferCount IS NOT NULL SET @CurrentCommand += ', @buffercount = ' + CAST(@BufferCount AS nvarchar)
-              IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', @maxtransfersize = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
-              IF @Threads IS NOT NULL SET @CurrentCommand += ', @threads = ' + CAST(@Threads AS nvarchar)
-              IF @Init = 'Y' SET @CurrentCommand += ', @init = 1'
-              IF @Format = 'Y' SET @CurrentCommand += ', @format = 1'
-              IF @Throttle IS NOT NULL SET @CurrentCommand += ', @throttle = ' + CAST(@Throttle AS nvarchar)
-              IF @Description IS NOT NULL SET @CurrentCommand += ', @desc = N''' + REPLACE(@Description,'''','''''') + ''''
-              IF @ObjectLevelRecoveryMap = 'Y' SET @CurrentCommand += ', @olrmap = 1'
-              IF @ExpireDate IS NOT NULL SET @CurrentCommand += ', @expiration = ''' + CONVERT(nvarchar, @ExpireDate, 21) + ''''
-              IF @RetainDays IS NOT NULL SET @CurrentCommand += ', @retaindays = ' + CAST(@RetainDays AS nvarchar)
-
-              IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', @cryptlevel = ' + CASE
-              WHEN @EncryptionAlgorithm = 'RC2_40' THEN '0'
-              WHEN @EncryptionAlgorithm = 'RC2_56' THEN '1'
-              WHEN @EncryptionAlgorithm = 'RC2_112' THEN '2'
-              WHEN @EncryptionAlgorithm = 'RC2_128' THEN '3'
-              WHEN @EncryptionAlgorithm = 'TRIPLE_DES_3KEY' THEN '4'
-              WHEN @EncryptionAlgorithm = 'RC4_128' THEN '5'
-              WHEN @EncryptionAlgorithm = 'AES_128' THEN '6'
-              WHEN @EncryptionAlgorithm = 'AES_192' THEN '7'
-              WHEN @EncryptionAlgorithm = 'AES_256' THEN '8'
-              END
-
               IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptionkey = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
-              SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing LiteSpeed backup.'', 16, 1)'
+
+              SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error verifying LiteSpeed backup.'', 16, 1)'
             END
 
             IF @BackupSoftware = 'SQLBACKUP'
@@ -4110,373 +4338,182 @@ BEGIN
 
               SET @CurrentCommandType = 'sqlbackup'
 
-              SELECT @CurrentCommand = CASE
-              WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP DATABASE ' + QUOTENAME(@CurrentDatabaseName)
-              WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP LOG ' + QUOTENAME(@CurrentDatabaseName)
-              END
-
-              IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' READ_WRITE_FILEGROUPS'
-
-              SET @CurrentCommand += ' TO'
+              SET @CurrentCommand = 'RESTORE VERIFYONLY FROM'
 
               SELECT @CurrentCommand += ' DISK = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
               FROM @CurrentFiles
-              WHERE Mirror = 0
+              WHERE Mirror = @CurrentIsMirror
               ORDER BY FilePath ASC
 
               SET @CurrentCommand += ' WITH '
-
-              IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
-              BEGIN
-                SET @CurrentCommand += ' MIRRORFILE' + ' = N''' + REPLACE((SELECT FilePath FROM @CurrentFiles WHERE Mirror = 1),'''','''''') + ''', '
-              END
-
               IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
               IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
-              IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
-              IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
-              IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
-              IF @Init = 'Y' SET @CurrentCommand += ', INIT'
-              IF @Format = 'Y' SET @CurrentCommand += ', FORMAT'
-              IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', COMPRESSION = ' + CAST(@CompressionLevelNumeric AS nvarchar)
-              IF @Threads IS NOT NULL SET @CurrentCommand += ', THREADCOUNT = ' + CAST(@Threads AS nvarchar)
-              IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', MAXTRANSFERSIZE = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
-              IF @Description IS NOT NULL SET @CurrentCommand += ', DESCRIPTION = N''' + REPLACE(@Description,'''','''''') + ''''
-
-              IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', KEYSIZE = ' + CASE
-              WHEN @EncryptionAlgorithm = 'AES_128' THEN '128'
-              WHEN @EncryptionAlgorithm = 'AES_256' THEN '256'
-              END
-
               IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', PASSWORD = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
-              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqlbackup N''-SQL "' + REPLACE(@CurrentCommand,'''','''''') + '"''' + ' IF @ReturnCode <> 0 RAISERROR(''Error performing SQLBackup backup.'', 16, 1)'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqlbackup N''-SQL "' + REPLACE(@CurrentCommand,'''','''''') + '"''' + ' IF @ReturnCode <> 0 RAISERROR(''Error verifying SQLBackup backup.'', 16, 1)'
             END
 
             IF @BackupSoftware = 'SQLSAFE'
             BEGIN
               SET @CurrentDatabaseContext = 'master'
 
-              SET @CurrentCommandType = 'xp_ss_backup'
+              SET @CurrentCommandType = 'xp_ss_verify'
 
-              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_backup @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_verify @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
 
               SELECT @CurrentCommand += ', ' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) = 1 THEN '@filename' ELSE '@backupfile' END + ' = N''' + REPLACE(FilePath,'''','''''') + ''''
               FROM @CurrentFiles
-              WHERE Mirror = 0
+              WHERE Mirror = @CurrentIsMirror
               ORDER BY FilePath ASC
 
-              SELECT @CurrentCommand += ', @mirrorfile = N''' + REPLACE(FilePath,'''','''''') + ''''
-              FROM @CurrentFiles
-              WHERE Mirror = 1
-              ORDER BY FilePath ASC
-
-              SET @CurrentCommand += ', @backuptype = ' + CASE WHEN @CurrentBackupType = 'FULL' THEN '''Full''' WHEN @CurrentBackupType = 'DIFF' THEN '''Differential''' WHEN @CurrentBackupType = 'LOG' THEN '''Log''' END
-              IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ', @readwritefilegroups = 1'
-              SET @CurrentCommand += ', @checksum = ' + CASE WHEN @Checksum = 'Y' THEN '1' WHEN @Checksum = 'N' THEN '0' END
-              SET @CurrentCommand += ', @copyonly = ' + CASE WHEN @CopyOnly = 'Y' THEN '1' WHEN @CopyOnly = 'N' THEN '0' END
-              IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', @compressionlevel = ' + CAST(@CompressionLevelNumeric AS nvarchar)
-              IF @Threads IS NOT NULL SET @CurrentCommand += ', @threads = ' + CAST(@Threads AS nvarchar)
-              IF @Init = 'Y' SET @CurrentCommand += ', @overwrite = 1'
-              IF @Description IS NOT NULL SET @CurrentCommand += ', @desc = N''' + REPLACE(@Description,'''','''''') + ''''
-
-              IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', @encryptiontype = N''' + CASE
-              WHEN @EncryptionAlgorithm = 'AES_128' THEN 'AES128'
-              WHEN @EncryptionAlgorithm = 'AES_256' THEN 'AES256'
-              END + ''''
-
-              IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptedbackuppassword = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
-              SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing SQLsafe backup.'', 16, 1)'
-            END
-
-            IF @BackupSoftware = 'DATA_DOMAIN_BOOST'
-            BEGIN
-              SET @CurrentDatabaseContext = 'master'
-
-              SET @CurrentCommandType = 'emc_run_backup'
-
-              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.emc_run_backup '''
-
-              SET @CurrentCommand += ' -c ' + CASE WHEN @Cluster IS NOT NULL AND @CurrentAvailabilityGroup IS NOT NULL THEN @Cluster ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar) END
-
-              SET @CurrentCommand += ' -l ' + CASE
-              WHEN @CurrentBackupType = 'FULL' THEN 'full'
-              WHEN @CurrentBackupType = 'DIFF' THEN 'diff'
-              WHEN @CurrentBackupType = 'LOG' THEN 'incr'
-              END
-
-              IF @NoRecovery = 'Y' SET @CurrentCommand += ' -H'
-
-              IF @CleanupTime IS NOT NULL SET @CurrentCommand += ' -y +' + CAST(@CleanupTime/24 + CASE WHEN @CleanupTime%24 > 0 THEN 1 ELSE 0 END AS nvarchar) + 'd'
-
-              IF @Checksum = 'Y' SET @CurrentCommand += ' -k'
-
-              SET @CurrentCommand += ' -S ' + CAST(@CurrentNumberOfFiles AS nvarchar)
-
-              IF @Description IS NOT NULL SET @CurrentCommand += ' -b "' + REPLACE(@Description,'''','''''') + '"'
-
-              IF @BufferCount IS NOT NULL SET @CurrentCommand += ' -O "BUFFERCOUNT=' + CAST(@BufferCount AS nvarchar) + '"'
-
-              IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' -O "READ_WRITE_FILEGROUPS"'
-
-              IF @DataDomainBoostHost IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_HOST=' + REPLACE(@DataDomainBoostHost,'''','''''') + '"'
-              IF @DataDomainBoostUser IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_USER=' + REPLACE(@DataDomainBoostUser,'''','''''') + '"'
-              IF @DataDomainBoostDevicePath IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DEVICE_PATH=' + REPLACE(@DataDomainBoostDevicePath,'''','''''') + '"'
-              IF @DataDomainBoostLockboxPath IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_LOCKBOX_PATH=' + REPLACE(@DataDomainBoostLockboxPath,'''','''''') + '"'
-              SET @CurrentCommand += ' -a "NSR_SKIP_NON_BACKUPABLE_STATE_DB=TRUE"'
-              SET @CurrentCommand += ' -a "BACKUP_PROMOTION=NONE"'
-              IF @CopyOnly = 'Y' SET @CurrentCommand += ' -a "NSR_COPY_ONLY=TRUE"'
-              IF @BackupSetName IS NOT NULL SET @CurrentCommand += ' -N "' + REPLACE(@BackupSetName,'''','''''') + '"'
-
-              IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentCommand += ' "MSSQL'
-              IF SERVERPROPERTY('InstanceName') IS NOT NULL SET @CurrentCommand += ' "MSSQL$' + CAST(SERVERPROPERTY('InstanceName') AS nvarchar)
-              SET @CurrentCommand += ':' + REPLACE(REPLACE(@CurrentDatabaseName,'''',''''''),'.','\.') + '"'
-
-              SET @CurrentCommand += ''''
-
-              SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing Data Domain Boost backup.'', 16, 1)'
+              SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error verifying SQLsafe backup.'', 16, 1)'
             END
 
             EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
             SET @Error = @@ERROR
             IF @Error <> 0 SET @CurrentCommandOutput = @Error
             IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
-            SET @CurrentBackupOutput = @CurrentCommandOutput
-          END
 
-          -- Verify the backup
-          IF @CurrentBackupOutput = 0 AND @Verify = 'Y'
+            UPDATE @CurrentBackupSet
+            SET VerifyCompleted = 1,
+                VerifyOutput = @CurrentCommandOutput
+            WHERE ID = @CurrentBackupSetID
+
+            SET @CurrentBackupSetID = NULL
+            SET @CurrentIsMirror = NULL
+
+            SET @CurrentDatabaseContext = NULL
+            SET @CurrentCommand = NULL
+            SET @CurrentCommandOutput = NULL
+            SET @CurrentCommandType = NULL
+          END
+        END
+
+        IF @CleanupMode = 'AFTER_BACKUP'
+        BEGIN
+          INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
+          SELECT DATEADD(hh,-(@CleanupTime),SYSDATETIME()), 0
+
+          IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 0 OR Mirror IS NULL) AND CleanupDate IS NULL)
           BEGIN
-            WHILE (1 = 1)
-            BEGIN
-              SELECT TOP 1 @CurrentBackupSetID = ID,
-                           @CurrentIsMirror = Mirror
-              FROM @CurrentBackupSet
-              WHERE VerifyCompleted = 0
-              ORDER BY ID ASC
-
-              IF @@ROWCOUNT = 0
-              BEGIN
-                BREAK
-              END
-
-              IF @BackupSoftware IS NULL
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'RESTORE_VERIFYONLY'
-
-                SET @CurrentCommand = 'RESTORE VERIFYONLY FROM'
-
-                SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
-                FROM @CurrentFiles
-                WHERE Mirror = @CurrentIsMirror
-                ORDER BY FilePath ASC
-
-                SET @CurrentCommand += ' WITH '
-                IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
-                IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
-                IF @Stats IS NOT NULL SET @CurrentCommand += ', STATS = ' + CAST(@Stats AS nvarchar)
-                IF @BackupOptions IS NOT NULL SET @CurrentCommand += ', RESTORE_OPTIONS = N''' + REPLACE(@BackupOptions,'''','''''') + ''''
-                IF @URL IS NOT NULL AND @Credential IS NOT NULL SET @CurrentCommand += ', CREDENTIAL = N''' + REPLACE(@Credential,'''','''''') + ''''
-              END
-
-              IF @BackupSoftware = 'LITESPEED'
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'xp_restore_verifyonly'
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_restore_verifyonly'
-
-                SELECT @CurrentCommand += ' @filename = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
-                FROM @CurrentFiles
-                WHERE Mirror = @CurrentIsMirror
-                ORDER BY FilePath ASC
-
-                SET @CurrentCommand += ', @with = '''
-                IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
-                IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
-                SET @CurrentCommand += ''''
-                IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptionkey = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
-
-                SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error verifying LiteSpeed backup.'', 16, 1)'
-              END
-
-              IF @BackupSoftware = 'SQLBACKUP'
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'sqlbackup'
-
-                SET @CurrentCommand = 'RESTORE VERIFYONLY FROM'
-
-                SELECT @CurrentCommand += ' DISK = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
-                FROM @CurrentFiles
-                WHERE Mirror = @CurrentIsMirror
-                ORDER BY FilePath ASC
-
-                SET @CurrentCommand += ' WITH '
-                IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
-                IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
-                IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', PASSWORD = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqlbackup N''-SQL "' + REPLACE(@CurrentCommand,'''','''''') + '"''' + ' IF @ReturnCode <> 0 RAISERROR(''Error verifying SQLBackup backup.'', 16, 1)'
-              END
-
-              IF @BackupSoftware = 'SQLSAFE'
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'xp_ss_verify'
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_verify @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
-
-                SELECT @CurrentCommand += ', ' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) = 1 THEN '@filename' ELSE '@backupfile' END + ' = N''' + REPLACE(FilePath,'''','''''') + ''''
-                FROM @CurrentFiles
-                WHERE Mirror = @CurrentIsMirror
-                ORDER BY FilePath ASC
-
-                SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error verifying SQLsafe backup.'', 16, 1)'
-              END
-
-              EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
-              SET @Error = @@ERROR
-              IF @Error <> 0 SET @CurrentCommandOutput = @Error
-              IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
-
-              UPDATE @CurrentBackupSet
-              SET VerifyCompleted = 1,
-                  VerifyOutput = @CurrentCommandOutput
-              WHERE ID = @CurrentBackupSetID
-
-              SET @CurrentBackupSetID = NULL
-              SET @CurrentIsMirror = NULL
-
-              SET @CurrentDatabaseContext = NULL
-              SET @CurrentCommand = NULL
-              SET @CurrentCommandOutput = NULL
-              SET @CurrentCommandType = NULL
-            END
+            UPDATE @CurrentDirectories
+            SET CleanupDate = (SELECT MIN(CleanupDate)
+                               FROM @CurrentCleanupDates
+                               WHERE (Mirror = 0 OR Mirror IS NULL)),
+                CleanupMode = 'AFTER_BACKUP'
+            WHERE Mirror = 0
           END
+        END
 
-          IF @CleanupMode = 'AFTER_BACKUP'
+        IF @MirrorCleanupMode = 'AFTER_BACKUP'
+        BEGIN
+          INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
+          SELECT DATEADD(hh,-(@MirrorCleanupTime),SYSDATETIME()), 1
+
+          IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 1 OR Mirror IS NULL) AND CleanupDate IS NULL)
           BEGIN
-            INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
-            SELECT DATEADD(hh,-(@CleanupTime),SYSDATETIME()), 0
-
-            IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 0 OR Mirror IS NULL) AND CleanupDate IS NULL)
-            BEGIN
-              UPDATE @CurrentDirectories
-              SET CleanupDate = (SELECT MIN(CleanupDate)
-                                 FROM @CurrentCleanupDates
-                                 WHERE (Mirror = 0 OR Mirror IS NULL)),
-                  CleanupMode = 'AFTER_BACKUP'
-              WHERE Mirror = 0
-            END
+            UPDATE @CurrentDirectories
+            SET CleanupDate = (SELECT MIN(CleanupDate)
+                               FROM @CurrentCleanupDates
+                               WHERE (Mirror = 1 OR Mirror IS NULL)),
+                CleanupMode = 'AFTER_BACKUP'
+            WHERE Mirror = 1
           END
+        END
 
-          IF @MirrorCleanupMode = 'AFTER_BACKUP'
+        -- Delete old backup files, after backup
+        IF ((@CurrentBackupOutput = 0 AND @Verify = 'N')
+        OR (@CurrentBackupOutput = 0 AND @Verify = 'Y' AND NOT EXISTS (SELECT * FROM @CurrentBackupSet WHERE VerifyOutput <> 0 OR VerifyOutput IS NULL)))
+        AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
+        AND @CurrentBackupType = @BackupType
+        BEGIN
+          WHILE (1 = 1)
           BEGIN
-            INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
-            SELECT DATEADD(hh,-(@MirrorCleanupTime),SYSDATETIME()), 1
+            SELECT TOP 1 @CurrentDirectoryID = ID,
+                         @CurrentDirectoryPath = DirectoryPath,
+                         @CurrentCleanupDate = CleanupDate
+            FROM @CurrentDirectories
+            WHERE CleanupDate IS NOT NULL
+            AND CleanupMode = 'AFTER_BACKUP'
+            AND CleanupCompleted = 0
+            ORDER BY ID ASC
 
-            IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 1 OR Mirror IS NULL) AND CleanupDate IS NULL)
+            IF @@ROWCOUNT = 0
             BEGIN
-              UPDATE @CurrentDirectories
-              SET CleanupDate = (SELECT MIN(CleanupDate)
-                                 FROM @CurrentCleanupDates
-                                 WHERE (Mirror = 1 OR Mirror IS NULL)),
-                  CleanupMode = 'AFTER_BACKUP'
-              WHERE Mirror = 1
+              BREAK
             END
-          END
 
-          -- Delete old backup files, after backup
-          IF ((@CurrentBackupOutput = 0 AND @Verify = 'N')
-          OR (@CurrentBackupOutput = 0 AND @Verify = 'Y' AND NOT EXISTS (SELECT * FROM @CurrentBackupSet WHERE VerifyOutput <> 0 OR VerifyOutput IS NULL)))
-          AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
-          AND @CurrentBackupType = @BackupType
-          BEGIN
-            WHILE (1 = 1)
+            IF @BackupSoftware IS NULL
             BEGIN
-              SELECT TOP 1 @CurrentDirectoryID = ID,
-                           @CurrentDirectoryPath = DirectoryPath,
-                           @CurrentCleanupDate = CleanupDate
-              FROM @CurrentDirectories
-              WHERE CleanupDate IS NOT NULL
-              AND CleanupMode = 'AFTER_BACKUP'
-              AND CleanupCompleted = 0
-              ORDER BY ID ASC
+              SET @CurrentDatabaseContext = 'master'
 
-              IF @@ROWCOUNT = 0
-              BEGIN
-                BREAK
-              END
+              SET @CurrentCommandType = 'xp_delete_file'
 
-              IF @BackupSoftware IS NULL
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'xp_delete_file'
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_delete_file 0, N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + @CurrentFileExtension + ''', ''' + CONVERT(nvarchar(19),@CurrentCleanupDate,126) + ''' IF @ReturnCode <> 0 RAISERROR(''Error deleting files.'', 16, 1)'
-              END
-
-              IF @BackupSoftware = 'LITESPEED'
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'xp_slssqlmaint'
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_slssqlmaint N''-MAINTDEL -DELFOLDER "' + REPLACE(@CurrentDirectoryPath,'''','''''') + '" -DELEXTENSION "' + @CurrentFileExtension + '" -DELUNIT "' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + '" -DELUNITTYPE "minutes" -DELUSEAGE'' IF @ReturnCode <> 0 RAISERROR(''Error deleting LiteSpeed backup files.'', 16, 1)'
-              END
-
-              IF @BackupSoftware = 'SQLBACKUP'
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'sqbutility'
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqbutility 1032, N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''', N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + CASE WHEN @CurrentBackupType = 'FULL' THEN 'D' WHEN @CurrentBackupType = 'DIFF' THEN 'I' WHEN @CurrentBackupType = 'LOG' THEN 'L' END + ''', ''' + CAST(DATEDIFF(hh,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'h'', ' + ISNULL('''' + REPLACE(@EncryptionKey,'''','''''') + '''','NULL') + ' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLBackup backup files.'', 16, 1)'
-              END
-
-              IF @BackupSoftware = 'SQLSAFE'
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'xp_ss_delete'
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_delete @filename = N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + '\*.' + @CurrentFileExtension + ''', @age = ''' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'Minutes'' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLsafe backup files.'', 16, 1)'
-              END
-
-              EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
-              SET @Error = @@ERROR
-              IF @Error <> 0 SET @CurrentCommandOutput = @Error
-              IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
-
-              UPDATE @CurrentDirectories
-              SET CleanupCompleted = 1,
-                  CleanupOutput = @CurrentCommandOutput
-              WHERE ID = @CurrentDirectoryID
-
-              SET @CurrentDirectoryID = NULL
-              SET @CurrentDirectoryPath = NULL
-              SET @CurrentCleanupDate = NULL
-
-              SET @CurrentDatabaseContext = NULL
-              SET @CurrentCommand = NULL
-              SET @CurrentCommandOutput = NULL
-              SET @CurrentCommandType = NULL
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_delete_file 0, N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + @CurrentFileExtension + ''', ''' + CONVERT(nvarchar(19),@CurrentCleanupDate,126) + ''' IF @ReturnCode <> 0 RAISERROR(''Error deleting files.'', 16, 1)'
             END
-          END
 
-        END -- End of file group check
+            IF @BackupSoftware = 'LITESPEED'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_slssqlmaint'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_slssqlmaint N''-MAINTDEL -DELFOLDER "' + REPLACE(@CurrentDirectoryPath,'''','''''') + '" -DELEXTENSION "' + @CurrentFileExtension + '" -DELUNIT "' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + '" -DELUNITTYPE "minutes" -DELUSEAGE'' IF @ReturnCode <> 0 RAISERROR(''Error deleting LiteSpeed backup files.'', 16, 1)'
+            END
+
+            IF @BackupSoftware = 'SQLBACKUP'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'sqbutility'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqbutility 1032, N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''', N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + CASE WHEN @CurrentBackupType = 'FULL' THEN 'D' WHEN @CurrentBackupType = 'DIFF' THEN 'I' WHEN @CurrentBackupType = 'LOG' THEN 'L' END + ''', ''' + CAST(DATEDIFF(hh,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'h'', ' + ISNULL('''' + REPLACE(@EncryptionKey,'''','''''') + '''','NULL') + ' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLBackup backup files.'', 16, 1)'
+            END
+
+            IF @BackupSoftware = 'SQLSAFE'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_ss_delete'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_delete @filename = N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + '\*.' + @CurrentFileExtension + ''', @age = ''' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'Minutes'' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLsafe backup files.'', 16, 1)'
+            END
+
+            EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
+            SET @Error = @@ERROR
+            IF @Error <> 0 SET @CurrentCommandOutput = @Error
+            IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
+
+            UPDATE @CurrentDirectories
+            SET CleanupCompleted = 1,
+                CleanupOutput = @CurrentCommandOutput
+            WHERE ID = @CurrentDirectoryID
+
+            SET @CurrentDirectoryID = NULL
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentCleanupDate = NULL
+
+            SET @CurrentDatabaseContext = NULL
+            SET @CurrentCommand = NULL
+            SET @CurrentCommandOutput = NULL
+            SET @CurrentCommandType = NULL
+          END
+        END
 
         UPDATE @tmpFileGroups
         SET Completed = 1
         WHERE Selected = 1
         AND Completed = 0
         AND ID = @CurrentFGID
+
+        IF @CurrentFileGroupName = 'PRIMARY' AND EXISTS (SELECT * FROM @tmpFileGroups WHERE [type] = 'FX' AND Selected = 1)
+        BEGIN
+          UPDATE @tmpFileGroups
+          SET Completed = 1
+          WHERE Selected = 1
+          AND Completed = 0
+          AND [type] = 'FX'
+        END
 
         SET @CurrentDatabaseContext = NULL
         SET @CurrentCommand = NULL
@@ -4567,6 +4604,8 @@ BEGIN
     SET @CurrentLogSizeSinceLastLogBackup = NULL
     SET @CurrentAllocatedExtentPageCount = NULL
     SET @CurrentModifiedExtentPageCount = NULL
+
+    DELETE FROM @tmpFileGroups
 
   END -- End of database while loop
 

--- a/DatabaseBackup.sql
+++ b/DatabaseBackup.sql
@@ -92,7 +92,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-08 12:16:23                                                               //--
+  --// Version: 2025-06-08 20:41:55                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON
@@ -1198,6 +1198,12 @@ BEGIN
     SELECT 'The value for the parameter @BackupType is not supported.', 16, 1
   END
 
+  IF @BackupType = 'LOG' AND @FileGroups IS NOT NULL
+  BEGIN
+    INSERT INTO @Errors ([Message], Severity, [State])
+    SELECT 'The value for the parameter @BackupType is not supported. Transaction log backup on file groups is not supported.', 16, 2
+  END
+
   ----------------------------------------------------------------------------------------------------
 
   IF SERVERPROPERTY('EngineEdition') = 8 AND NOT (@BackupType = 'FULL' AND @CopyOnly = 'Y')
@@ -1268,6 +1274,12 @@ BEGIN
   BEGIN
     INSERT INTO @Errors ([Message], Severity, [State])
     SELECT 'The value for the parameter @CleanupTime is not supported. Cleanup is not supported if the token {CopyOnly} is not part of the directory.', 16, 7
+  END
+
+  IF @CleanupTime IS NOT NULL AND @FileGroups IS NOT NULL AND ((@DirectoryStructure NOT LIKE '%{FileGroupName}%' OR @DirectoryStructure IS NULL) OR (SERVERPROPERTY('IsHadrEnabled') = 1 AND (@AvailabilityGroupDirectoryStructure NOT LIKE '%{FileGroupName}%' OR @AvailabilityGroupDirectoryStructure IS NULL)))
+  BEGIN
+    INSERT INTO @Errors ([Message], Severity, [State])
+    SELECT 'The value for the parameter @CleanupTime is not supported. Cleanup is not supported if the token {FileGroupName} is not part of the directory.', 16, 8
   END
 
   ----------------------------------------------------------------------------------------------------
@@ -1370,6 +1382,12 @@ BEGIN
   BEGIN
     INSERT INTO @Errors ([Message], Severity, [State])
     SELECT 'The value for the parameter @ChangeBackupType is not supported.', 16, 1
+  END
+
+  IF @ChangeBackupType = 'Y' AND @FileGroups IS NOT NULL
+  BEGIN
+    INSERT INTO @Errors ([Message], Severity, [State])
+    SELECT 'The value for the parameter @ChangeBackupType is not supported. Changing the backup type is not supported with file group backup.', 16, 2
   END
 
   ----------------------------------------------------------------------------------------------------
@@ -1590,6 +1608,12 @@ BEGIN
     SELECT 'The value for the parameter @MinBackupSizeForMultipleFiles is not supported. The column sys.dm_db_log_stats.log_since_last_log_backup_mb is not available in this version of SQL Server.', 16, 4
   END
 
+  IF @MinBackupSizeForMultipleFiles IS NOT NULL AND @FileGroups IS NOT NULL
+  BEGIN
+    INSERT INTO @Errors ([Message], Severity, [State])
+    SELECT 'The value for the parameter @MinBackupSizeForMultipleFiles is not supported. This option is not supported with file group backup.', 16, 5
+  END
+
   ----------------------------------------------------------------------------------------------------
 
   IF @MaxFileSize <= 0
@@ -1614,6 +1638,12 @@ BEGIN
   BEGIN
     INSERT INTO @Errors ([Message], Severity, [State])
     SELECT 'The value for the parameter @MaxFileSize is not supported. The column sys.dm_db_log_stats.log_since_last_log_backup_mb is not available in this version of SQL Server.', 16, 4
+  END
+
+  IF @MaxFileSize IS NOT NULL AND @FileGroups IS NOT NULL
+  BEGIN
+    INSERT INTO @Errors ([Message], Severity, [State])
+    SELECT 'The value for the parameter @MaxFileSize is not supported. This option is not supported with file group backup.', 16, 5
   END
 
   ----------------------------------------------------------------------------------------------------
@@ -1861,6 +1891,12 @@ BEGIN
     SELECT 'The value for the parameter @ReadWriteFileGroups is not supported.', 16, 2
   END
 
+  IF @ReadWriteFileGroups = 'Y' AND @FileGroups IS NOT NULL
+  BEGIN
+    INSERT INTO @Errors ([Message], Severity, [State])
+    SELECT 'The value for the parameter @ReadWriteFileGroups is not supported. This option is not supported with file group backup.', 16, 3
+  END
+
   ----------------------------------------------------------------------------------------------------
 
   IF @OverrideBackupPreference NOT IN('Y','N') OR @OverrideBackupPreference IS NULL
@@ -2055,6 +2091,12 @@ BEGIN
   BEGIN
     INSERT INTO @Errors ([Message], Severity, [State])
     SELECT 'The parameter @MinDatabaseSizeForDifferentialBackup can only be used for differential backups.', 16, 2
+  END
+
+  IF @MinDatabaseSizeForDifferentialBackup IS NOT NULL AND @FileGroups IS NOT NULL
+  BEGIN
+    INSERT INTO @Errors ([Message], Severity, [State])
+    SELECT 'The value for the parameter @MinDatabaseSizeForDifferentialBackup is not supported. This option is not supported with file group backup.', 16, 3
   END
 
   ----------------------------------------------------------------------------------------------------
@@ -2439,6 +2481,26 @@ BEGIN
   BEGIN
     INSERT INTO @Errors ([Message], Severity, [State])
     SELECT 'The value for the parameter @RetainDays is not supported.', 16, 1
+  END
+
+  ----------------------------------------------------------------------------------------------------
+
+  IF EXISTS(SELECT * FROM @SelectedFileGroups WHERE DatabaseName IS NULL OR FileGroupName IS NULL)
+  BEGIN
+    INSERT INTO @Errors ([Message], Severity, [State])
+    SELECT 'The value for the parameter @FileGroups is not supported.', 16, 1
+  END
+
+  IF @FileGroups IS NOT NULL AND NOT EXISTS(SELECT * FROM @SelectedFileGroups)
+  BEGIN
+    INSERT INTO @Errors ([Message], Severity, [State])
+    SELECT 'The value for the parameter @FileGroups is not supported.', 16, 2
+  END
+
+  IF @FileGroups IS NOT NULL AND @BackupSoftware IS NOT NULL
+  BEGIN
+    INSERT INTO @Errors ([Message], Severity, [State])
+    SELECT 'The value for the parameter @FileGroups is not supported. File group backup is only supported with native SQL Server backup.', 16, 2
   END
 
   ----------------------------------------------------------------------------------------------------
@@ -2895,7 +2957,6 @@ BEGIN
         RAISERROR(@ErrorMessage,16,1) WITH NOWAIT
         SET @Error = @@ERROR
       END
-
     END
 
     SET @CurrentDatabase_sp_executesql = QUOTENAME(@CurrentDatabaseName) + '.sys.sp_executesql'
@@ -3151,602 +3212,721 @@ BEGIN
     AND NOT (@CurrentBackupType = 'DIFF' AND @MinDatabaseSizeForDifferentialBackup IS NOT NULL AND (COALESCE(CAST(@CurrentAllocatedExtentPageCount AS bigint) * 8192, CAST(@CurrentDatabaseSize AS bigint) * 8192) < CAST(@MinDatabaseSizeForDifferentialBackup AS bigint) * 1024 * 1024))
     BEGIN
 
-    WHILE (1 = 1)
-    BEGIN
-
-      IF @FileGroups IS NOT NULL
+      WHILE (1 = 1)
       BEGIN
-        SELECT TOP 1 @CurrentFGID = ID,
-                     @CurrentFileGroupID = FileGroupID,
-                     @CurrentFileGroupName = FileGroupName
-        FROM @tmpFileGroups
-        WHERE Selected = 1
-        AND Completed = 0
-        ORDER BY [Order] ASC
 
-        IF @@ROWCOUNT = 0
+        IF @FileGroups IS NOT NULL
         BEGIN
-          BREAK
-        END
-
-        -- Does the filegroup exist?
-        SET @CurrentCommand = ''
-        SET @CurrentCommand = @CurrentCommand + 'IF EXISTS(SELECT * FROM ' + QUOTENAME(@CurrentDatabaseName) + '.sys.filegroups filegroups WHERE [type] <> ''FX'' AND filegroups.data_space_id = @ParamFileGroupID AND filegroups.[name] = @ParamFileGroupName) BEGIN SET @ParamFileGroupExists = 1 END'
-
-        EXECUTE sp_executesql @statement = @CurrentCommand, @params = N'@ParamFileGroupID int, @ParamFileGroupName sysname, @ParamFileGroupExists bit OUTPUT', @ParamFileGroupID = @CurrentFileGroupID, @ParamFileGroupName = @CurrentFileGroupName, @ParamFileGroupExists = @CurrentFileGroupExists OUTPUT
-        SET @Error = @@ERROR
-        IF @Error = 0 AND @CurrentFileGroupExists IS NULL SET @CurrentFileGroupExists = 0
-        IF @Error = 1222
-        BEGIN
-          SET @ErrorMessage = 'The file group ' + QUOTENAME(@CurrentFileGroupName) + ' in the database ' + QUOTENAME(@CurrentDatabaseName) + ' is locked. It could not be checked if the filegroup exists.' + CHAR(13) + CHAR(10) + ' '
-          SET @ErrorMessage = REPLACE(@ErrorMessage,'%','%%')
-          RAISERROR(@ErrorMessage,16,1) WITH NOWAIT
-        END
-        IF @Error <> 0
-        BEGIN
-          SET @ReturnCode = @Error
-        END
-      END
-
-      IF @CurrentBackupType = 'LOG' AND (@CleanupTime IS NOT NULL OR @MirrorCleanupTime IS NOT NULL)
-      BEGIN
-        SELECT @CurrentLatestBackup = MAX(backup_start_date)
-        FROM msdb.dbo.backupset
-        WHERE ([type] IN('D','I')
-        OR ([type] = 'L' AND last_lsn < @CurrentDifferentialBaseLSN))
-        AND is_damaged = 0
-        AND [database_name] = @CurrentDatabaseName
-      END
-
-      SET @CurrentDate = SYSDATETIME()
-      SET @CurrentDateUTC = SYSUTCDATETIME()
-
-      INSERT INTO @CurrentCleanupDates (CleanupDate)
-      SELECT @CurrentDate
-
-      IF @CurrentBackupType = 'LOG'
-      BEGIN
-        INSERT INTO @CurrentCleanupDates (CleanupDate)
-        SELECT @CurrentLatestBackup
-      END
-
-      SELECT @CurrentDirectoryStructure = CASE
-      WHEN @CurrentAvailabilityGroup IS NOT NULL THEN @AvailabilityGroupDirectoryStructure
-      ELSE @DirectoryStructure
-      END
-
-      IF @CurrentDirectoryStructure IS NOT NULL
-      BEGIN
-      -- Directory structure - remove tokens that are not needed
-        IF @CurrentFileGroupName IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}','')
-        IF @ReadWriteFileGroups = 'N' SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Partial}','')
-        IF @CopyOnly = 'N' SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{CopyOnly}','')
-        IF @Cluster IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}','')
-        IF @CurrentAvailabilityGroup IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}','')
-        IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}','')
-        IF @@SERVICENAME IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServiceName}','')
-        IF @Description IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Description}','')
-        IF @BackupSetName IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupSetName}','')
-
-        IF @Directory IS NULL AND @MirrorDirectory IS NULL AND @URL IS NULL AND @DefaultDirectory LIKE '%' + '.' + @@SERVICENAME + @DirectorySeparator + 'MSSQL' + @DirectorySeparator + 'Backup'
-        BEGIN
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServerName}','')
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}','')
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}','')
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}','')
-        END
-
-        WHILE (@Updated = 1 OR @Updated IS NULL)
-        BEGIN
-          SET @Updated = 0
-
-          IF CHARINDEX('\',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'\','{DirectorySeparator}')
-            SET @Updated = 1
-          END
-
-          IF CHARINDEX('/',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'/','{DirectorySeparator}')
-            SET @Updated = 1
-          END
-
-          IF CHARINDEX('__',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'__','_')
-            SET @Updated = 1
-          END
-
-          IF CHARINDEX('--',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'--','-')
-            SET @Updated = 1
-          END
-
-          IF CHARINDEX('{DirectorySeparator}{DirectorySeparator}',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}{DirectorySeparator}','{DirectorySeparator}')
-            SET @Updated = 1
-          END
-
-          IF CHARINDEX('{DirectorySeparator}$',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}$','{DirectorySeparator}')
-            SET @Updated = 1
-          END
-          IF CHARINDEX('${DirectorySeparator}',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'${DirectorySeparator}','{DirectorySeparator}')
-            SET @Updated = 1
-          END
-
-          IF CHARINDEX('{DirectorySeparator}_',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}_','{DirectorySeparator}')
-            SET @Updated = 1
-          END
-          IF CHARINDEX('_{DirectorySeparator}',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'_{DirectorySeparator}','{DirectorySeparator}')
-            SET @Updated = 1
-          END
-
-          IF CHARINDEX('{DirectorySeparator}-',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}-','{DirectorySeparator}')
-            SET @Updated = 1
-          END
-          IF CHARINDEX('-{DirectorySeparator}',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'-{DirectorySeparator}','{DirectorySeparator}')
-            SET @Updated = 1
-          END
-
-          IF CHARINDEX('_$',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'_$','_')
-            SET @Updated = 1
-          END
-          IF CHARINDEX('$_',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'$_','_')
-            SET @Updated = 1
-          END
-
-          IF CHARINDEX('-$',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'-$','-')
-            SET @Updated = 1
-          END
-          IF CHARINDEX('$-',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'$-','-')
-            SET @Updated = 1
-          END
-
-          IF LEFT(@CurrentDirectoryStructure,1) = '_'
-          BEGIN
-            SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-            SET @Updated = 1
-          END
-          IF RIGHT(@CurrentDirectoryStructure,1) = '_'
-          BEGIN
-            SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-            SET @Updated = 1
-          END
-
-          IF LEFT(@CurrentDirectoryStructure,1) = '-'
-          BEGIN
-            SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-            SET @Updated = 1
-          END
-          IF RIGHT(@CurrentDirectoryStructure,1) = '-'
-          BEGIN
-            SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-            SET @Updated = 1
-          END
-
-          IF LEFT(@CurrentDirectoryStructure,1) = '$'
-          BEGIN
-            SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-            SET @Updated = 1
-          END
-          IF RIGHT(@CurrentDirectoryStructure,1) = '$'
-          BEGIN
-            SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-            SET @Updated = 1
-          END
-
-          IF LEFT(@CurrentDirectoryStructure,20) = '{DirectorySeparator}'
-          BEGIN
-            SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 20)
-            SET @Updated = 1
-          END
-          IF RIGHT(@CurrentDirectoryStructure,20) = '{DirectorySeparator}'
-          BEGIN
-            SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 20)
-            SET @Updated = 1
-          END
-        END
-
-        SET @Updated = NULL
-
-        -- Directory structure - replace tokens with real values
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}',@DirectorySeparator)
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServerName}',CASE WHEN SERVERPROPERTY('EngineEdition') = 8 THEN LEFT(CAST(SERVERPROPERTY('ServerName') AS nvarchar(max)),CHARINDEX('.',CAST(SERVERPROPERTY('ServerName') AS nvarchar(max))) - 1) ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar(max)) END)
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}',ISNULL(CAST(SERVERPROPERTY('InstanceName') AS nvarchar(max)),''))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServiceName}',ISNULL(@@SERVICENAME,''))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}',ISNULL(@Cluster,''))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}',ISNULL(@CurrentAvailabilityGroup,''))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DatabaseName}',@CurrentDatabaseNameFS)
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}',ISNULL(@CurrentFileGroupName,''))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupType}',@CurrentBackupType)
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Partial}','PARTIAL')
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{CopyOnly}','COPY_ONLY')
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Description}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@Description,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupSetName}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@BackupSetName,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Year}',CAST(DATEPART(YEAR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Month}',RIGHT('0' + CAST(DATEPART(MONTH,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Day}',RIGHT('0' + CAST(DATEPART(DAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Week}',RIGHT('0' + CAST(DATEPART(WEEK,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Weekday}',DATENAME(WEEKDAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Hour}',RIGHT('0' + CAST(DATEPART(HOUR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Minute}',RIGHT('0' + CAST(DATEPART(MINUTE,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Second}',RIGHT('0' + CAST(DATEPART(SECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Millisecond}',RIGHT('00' + CAST(DATEPART(MILLISECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),3))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Microsecond}',RIGHT('00000' + CAST(DATEPART(MICROSECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),6))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{MajorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMajorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4)))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{MinorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMinorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3)))
-      END
-
-      IF @DirectoryStructureCase IS NOT NULL
-      BEGIN
-        SET @CurrentDirectoryStructure = CASE WHEN @DirectoryStructureCase = 'LOWER' THEN LOWER(@CurrentDirectoryStructure)
-                                              WHEN @DirectoryStructureCase = 'UPPER' THEN UPPER(@CurrentDirectoryStructure) END
-      END
-
-      INSERT INTO @CurrentDirectories (ID, DirectoryPath, Mirror, DirectoryNumber, CreateCompleted, CleanupCompleted)
-      SELECT ROW_NUMBER() OVER (ORDER BY ID),
-             DirectoryPath + CASE WHEN DirectoryPath = 'NUL' THEN '' WHEN @CurrentDirectoryStructure IS NOT NULL THEN @DirectorySeparator + @CurrentDirectoryStructure ELSE '' END,
-             Mirror,
-             ROW_NUMBER() OVER (PARTITION BY Mirror ORDER BY ID ASC),
-             0,
-             0
-      FROM @Directories
-      ORDER BY ID ASC
-
-      INSERT INTO @CurrentURLs (ID, DirectoryPath, Mirror, DirectoryNumber)
-      SELECT ROW_NUMBER() OVER (ORDER BY ID),
-             DirectoryPath + CASE WHEN @CurrentDirectoryStructure IS NOT NULL THEN @DirectorySeparator + @CurrentDirectoryStructure ELSE '' END,
-             Mirror,
-             ROW_NUMBER() OVER (PARTITION BY Mirror ORDER BY ID ASC)
-      FROM @URLs
-      ORDER BY ID ASC
-
-      SELECT @CurrentDatabaseFileName = CASE
-      WHEN @CurrentAvailabilityGroup IS NOT NULL THEN @AvailabilityGroupFileName
-      ELSE @FileName
-      END
-
-      -- File name - remove tokens that are not needed
-      IF @CurrentFileGroupName IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}','')
-      IF @ReadWriteFileGroups = 'N' SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Partial}','')
-      IF @CopyOnly = 'N' SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{CopyOnly}','')
-      IF @Cluster IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ClusterName}','')
-      IF @CurrentAvailabilityGroup IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{AvailabilityGroupName}','')
-      IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{InstanceName}','')
-      IF @@SERVICENAME IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServiceName}','')
-      IF @Description IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Description}','')
-      IF @BackupSetName IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupSetName}','')
-      IF @CurrentNumberOfFiles = 1 SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileNumber}','')
-      IF @CurrentNumberOfFiles = 1 SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{NumberOfFiles}','')
-
-      WHILE (@Updated = 1 OR @Updated IS NULL)
-      BEGIN
-        SET @Updated = 0
-
-        IF CHARINDEX('__',@CurrentDatabaseFileName) > 0
-        BEGIN
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'__','_')
-          SET @Updated = 1
-        END
-
-        IF CHARINDEX('--',@CurrentDatabaseFileName) > 0
-        BEGIN
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'--','-')
-          SET @Updated = 1
-        END
-
-        IF CHARINDEX('_$',@CurrentDatabaseFileName) > 0
-        BEGIN
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'_$','_')
-          SET @Updated = 1
-        END
-        IF CHARINDEX('$_',@CurrentDatabaseFileName) > 0
-        BEGIN
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'$_','_')
-          SET @Updated = 1
-        END
-
-        IF CHARINDEX('-$',@CurrentDatabaseFileName) > 0
-        BEGIN
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'-$','-')
-          SET @Updated = 1
-        END
-        IF CHARINDEX('$-',@CurrentDatabaseFileName) > 0
-        BEGIN
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'$-','-')
-          SET @Updated = 1
-        END
-
-        IF CHARINDEX('_.',@CurrentDatabaseFileName) > 0
-        BEGIN
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'_.','.')
-          SET @Updated = 1
-        END
-
-        IF CHARINDEX('-.',@CurrentDatabaseFileName) > 0
-        BEGIN
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'-.','.')
-          SET @Updated = 1
-        END
-
-        IF CHARINDEX('of.',@CurrentDatabaseFileName) > 0
-        BEGIN
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'of.','.')
-          SET @Updated = 1
-        END
-
-        IF LEFT(@CurrentDatabaseFileName,1) = '_'
-        BEGIN
-          SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
-          SET @Updated = 1
-        END
-        IF RIGHT(@CurrentDatabaseFileName,1) = '_'
-        BEGIN
-          SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
-          SET @Updated = 1
-        END
-
-        IF LEFT(@CurrentDatabaseFileName,1) = '-'
-        BEGIN
-          SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
-          SET @Updated = 1
-        END
-        IF RIGHT(@CurrentDatabaseFileName,1) = '-'
-        BEGIN
-          SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
-          SET @Updated = 1
-        END
-
-        IF LEFT(@CurrentDatabaseFileName,1) = '$'
-        BEGIN
-          SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
-          SET @Updated = 1
-        END
-        IF RIGHT(@CurrentDatabaseFileName,1) = '$'
-        BEGIN
-          SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
-          SET @Updated = 1
-        END
-      END
-
-      SET @Updated = NULL
-
-      SELECT @CurrentFileExtension = CASE
-      WHEN @CurrentBackupType = 'FULL' THEN @FileExtensionFull
-      WHEN @CurrentBackupType = 'DIFF' THEN @FileExtensionDiff
-      WHEN @CurrentBackupType = 'LOG' THEN @FileExtensionLog
-      END
-
-      -- File name - replace tokens with real values
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServerName}',CASE WHEN SERVERPROPERTY('EngineEdition') = 8 THEN LEFT(CAST(SERVERPROPERTY('ServerName') AS nvarchar(max)),CHARINDEX('.',CAST(SERVERPROPERTY('ServerName') AS nvarchar(max))) - 1) ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar(max)) END)
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{InstanceName}',ISNULL(CAST(SERVERPROPERTY('InstanceName') AS nvarchar(max)),''))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServiceName}',ISNULL(@@SERVICENAME,''))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ClusterName}',ISNULL(@Cluster,''))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{AvailabilityGroupName}',ISNULL(@CurrentAvailabilityGroup,''))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}',ISNULL(@CurrentFileGroupName,''))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupType}',@CurrentBackupType)
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Partial}','PARTIAL')
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{CopyOnly}','COPY_ONLY')
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Description}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@Description,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupSetName}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@BackupSetName,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Year}',CAST(DATEPART(YEAR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Month}',RIGHT('0' + CAST(DATEPART(MONTH,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Day}',RIGHT('0' + CAST(DATEPART(DAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Week}',RIGHT('0' + CAST(DATEPART(WEEK,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Weekday}',DATENAME(WEEKDAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Hour}',RIGHT('0' + CAST(DATEPART(HOUR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Minute}',RIGHT('0' + CAST(DATEPART(MINUTE,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Second}',RIGHT('0' + CAST(DATEPART(SECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Millisecond}',RIGHT('00' + CAST(DATEPART(MILLISECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),3))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Microsecond}',RIGHT('00000' + CAST(DATEPART(MICROSECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),6))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{NumberOfFiles}',@CurrentNumberOfFiles)
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileExtension}',@CurrentFileExtension)
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{MajorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMajorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4)))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{MinorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMinorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3)))
-
-      SELECT @CurrentMaxFilePathLength = CASE
-      WHEN EXISTS (SELECT * FROM @CurrentDirectories) THEN (SELECT MAX(LEN(DirectoryPath + @DirectorySeparator)) FROM @CurrentDirectories)
-      WHEN EXISTS (SELECT * FROM @CurrentURLs) THEN (SELECT MAX(LEN(DirectoryPath + @DirectorySeparator)) FROM @CurrentURLs)
-      END
-      + LEN(REPLACE(REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',@CurrentDatabaseNameFS), '{FileNumber}', CASE WHEN @CurrentNumberOfFiles >= 1 AND @CurrentNumberOfFiles <= 9 THEN '1' WHEN @CurrentNumberOfFiles >= 10 THEN '01' END))
-
-      -- The maximum length of a backup device is 259 characters
-      IF @CurrentMaxFilePathLength > 259
-      BEGIN
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',LEFT(@CurrentDatabaseNameFS,CASE WHEN (LEN(@CurrentDatabaseNameFS) + 259 - @CurrentMaxFilePathLength - 3) < 20 THEN 20 ELSE (LEN(@CurrentDatabaseNameFS) + 259 - @CurrentMaxFilePathLength - 3) END) + '...')
-      END
-      ELSE
-      BEGIN
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',@CurrentDatabaseNameFS)
-      END
-
-      IF @FileNameCase IS NOT NULL
-      BEGIN
-        SET @CurrentDatabaseFileName = CASE WHEN @FileNameCase = 'LOWER' THEN LOWER(@CurrentDatabaseFileName)
-                                            WHEN @FileNameCase = 'UPPER' THEN UPPER(@CurrentDatabaseFileName) END
-      END
-
-      IF EXISTS (SELECT * FROM @CurrentDirectories WHERE Mirror = 0)
-      BEGIN
-        SET @CurrentFileNumber = 0
-
-        WHILE @CurrentFileNumber < @CurrentNumberOfFiles
-        BEGIN
-          SET @CurrentFileNumber = @CurrentFileNumber + 1
-
-          SELECT @CurrentDirectoryPath = DirectoryPath
-          FROM @CurrentDirectories
-          WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 0) + 1
-          AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 0)
-          AND Mirror = 0
-
-          SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles >= 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) END)
-
-          IF @CurrentDirectoryPath = 'NUL'
-          BEGIN
-            SET @CurrentFilePath = 'NUL'
-          END
-          ELSE
-          BEGIN
-            SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
-          END
-
-          INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
-          SELECT 'DISK', @CurrentFilePath, 0
-
-          SET @CurrentDirectoryPath = NULL
-          SET @CurrentFileName = NULL
-          SET @CurrentFilePath = NULL
-        END
-
-        INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
-        SELECT 0, 0
-      END
-
-      IF EXISTS (SELECT * FROM @CurrentDirectories WHERE Mirror = 1)
-      BEGIN
-        SET @CurrentFileNumber = 0
-
-        WHILE @CurrentFileNumber < @CurrentNumberOfFiles
-        BEGIN
-          SET @CurrentFileNumber = @CurrentFileNumber + 1
-
-          SELECT @CurrentDirectoryPath = DirectoryPath
-          FROM @CurrentDirectories
-          WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 1) + 1
-          AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 1)
-          AND Mirror = 1
-
-          SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
-
-          SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
-
-          INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
-          SELECT 'DISK', @CurrentFilePath, 1
-
-          SET @CurrentDirectoryPath = NULL
-          SET @CurrentFileName = NULL
-          SET @CurrentFilePath = NULL
-        END
-
-        INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
-        SELECT 1, 0
-      END
-
-      IF EXISTS (SELECT * FROM @CurrentURLs WHERE Mirror = 0)
-      BEGIN
-        SET @CurrentFileNumber = 0
-
-        WHILE @CurrentFileNumber < @CurrentNumberOfFiles
-        BEGIN
-          SET @CurrentFileNumber = @CurrentFileNumber + 1
-
-          SELECT @CurrentDirectoryPath = DirectoryPath
-          FROM @CurrentURLs
-          WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0) + 1
-          AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0)
-          AND Mirror = 0
-
-          SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
-
-          SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
-
-          INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
-          SELECT 'URL', @CurrentFilePath, 0
-
-          SET @CurrentDirectoryPath = NULL
-          SET @CurrentFileName = NULL
-          SET @CurrentFilePath = NULL
-        END
-
-        INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
-        SELECT 0, 0
-      END
-
-      IF EXISTS (SELECT * FROM @CurrentURLs WHERE Mirror = 1)
-      BEGIN
-        SET @CurrentFileNumber = 0
-
-        WHILE @CurrentFileNumber < @CurrentNumberOfFiles
-        BEGIN
-          SET @CurrentFileNumber = @CurrentFileNumber + 1
-
-          SELECT @CurrentDirectoryPath = DirectoryPath
-          FROM @CurrentURLs
-          WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0) + 1
-          AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0)
-          AND Mirror = 1
-
-          SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
-
-          SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
-
-          INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
-          SELECT 'URL', @CurrentFilePath, 1
-
-          SET @CurrentDirectoryPath = NULL
-          SET @CurrentFileName = NULL
-          SET @CurrentFilePath = NULL
-        END
-
-        INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
-        SELECT 1, 0
-      END
-
-      -- Create directory
-      IF @HostPlatform = 'Windows'
-      AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
-      AND NOT EXISTS(SELECT * FROM @CurrentDirectories WHERE DirectoryPath = 'NUL' OR DirectoryPath IN(SELECT DirectoryPath FROM @Directories))
-      BEGIN
-        WHILE (1 = 1)
-        BEGIN
-          SELECT TOP 1 @CurrentDirectoryID = ID,
-                       @CurrentDirectoryPath = DirectoryPath
-          FROM @CurrentDirectories
-          WHERE CreateCompleted = 0
-          ORDER BY ID ASC
+          SELECT TOP 1 @CurrentFGID = ID,
+                       @CurrentFileGroupID = FileGroupID,
+                       @CurrentFileGroupName = FileGroupName
+          FROM @tmpFileGroups
+          WHERE Selected = 1
+          AND Completed = 0
+          ORDER BY [Order] ASC
 
           IF @@ROWCOUNT = 0
           BEGIN
             BREAK
           END
 
-          IF @DirectoryCheck = 'Y'
+          -- Does the filegroup exist?
+          SET @CurrentCommand = ''
+          SET @CurrentCommand = @CurrentCommand + 'IF EXISTS(SELECT * FROM ' + QUOTENAME(@CurrentDatabaseName) + '.sys.filegroups filegroups WHERE [type] <> ''FX'' AND filegroups.data_space_id = @ParamFileGroupID AND filegroups.[name] = @ParamFileGroupName) BEGIN SET @ParamFileGroupExists = 1 END'
+
+          EXECUTE sp_executesql @statement = @CurrentCommand, @params = N'@ParamFileGroupID int, @ParamFileGroupName sysname, @ParamFileGroupExists bit OUTPUT', @ParamFileGroupID = @CurrentFileGroupID, @ParamFileGroupName = @CurrentFileGroupName, @ParamFileGroupExists = @CurrentFileGroupExists OUTPUT
+          SET @Error = @@ERROR
+          IF @Error = 0 AND @CurrentFileGroupExists IS NULL SET @CurrentFileGroupExists = 0
+          IF @Error = 1222
           BEGIN
-            INSERT INTO @DirectoryInfo (FileExists, FileIsADirectory, ParentDirectoryExists)
-            EXECUTE [master].dbo.xp_fileexist @CurrentDirectoryPath
+            SET @ErrorMessage = 'The file group ' + QUOTENAME(@CurrentFileGroupName) + ' in the database ' + QUOTENAME(@CurrentDatabaseName) + ' is locked. It could not be checked if the filegroup exists.' + CHAR(13) + CHAR(10) + ' '
+            SET @ErrorMessage = REPLACE(@ErrorMessage,'%','%%')
+            RAISERROR(@ErrorMessage,16,1) WITH NOWAIT
+          END
+          IF @Error <> 0
+          BEGIN
+            SET @ReturnCode = @Error
+          END
+        END
+
+        IF @CurrentBackupType = 'LOG' AND (@CleanupTime IS NOT NULL OR @MirrorCleanupTime IS NOT NULL)
+        BEGIN
+          SELECT @CurrentLatestBackup = MAX(backup_start_date)
+          FROM msdb.dbo.backupset
+          WHERE ([type] IN('D','I')
+          OR ([type] = 'L' AND last_lsn < @CurrentDifferentialBaseLSN))
+          AND is_damaged = 0
+          AND [database_name] = @CurrentDatabaseName
+        END
+
+        SET @CurrentDate = SYSDATETIME()
+        SET @CurrentDateUTC = SYSUTCDATETIME()
+
+        INSERT INTO @CurrentCleanupDates (CleanupDate)
+        SELECT @CurrentDate
+
+        IF @CurrentBackupType = 'LOG'
+        BEGIN
+          INSERT INTO @CurrentCleanupDates (CleanupDate)
+          SELECT @CurrentLatestBackup
+        END
+
+        SELECT @CurrentDirectoryStructure = CASE
+        WHEN @CurrentAvailabilityGroup IS NOT NULL THEN @AvailabilityGroupDirectoryStructure
+        ELSE @DirectoryStructure
+        END
+
+        IF @CurrentDirectoryStructure IS NOT NULL
+        BEGIN
+        -- Directory structure - remove tokens that are not needed
+          IF @CurrentFileGroupName IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}','')
+          IF @ReadWriteFileGroups = 'N' SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Partial}','')
+          IF @CopyOnly = 'N' SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{CopyOnly}','')
+          IF @Cluster IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}','')
+          IF @CurrentAvailabilityGroup IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}','')
+          IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}','')
+          IF @@SERVICENAME IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServiceName}','')
+          IF @Description IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Description}','')
+          IF @BackupSetName IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupSetName}','')
+
+          IF @Directory IS NULL AND @MirrorDirectory IS NULL AND @URL IS NULL AND @DefaultDirectory LIKE '%' + '.' + @@SERVICENAME + @DirectorySeparator + 'MSSQL' + @DirectorySeparator + 'Backup'
+          BEGIN
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServerName}','')
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}','')
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}','')
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}','')
           END
 
-          IF NOT EXISTS (SELECT * FROM @DirectoryInfo WHERE FileExists = 0 AND FileIsADirectory = 1 AND ParentDirectoryExists = 1)
+          WHILE (@Updated = 1 OR @Updated IS NULL)
           BEGIN
-            SET @CurrentDatabaseContext = 'master'
+            SET @Updated = 0
 
-            SET @CurrentCommandType = 'xp_create_subdir'
+            IF CHARINDEX('\',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'\','{DirectorySeparator}')
+              SET @Updated = 1
+            END
 
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_create_subdir N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''' IF @ReturnCode <> 0 RAISERROR(''Error creating directory.'', 16, 1)'
+            IF CHARINDEX('/',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'/','{DirectorySeparator}')
+              SET @Updated = 1
+            END
+
+            IF CHARINDEX('__',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'__','_')
+              SET @Updated = 1
+            END
+
+            IF CHARINDEX('--',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'--','-')
+              SET @Updated = 1
+            END
+
+            IF CHARINDEX('{DirectorySeparator}{DirectorySeparator}',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}{DirectorySeparator}','{DirectorySeparator}')
+              SET @Updated = 1
+            END
+
+            IF CHARINDEX('{DirectorySeparator}$',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}$','{DirectorySeparator}')
+              SET @Updated = 1
+            END
+            IF CHARINDEX('${DirectorySeparator}',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'${DirectorySeparator}','{DirectorySeparator}')
+              SET @Updated = 1
+            END
+
+            IF CHARINDEX('{DirectorySeparator}_',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}_','{DirectorySeparator}')
+              SET @Updated = 1
+            END
+            IF CHARINDEX('_{DirectorySeparator}',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'_{DirectorySeparator}','{DirectorySeparator}')
+              SET @Updated = 1
+            END
+
+            IF CHARINDEX('{DirectorySeparator}-',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}-','{DirectorySeparator}')
+              SET @Updated = 1
+            END
+            IF CHARINDEX('-{DirectorySeparator}',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'-{DirectorySeparator}','{DirectorySeparator}')
+              SET @Updated = 1
+            END
+
+            IF CHARINDEX('_$',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'_$','_')
+              SET @Updated = 1
+            END
+            IF CHARINDEX('$_',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'$_','_')
+              SET @Updated = 1
+            END
+
+            IF CHARINDEX('-$',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'-$','-')
+              SET @Updated = 1
+            END
+            IF CHARINDEX('$-',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'$-','-')
+              SET @Updated = 1
+            END
+
+            IF LEFT(@CurrentDirectoryStructure,1) = '_'
+            BEGIN
+              SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+            IF RIGHT(@CurrentDirectoryStructure,1) = '_'
+            BEGIN
+              SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+
+            IF LEFT(@CurrentDirectoryStructure,1) = '-'
+            BEGIN
+              SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+            IF RIGHT(@CurrentDirectoryStructure,1) = '-'
+            BEGIN
+              SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+
+            IF LEFT(@CurrentDirectoryStructure,1) = '$'
+            BEGIN
+              SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+            IF RIGHT(@CurrentDirectoryStructure,1) = '$'
+            BEGIN
+              SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+
+            IF LEFT(@CurrentDirectoryStructure,20) = '{DirectorySeparator}'
+            BEGIN
+              SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 20)
+              SET @Updated = 1
+            END
+            IF RIGHT(@CurrentDirectoryStructure,20) = '{DirectorySeparator}'
+            BEGIN
+              SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 20)
+              SET @Updated = 1
+            END
+          END
+
+          SET @Updated = NULL
+
+          -- Directory structure - replace tokens with real values
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}',@DirectorySeparator)
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServerName}',CASE WHEN SERVERPROPERTY('EngineEdition') = 8 THEN LEFT(CAST(SERVERPROPERTY('ServerName') AS nvarchar(max)),CHARINDEX('.',CAST(SERVERPROPERTY('ServerName') AS nvarchar(max))) - 1) ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar(max)) END)
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}',ISNULL(CAST(SERVERPROPERTY('InstanceName') AS nvarchar(max)),''))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServiceName}',ISNULL(@@SERVICENAME,''))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}',ISNULL(@Cluster,''))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}',ISNULL(@CurrentAvailabilityGroup,''))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DatabaseName}',@CurrentDatabaseNameFS)
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}',ISNULL(@CurrentFileGroupName,''))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupType}',@CurrentBackupType)
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Partial}','PARTIAL')
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{CopyOnly}','COPY_ONLY')
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Description}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@Description,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupSetName}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@BackupSetName,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Year}',CAST(DATEPART(YEAR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Month}',RIGHT('0' + CAST(DATEPART(MONTH,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Day}',RIGHT('0' + CAST(DATEPART(DAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Week}',RIGHT('0' + CAST(DATEPART(WEEK,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Weekday}',DATENAME(WEEKDAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Hour}',RIGHT('0' + CAST(DATEPART(HOUR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Minute}',RIGHT('0' + CAST(DATEPART(MINUTE,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Second}',RIGHT('0' + CAST(DATEPART(SECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Millisecond}',RIGHT('00' + CAST(DATEPART(MILLISECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),3))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Microsecond}',RIGHT('00000' + CAST(DATEPART(MICROSECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),6))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{MajorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMajorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4)))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{MinorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMinorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3)))
+        END
+
+        IF @DirectoryStructureCase IS NOT NULL
+        BEGIN
+          SET @CurrentDirectoryStructure = CASE WHEN @DirectoryStructureCase = 'LOWER' THEN LOWER(@CurrentDirectoryStructure)
+                                                WHEN @DirectoryStructureCase = 'UPPER' THEN UPPER(@CurrentDirectoryStructure) END
+        END
+
+        INSERT INTO @CurrentDirectories (ID, DirectoryPath, Mirror, DirectoryNumber, CreateCompleted, CleanupCompleted)
+        SELECT ROW_NUMBER() OVER (ORDER BY ID),
+               DirectoryPath + CASE WHEN DirectoryPath = 'NUL' THEN '' WHEN @CurrentDirectoryStructure IS NOT NULL THEN @DirectorySeparator + @CurrentDirectoryStructure ELSE '' END,
+               Mirror,
+               ROW_NUMBER() OVER (PARTITION BY Mirror ORDER BY ID ASC),
+               0,
+               0
+        FROM @Directories
+        ORDER BY ID ASC
+
+        INSERT INTO @CurrentURLs (ID, DirectoryPath, Mirror, DirectoryNumber)
+        SELECT ROW_NUMBER() OVER (ORDER BY ID),
+               DirectoryPath + CASE WHEN @CurrentDirectoryStructure IS NOT NULL THEN @DirectorySeparator + @CurrentDirectoryStructure ELSE '' END,
+               Mirror,
+               ROW_NUMBER() OVER (PARTITION BY Mirror ORDER BY ID ASC)
+        FROM @URLs
+        ORDER BY ID ASC
+
+        SELECT @CurrentDatabaseFileName = CASE
+        WHEN @CurrentAvailabilityGroup IS NOT NULL THEN @AvailabilityGroupFileName
+        ELSE @FileName
+        END
+
+        -- File name - remove tokens that are not needed
+        IF @CurrentFileGroupName IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}','')
+        IF @ReadWriteFileGroups = 'N' SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Partial}','')
+        IF @CopyOnly = 'N' SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{CopyOnly}','')
+        IF @Cluster IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ClusterName}','')
+        IF @CurrentAvailabilityGroup IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{AvailabilityGroupName}','')
+        IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{InstanceName}','')
+        IF @@SERVICENAME IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServiceName}','')
+        IF @Description IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Description}','')
+        IF @BackupSetName IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupSetName}','')
+        IF @CurrentNumberOfFiles = 1 SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileNumber}','')
+        IF @CurrentNumberOfFiles = 1 SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{NumberOfFiles}','')
+
+        WHILE (@Updated = 1 OR @Updated IS NULL)
+        BEGIN
+          SET @Updated = 0
+
+          IF CHARINDEX('__',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'__','_')
+            SET @Updated = 1
+          END
+
+          IF CHARINDEX('--',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'--','-')
+            SET @Updated = 1
+          END
+
+          IF CHARINDEX('_$',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'_$','_')
+            SET @Updated = 1
+          END
+          IF CHARINDEX('$_',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'$_','_')
+            SET @Updated = 1
+          END
+
+          IF CHARINDEX('-$',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'-$','-')
+            SET @Updated = 1
+          END
+          IF CHARINDEX('$-',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'$-','-')
+            SET @Updated = 1
+          END
+
+          IF CHARINDEX('_.',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'_.','.')
+            SET @Updated = 1
+          END
+
+          IF CHARINDEX('-.',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'-.','.')
+            SET @Updated = 1
+          END
+
+          IF CHARINDEX('of.',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'of.','.')
+            SET @Updated = 1
+          END
+
+          IF LEFT(@CurrentDatabaseFileName,1) = '_'
+          BEGIN
+            SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+          IF RIGHT(@CurrentDatabaseFileName,1) = '_'
+          BEGIN
+            SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+
+          IF LEFT(@CurrentDatabaseFileName,1) = '-'
+          BEGIN
+            SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+          IF RIGHT(@CurrentDatabaseFileName,1) = '-'
+          BEGIN
+            SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+
+          IF LEFT(@CurrentDatabaseFileName,1) = '$'
+          BEGIN
+            SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+          IF RIGHT(@CurrentDatabaseFileName,1) = '$'
+          BEGIN
+            SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+        END
+
+        SET @Updated = NULL
+
+        SELECT @CurrentFileExtension = CASE
+        WHEN @CurrentBackupType = 'FULL' THEN @FileExtensionFull
+        WHEN @CurrentBackupType = 'DIFF' THEN @FileExtensionDiff
+        WHEN @CurrentBackupType = 'LOG' THEN @FileExtensionLog
+        END
+
+        -- File name - replace tokens with real values
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServerName}',CASE WHEN SERVERPROPERTY('EngineEdition') = 8 THEN LEFT(CAST(SERVERPROPERTY('ServerName') AS nvarchar(max)),CHARINDEX('.',CAST(SERVERPROPERTY('ServerName') AS nvarchar(max))) - 1) ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar(max)) END)
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{InstanceName}',ISNULL(CAST(SERVERPROPERTY('InstanceName') AS nvarchar(max)),''))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServiceName}',ISNULL(@@SERVICENAME,''))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ClusterName}',ISNULL(@Cluster,''))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{AvailabilityGroupName}',ISNULL(@CurrentAvailabilityGroup,''))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}',ISNULL(@CurrentFileGroupName,''))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupType}',@CurrentBackupType)
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Partial}','PARTIAL')
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{CopyOnly}','COPY_ONLY')
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Description}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@Description,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupSetName}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@BackupSetName,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Year}',CAST(DATEPART(YEAR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Month}',RIGHT('0' + CAST(DATEPART(MONTH,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Day}',RIGHT('0' + CAST(DATEPART(DAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Week}',RIGHT('0' + CAST(DATEPART(WEEK,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Weekday}',DATENAME(WEEKDAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Hour}',RIGHT('0' + CAST(DATEPART(HOUR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Minute}',RIGHT('0' + CAST(DATEPART(MINUTE,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Second}',RIGHT('0' + CAST(DATEPART(SECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Millisecond}',RIGHT('00' + CAST(DATEPART(MILLISECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),3))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Microsecond}',RIGHT('00000' + CAST(DATEPART(MICROSECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),6))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{NumberOfFiles}',@CurrentNumberOfFiles)
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileExtension}',@CurrentFileExtension)
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{MajorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMajorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4)))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{MinorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMinorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3)))
+
+        SELECT @CurrentMaxFilePathLength = CASE
+        WHEN EXISTS (SELECT * FROM @CurrentDirectories) THEN (SELECT MAX(LEN(DirectoryPath + @DirectorySeparator)) FROM @CurrentDirectories)
+        WHEN EXISTS (SELECT * FROM @CurrentURLs) THEN (SELECT MAX(LEN(DirectoryPath + @DirectorySeparator)) FROM @CurrentURLs)
+        END
+        + LEN(REPLACE(REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',@CurrentDatabaseNameFS), '{FileNumber}', CASE WHEN @CurrentNumberOfFiles >= 1 AND @CurrentNumberOfFiles <= 9 THEN '1' WHEN @CurrentNumberOfFiles >= 10 THEN '01' END))
+
+        -- The maximum length of a backup device is 259 characters
+        IF @CurrentMaxFilePathLength > 259
+        BEGIN
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',LEFT(@CurrentDatabaseNameFS,CASE WHEN (LEN(@CurrentDatabaseNameFS) + 259 - @CurrentMaxFilePathLength - 3) < 20 THEN 20 ELSE (LEN(@CurrentDatabaseNameFS) + 259 - @CurrentMaxFilePathLength - 3) END) + '...')
+        END
+        ELSE
+        BEGIN
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',@CurrentDatabaseNameFS)
+        END
+
+        IF @FileNameCase IS NOT NULL
+        BEGIN
+          SET @CurrentDatabaseFileName = CASE WHEN @FileNameCase = 'LOWER' THEN LOWER(@CurrentDatabaseFileName)
+                                              WHEN @FileNameCase = 'UPPER' THEN UPPER(@CurrentDatabaseFileName) END
+        END
+
+        IF EXISTS (SELECT * FROM @CurrentDirectories WHERE Mirror = 0)
+        BEGIN
+          SET @CurrentFileNumber = 0
+
+          WHILE @CurrentFileNumber < @CurrentNumberOfFiles
+          BEGIN
+            SET @CurrentFileNumber = @CurrentFileNumber + 1
+
+            SELECT @CurrentDirectoryPath = DirectoryPath
+            FROM @CurrentDirectories
+            WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 0) + 1
+            AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 0)
+            AND Mirror = 0
+
+            SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles >= 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) END)
+
+            IF @CurrentDirectoryPath = 'NUL'
+            BEGIN
+              SET @CurrentFilePath = 'NUL'
+            END
+            ELSE
+            BEGIN
+              SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
+            END
+
+            INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
+            SELECT 'DISK', @CurrentFilePath, 0
+
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentFileName = NULL
+            SET @CurrentFilePath = NULL
+          END
+
+          INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
+          SELECT 0, 0
+        END
+
+        IF EXISTS (SELECT * FROM @CurrentDirectories WHERE Mirror = 1)
+        BEGIN
+          SET @CurrentFileNumber = 0
+
+          WHILE @CurrentFileNumber < @CurrentNumberOfFiles
+          BEGIN
+            SET @CurrentFileNumber = @CurrentFileNumber + 1
+
+            SELECT @CurrentDirectoryPath = DirectoryPath
+            FROM @CurrentDirectories
+            WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 1) + 1
+            AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 1)
+            AND Mirror = 1
+
+            SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
+
+            SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
+
+            INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
+            SELECT 'DISK', @CurrentFilePath, 1
+
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentFileName = NULL
+            SET @CurrentFilePath = NULL
+          END
+
+          INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
+          SELECT 1, 0
+        END
+
+        IF EXISTS (SELECT * FROM @CurrentURLs WHERE Mirror = 0)
+        BEGIN
+          SET @CurrentFileNumber = 0
+
+          WHILE @CurrentFileNumber < @CurrentNumberOfFiles
+          BEGIN
+            SET @CurrentFileNumber = @CurrentFileNumber + 1
+
+            SELECT @CurrentDirectoryPath = DirectoryPath
+            FROM @CurrentURLs
+            WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0) + 1
+            AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0)
+            AND Mirror = 0
+
+            SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
+
+            SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
+
+            INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
+            SELECT 'URL', @CurrentFilePath, 0
+
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentFileName = NULL
+            SET @CurrentFilePath = NULL
+          END
+
+          INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
+          SELECT 0, 0
+        END
+
+        IF EXISTS (SELECT * FROM @CurrentURLs WHERE Mirror = 1)
+        BEGIN
+          SET @CurrentFileNumber = 0
+
+          WHILE @CurrentFileNumber < @CurrentNumberOfFiles
+          BEGIN
+            SET @CurrentFileNumber = @CurrentFileNumber + 1
+
+            SELECT @CurrentDirectoryPath = DirectoryPath
+            FROM @CurrentURLs
+            WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0) + 1
+            AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0)
+            AND Mirror = 1
+
+            SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
+
+            SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
+
+            INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
+            SELECT 'URL', @CurrentFilePath, 1
+
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentFileName = NULL
+            SET @CurrentFilePath = NULL
+          END
+
+          INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
+          SELECT 1, 0
+        END
+
+        -- Create directory
+        IF @HostPlatform = 'Windows'
+        AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
+        AND NOT EXISTS(SELECT * FROM @CurrentDirectories WHERE DirectoryPath = 'NUL' OR DirectoryPath IN(SELECT DirectoryPath FROM @Directories))
+        BEGIN
+          WHILE (1 = 1)
+          BEGIN
+            SELECT TOP 1 @CurrentDirectoryID = ID,
+                         @CurrentDirectoryPath = DirectoryPath
+            FROM @CurrentDirectories
+            WHERE CreateCompleted = 0
+            ORDER BY ID ASC
+
+            IF @@ROWCOUNT = 0
+            BEGIN
+              BREAK
+            END
+
+            IF @DirectoryCheck = 'Y'
+            BEGIN
+              INSERT INTO @DirectoryInfo (FileExists, FileIsADirectory, ParentDirectoryExists)
+              EXECUTE [master].dbo.xp_fileexist @CurrentDirectoryPath
+            END
+
+            IF NOT EXISTS (SELECT * FROM @DirectoryInfo WHERE FileExists = 0 AND FileIsADirectory = 1 AND ParentDirectoryExists = 1)
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_create_subdir'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_create_subdir N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''' IF @ReturnCode <> 0 RAISERROR(''Error creating directory.'', 16, 1)'
+
+              EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
+              SET @Error = @@ERROR
+              IF @Error <> 0 SET @CurrentCommandOutput = @Error
+              IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
+
+              UPDATE @CurrentDirectories
+              SET CreateCompleted = 1,
+                  CreateOutput = @CurrentCommandOutput
+              WHERE ID = @CurrentDirectoryID
+            END
+            ELSE
+            BEGIN
+              UPDATE @CurrentDirectories
+              SET CreateCompleted = 1,
+                  CreateOutput = 0
+              WHERE ID = @CurrentDirectoryID
+            END
+
+            SET @CurrentDirectoryID = NULL
+            SET @CurrentDirectoryPath = NULL
+
+            SET @CurrentDatabaseContext = NULL
+            SET @CurrentCommand = NULL
+            SET @CurrentCommandOutput = NULL
+            SET @CurrentCommandType = NULL
+
+            DELETE FROM @DirectoryInfo
+          END
+        END
+
+        IF @CleanupMode = 'BEFORE_BACKUP'
+        BEGIN
+          INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
+          SELECT DATEADD(hh,-(@CleanupTime),SYSDATETIME()), 0
+
+          IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 0 OR Mirror IS NULL) AND CleanupDate IS NULL)
+          BEGIN
+            UPDATE @CurrentDirectories
+            SET CleanupDate = (SELECT MIN(CleanupDate)
+                               FROM @CurrentCleanupDates
+                               WHERE (Mirror = 0 OR Mirror IS NULL)),
+                CleanupMode = 'BEFORE_BACKUP'
+            WHERE Mirror = 0
+          END
+        END
+
+        IF @MirrorCleanupMode = 'BEFORE_BACKUP'
+        BEGIN
+          INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
+          SELECT DATEADD(hh,-(@MirrorCleanupTime),SYSDATETIME()), 1
+
+          IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 1 OR Mirror IS NULL) AND CleanupDate IS NULL)
+          BEGIN
+            UPDATE @CurrentDirectories
+            SET CleanupDate = (SELECT MIN(CleanupDate)
+                               FROM @CurrentCleanupDates
+                               WHERE (Mirror = 1 OR Mirror IS NULL)),
+                CleanupMode = 'BEFORE_BACKUP'
+            WHERE Mirror = 1
+          END
+        END
+
+        -- Delete old backup files, before backup
+        IF (NOT EXISTS (SELECT * FROM @CurrentDirectories WHERE CreateOutput <> 0 OR CreateOutput IS NULL) OR @HostPlatform = 'Linux')
+        AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
+        AND @CurrentBackupType = @BackupType
+        BEGIN
+          WHILE (1 = 1)
+          BEGIN
+            SELECT TOP 1 @CurrentDirectoryID = ID,
+                         @CurrentDirectoryPath = DirectoryPath,
+                         @CurrentCleanupDate = CleanupDate
+            FROM @CurrentDirectories
+            WHERE CleanupDate IS NOT NULL
+            AND CleanupMode = 'BEFORE_BACKUP'
+            AND CleanupCompleted = 0
+            ORDER BY ID ASC
+
+            IF @@ROWCOUNT = 0
+            BEGIN
+              BREAK
+            END
+
+            IF @BackupSoftware IS NULL
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_delete_file'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_delete_file 0, N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + @CurrentFileExtension + ''', ''' + CONVERT(nvarchar(19),@CurrentCleanupDate,126) + ''' IF @ReturnCode <> 0 RAISERROR(''Error deleting files.'', 16, 1)'
+            END
+
+            IF @BackupSoftware = 'LITESPEED'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_slssqlmaint'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_slssqlmaint N''-MAINTDEL -DELFOLDER "' + REPLACE(@CurrentDirectoryPath,'''','''''') + '" -DELEXTENSION "' + @CurrentFileExtension + '" -DELUNIT "' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + '" -DELUNITTYPE "minutes" -DELUSEAGE'' IF @ReturnCode <> 0 RAISERROR(''Error deleting LiteSpeed backup files.'', 16, 1)'
+            END
+
+            IF @BackupSoftware = 'SQLBACKUP'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'sqbutility'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqbutility 1032, N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''', N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + CASE WHEN @CurrentBackupType = 'FULL' THEN 'D' WHEN @CurrentBackupType = 'DIFF' THEN 'I' WHEN @CurrentBackupType = 'LOG' THEN 'L' END + ''', ''' + CAST(DATEDIFF(hh,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'h'', ' + ISNULL('''' + REPLACE(@EncryptionKey,'''','''''') + '''','NULL') + ' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLBackup backup files.'', 16, 1)'
+            END
+
+            IF @BackupSoftware = 'SQLSAFE'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_ss_delete'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_delete @filename = N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + '\*.' + @CurrentFileExtension + ''', @age = ''' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'Minutes'' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLsafe backup files.'', 16, 1)'
+            END
 
             EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
             SET @Error = @@ERROR
@@ -3754,481 +3934,164 @@ BEGIN
             IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
 
             UPDATE @CurrentDirectories
-            SET CreateCompleted = 1,
-                CreateOutput = @CurrentCommandOutput
+            SET CleanupCompleted = 1,
+                CleanupOutput = @CurrentCommandOutput
             WHERE ID = @CurrentDirectoryID
+
+            SET @CurrentDirectoryID = NULL
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentCleanupDate = NULL
+
+            SET @CurrentDatabaseContext = NULL
+            SET @CurrentCommand = NULL
+            SET @CurrentCommandOutput = NULL
+            SET @CurrentCommandType = NULL
           END
-          ELSE
-          BEGIN
-            UPDATE @CurrentDirectories
-            SET CreateCompleted = 1,
-                CreateOutput = 0
-            WHERE ID = @CurrentDirectoryID
-          END
-
-          SET @CurrentDirectoryID = NULL
-          SET @CurrentDirectoryPath = NULL
-
-          SET @CurrentDatabaseContext = NULL
-          SET @CurrentCommand = NULL
-          SET @CurrentCommandOutput = NULL
-          SET @CurrentCommandType = NULL
-
-          DELETE FROM @DirectoryInfo
         END
-      END
 
-      IF @CleanupMode = 'BEFORE_BACKUP'
-      BEGIN
-        INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
-        SELECT DATEADD(hh,-(@CleanupTime),SYSDATETIME()), 0
-
-        IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 0 OR Mirror IS NULL) AND CleanupDate IS NULL)
+        -- Perform a backup
+        IF NOT EXISTS (SELECT * FROM @CurrentDirectories WHERE DirectoryPath <> 'NUL' AND DirectoryPath NOT IN(SELECT DirectoryPath FROM @Directories) AND (CreateOutput <> 0 OR CreateOutput IS NULL))
+        OR @HostPlatform = 'Linux'
         BEGIN
-          UPDATE @CurrentDirectories
-          SET CleanupDate = (SELECT MIN(CleanupDate)
-                             FROM @CurrentCleanupDates
-                             WHERE (Mirror = 0 OR Mirror IS NULL)),
-              CleanupMode = 'BEFORE_BACKUP'
-          WHERE Mirror = 0
-        END
-      END
-
-      IF @MirrorCleanupMode = 'BEFORE_BACKUP'
-      BEGIN
-        INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
-        SELECT DATEADD(hh,-(@MirrorCleanupTime),SYSDATETIME()), 1
-
-        IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 1 OR Mirror IS NULL) AND CleanupDate IS NULL)
-        BEGIN
-          UPDATE @CurrentDirectories
-          SET CleanupDate = (SELECT MIN(CleanupDate)
-                             FROM @CurrentCleanupDates
-                             WHERE (Mirror = 1 OR Mirror IS NULL)),
-              CleanupMode = 'BEFORE_BACKUP'
-          WHERE Mirror = 1
-        END
-      END
-
-      -- Delete old backup files, before backup
-      IF (NOT EXISTS (SELECT * FROM @CurrentDirectories WHERE CreateOutput <> 0 OR CreateOutput IS NULL) OR @HostPlatform = 'Linux')
-      AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
-      AND @CurrentBackupType = @BackupType
-      BEGIN
-        WHILE (1 = 1)
-        BEGIN
-          SELECT TOP 1 @CurrentDirectoryID = ID,
-                       @CurrentDirectoryPath = DirectoryPath,
-                       @CurrentCleanupDate = CleanupDate
-          FROM @CurrentDirectories
-          WHERE CleanupDate IS NOT NULL
-          AND CleanupMode = 'BEFORE_BACKUP'
-          AND CleanupCompleted = 0
-          ORDER BY ID ASC
-
-          IF @@ROWCOUNT = 0
-          BEGIN
-            BREAK
-          END
-
           IF @BackupSoftware IS NULL
           BEGIN
             SET @CurrentDatabaseContext = 'master'
 
-            SET @CurrentCommandType = 'xp_delete_file'
+            SELECT @CurrentCommandType = CASE
+            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP_DATABASE'
+            WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP_LOG'
+            END
 
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_delete_file 0, N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + @CurrentFileExtension + ''', ''' + CONVERT(nvarchar(19),@CurrentCleanupDate,126) + ''' IF @ReturnCode <> 0 RAISERROR(''Error deleting files.'', 16, 1)'
-          END
+            SELECT @CurrentCommand = CASE
+            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP DATABASE ' + QUOTENAME(@CurrentDatabaseName)
+            WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP LOG ' + QUOTENAME(@CurrentDatabaseName)
+            END
 
-          IF @BackupSoftware = 'LITESPEED'
-          BEGIN
-            SET @CurrentDatabaseContext = 'master'
+            IF @FileGroups IS NOT NULL SET @CurrentCommand += ' FILEGROUP = ''' + @CurrentFileGroupName + ''''
 
-            SET @CurrentCommandType = 'xp_slssqlmaint'
+            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' READ_WRITE_FILEGROUPS'
 
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_slssqlmaint N''-MAINTDEL -DELFOLDER "' + REPLACE(@CurrentDirectoryPath,'''','''''') + '" -DELEXTENSION "' + @CurrentFileExtension + '" -DELUNIT "' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + '" -DELUNITTYPE "minutes" -DELUSEAGE'' IF @ReturnCode <> 0 RAISERROR(''Error deleting LiteSpeed backup files.'', 16, 1)'
-          END
-
-          IF @BackupSoftware = 'SQLBACKUP'
-          BEGIN
-            SET @CurrentDatabaseContext = 'master'
-
-            SET @CurrentCommandType = 'sqbutility'
-
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqbutility 1032, N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''', N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + CASE WHEN @CurrentBackupType = 'FULL' THEN 'D' WHEN @CurrentBackupType = 'DIFF' THEN 'I' WHEN @CurrentBackupType = 'LOG' THEN 'L' END + ''', ''' + CAST(DATEDIFF(hh,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'h'', ' + ISNULL('''' + REPLACE(@EncryptionKey,'''','''''') + '''','NULL') + ' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLBackup backup files.'', 16, 1)'
-          END
-
-          IF @BackupSoftware = 'SQLSAFE'
-          BEGIN
-            SET @CurrentDatabaseContext = 'master'
-
-            SET @CurrentCommandType = 'xp_ss_delete'
-
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_delete @filename = N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + '\*.' + @CurrentFileExtension + ''', @age = ''' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'Minutes'' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLsafe backup files.'', 16, 1)'
-          END
-
-          EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
-          SET @Error = @@ERROR
-          IF @Error <> 0 SET @CurrentCommandOutput = @Error
-          IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
-
-          UPDATE @CurrentDirectories
-          SET CleanupCompleted = 1,
-              CleanupOutput = @CurrentCommandOutput
-          WHERE ID = @CurrentDirectoryID
-
-          SET @CurrentDirectoryID = NULL
-          SET @CurrentDirectoryPath = NULL
-          SET @CurrentCleanupDate = NULL
-
-          SET @CurrentDatabaseContext = NULL
-          SET @CurrentCommand = NULL
-          SET @CurrentCommandOutput = NULL
-          SET @CurrentCommandType = NULL
-        END
-      END
-
-      -- Perform a backup
-      IF NOT EXISTS (SELECT * FROM @CurrentDirectories WHERE DirectoryPath <> 'NUL' AND DirectoryPath NOT IN(SELECT DirectoryPath FROM @Directories) AND (CreateOutput <> 0 OR CreateOutput IS NULL))
-      OR @HostPlatform = 'Linux'
-      BEGIN
-        IF @BackupSoftware IS NULL
-        BEGIN
-          SET @CurrentDatabaseContext = 'master'
-
-          SELECT @CurrentCommandType = CASE
-          WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP_DATABASE'
-          WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP_LOG'
-          END
-
-          SELECT @CurrentCommand = CASE
-          WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP DATABASE ' + QUOTENAME(@CurrentDatabaseName)
-          WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP LOG ' + QUOTENAME(@CurrentDatabaseName)
-          END
-
-          IF @FileGroups IS NOT NULL SET @CurrentCommand += ' FILEGROUP = ''' + @CurrentFileGroupName + ''''
-
-          IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' READ_WRITE_FILEGROUPS'
-
-          SET @CurrentCommand += ' TO'
-
-          SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
-          FROM @CurrentFiles
-          WHERE Mirror = 0
-          ORDER BY FilePath ASC
-
-          IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
-          BEGIN
-            SET @CurrentCommand += ' MIRROR TO'
+            SET @CurrentCommand += ' TO'
 
             SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
             FROM @CurrentFiles
-            WHERE Mirror = 1
+            WHERE Mirror = 0
             ORDER BY FilePath ASC
-          END
 
-          SET @CurrentCommand += ' WITH '
-          IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
-          IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+            IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
+            BEGIN
+              SET @CurrentCommand += ' MIRROR TO'
 
-          IF @Version >= 10
-          BEGIN
-            SET @CurrentCommand += CASE WHEN @Compress = 'Y' AND (@CurrentIsEncrypted = 0 OR (@CurrentIsEncrypted = 1 AND ((@Version >= 13 AND @CurrentMaxTransferSize >= 65537) OR @Version >= 15.0404316 OR SERVERPROPERTY('EngineEdition') = 8))) THEN ', COMPRESSION' ELSE ', NO_COMPRESSION' END
-          END
-
-          IF @Compress = 'Y' AND @CompressionAlgorithm IS NOT NULL
-          BEGIN
-            SET @CurrentCommand += ' (ALGORITHM = ' + @CompressionAlgorithm + CASE WHEN @CompressionLevel IS NOT NULL THEN ', LEVEL = ' + @CompressionLevel ELSE '' END + ')'
-          END
-
-          IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
-
-          IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
-          BEGIN
-            SET @CurrentCommand += ', FORMAT'
-          END
-
-          IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
-          IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
-          IF @Init = 'Y' SET @CurrentCommand += ', INIT'
-          IF @Format = 'Y' SET @CurrentCommand += ', FORMAT'
-          IF @BlockSize IS NOT NULL SET @CurrentCommand += ', BLOCKSIZE = ' + CAST(@BlockSize AS nvarchar)
-          IF @BufferCount IS NOT NULL SET @CurrentCommand += ', BUFFERCOUNT = ' + CAST(@BufferCount AS nvarchar)
-          IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', MAXTRANSFERSIZE = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
-          IF @Description IS NOT NULL SET @CurrentCommand += ', DESCRIPTION = N''' + REPLACE(@Description,'''','''''') + ''''
-          IF @BackupSetName IS NOT NULL SET @CurrentCommand += ', NAME = N''' + REPLACE(@BackupSetName,'''','''''') + ''''
-          IF @Stats IS NOT NULL SET @CurrentCommand += ', STATS = ' + CAST(@Stats AS nvarchar)
-          IF @BackupOptions IS NOT NULL SET @CurrentCommand += ', BACKUP_OPTIONS = N''' + REPLACE(@BackupOptions,'''','''''') + ''''
-          IF @Encrypt = 'Y' SET @CurrentCommand += ', ENCRYPTION (ALGORITHM = ' + UPPER(@EncryptionAlgorithm) + ', '
-          IF @Encrypt = 'Y' AND @ServerCertificate IS NOT NULL SET @CurrentCommand += 'SERVER CERTIFICATE = ' + QUOTENAME(@ServerCertificate)
-          IF @Encrypt = 'Y' AND @ServerAsymmetricKey IS NOT NULL SET @CurrentCommand += 'SERVER ASYMMETRIC KEY = ' + QUOTENAME(@ServerAsymmetricKey)
-          IF @Encrypt = 'Y' SET @CurrentCommand += ')'
-          IF @URL IS NOT NULL AND @Credential IS NOT NULL SET @CurrentCommand += ', CREDENTIAL = N''' + REPLACE(@Credential,'''','''''') + ''''
-          IF @ExpireDate IS NOT NULL SET @CurrentCommand += ', EXPIREDATE = ''' + CONVERT(nvarchar, @ExpireDate, 21) + ''''
-          IF @RetainDays IS NOT NULL SET @CurrentCommand += ', RETAINDAYS = ' + CAST(@RetainDays AS nvarchar)
-        END
-
-        IF @BackupSoftware = 'LITESPEED'
-        BEGIN
-          SET @CurrentDatabaseContext = 'master'
-
-          SELECT @CurrentCommandType = CASE
-          WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'xp_backup_database'
-          WHEN @CurrentBackupType = 'LOG' THEN 'xp_backup_log'
-          END
-
-          SELECT @CurrentCommand = CASE
-          WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_backup_database @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
-          WHEN @CurrentBackupType = 'LOG' THEN 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_backup_log @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
-          END
-
-          SELECT @CurrentCommand += ', @filename = N''' + REPLACE(FilePath,'''','''''') + ''''
-          FROM @CurrentFiles
-          WHERE Mirror = 0
-          ORDER BY FilePath ASC
-
-          IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
-          BEGIN
-            SELECT @CurrentCommand += ', @mirror = N''' + REPLACE(FilePath,'''','''''') + ''''
-            FROM @CurrentFiles
-            WHERE Mirror = 1
-            ORDER BY FilePath ASC
-          END
-
-          SET @CurrentCommand += ', @with = '''
-          IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
-          IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
-          IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
-          IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
-          IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
-          IF @BlockSize IS NOT NULL SET @CurrentCommand += ', BLOCKSIZE = ' + CAST(@BlockSize AS nvarchar)
-          SET @CurrentCommand += ''''
-          IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ', @read_write_filegroups = 1'
-          IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', @compressionlevel = ' + CAST(@CompressionLevelNumeric AS nvarchar)
-          IF @AdaptiveCompression IS NOT NULL SET @CurrentCommand += ', @adaptivecompression = ''' + CASE WHEN @AdaptiveCompression = 'SIZE' THEN 'Size' WHEN @AdaptiveCompression = 'SPEED' THEN 'Speed' END + ''''
-          IF @BufferCount IS NOT NULL SET @CurrentCommand += ', @buffercount = ' + CAST(@BufferCount AS nvarchar)
-          IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', @maxtransfersize = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
-          IF @Threads IS NOT NULL SET @CurrentCommand += ', @threads = ' + CAST(@Threads AS nvarchar)
-          IF @Init = 'Y' SET @CurrentCommand += ', @init = 1'
-          IF @Format = 'Y' SET @CurrentCommand += ', @format = 1'
-          IF @Throttle IS NOT NULL SET @CurrentCommand += ', @throttle = ' + CAST(@Throttle AS nvarchar)
-          IF @Description IS NOT NULL SET @CurrentCommand += ', @desc = N''' + REPLACE(@Description,'''','''''') + ''''
-          IF @ObjectLevelRecoveryMap = 'Y' SET @CurrentCommand += ', @olrmap = 1'
-          IF @ExpireDate IS NOT NULL SET @CurrentCommand += ', @expiration = ''' + CONVERT(nvarchar, @ExpireDate, 21) + ''''
-          IF @RetainDays IS NOT NULL SET @CurrentCommand += ', @retaindays = ' + CAST(@RetainDays AS nvarchar)
-
-          IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', @cryptlevel = ' + CASE
-          WHEN @EncryptionAlgorithm = 'RC2_40' THEN '0'
-          WHEN @EncryptionAlgorithm = 'RC2_56' THEN '1'
-          WHEN @EncryptionAlgorithm = 'RC2_112' THEN '2'
-          WHEN @EncryptionAlgorithm = 'RC2_128' THEN '3'
-          WHEN @EncryptionAlgorithm = 'TRIPLE_DES_3KEY' THEN '4'
-          WHEN @EncryptionAlgorithm = 'RC4_128' THEN '5'
-          WHEN @EncryptionAlgorithm = 'AES_128' THEN '6'
-          WHEN @EncryptionAlgorithm = 'AES_192' THEN '7'
-          WHEN @EncryptionAlgorithm = 'AES_256' THEN '8'
-          END
-
-          IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptionkey = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
-          SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing LiteSpeed backup.'', 16, 1)'
-        END
-
-        IF @BackupSoftware = 'SQLBACKUP'
-        BEGIN
-          SET @CurrentDatabaseContext = 'master'
-
-          SET @CurrentCommandType = 'sqlbackup'
-
-          SELECT @CurrentCommand = CASE
-          WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP DATABASE ' + QUOTENAME(@CurrentDatabaseName)
-          WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP LOG ' + QUOTENAME(@CurrentDatabaseName)
-          END
-
-          IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' READ_WRITE_FILEGROUPS'
-
-          SET @CurrentCommand += ' TO'
-
-          SELECT @CurrentCommand += ' DISK = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
-          FROM @CurrentFiles
-          WHERE Mirror = 0
-          ORDER BY FilePath ASC
-
-          SET @CurrentCommand += ' WITH '
-
-          IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
-          BEGIN
-            SET @CurrentCommand += ' MIRRORFILE' + ' = N''' + REPLACE((SELECT FilePath FROM @CurrentFiles WHERE Mirror = 1),'''','''''') + ''', '
-          END
-
-          IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
-          IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
-          IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
-          IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
-          IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
-          IF @Init = 'Y' SET @CurrentCommand += ', INIT'
-          IF @Format = 'Y' SET @CurrentCommand += ', FORMAT'
-          IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', COMPRESSION = ' + CAST(@CompressionLevelNumeric AS nvarchar)
-          IF @Threads IS NOT NULL SET @CurrentCommand += ', THREADCOUNT = ' + CAST(@Threads AS nvarchar)
-          IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', MAXTRANSFERSIZE = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
-          IF @Description IS NOT NULL SET @CurrentCommand += ', DESCRIPTION = N''' + REPLACE(@Description,'''','''''') + ''''
-
-          IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', KEYSIZE = ' + CASE
-          WHEN @EncryptionAlgorithm = 'AES_128' THEN '128'
-          WHEN @EncryptionAlgorithm = 'AES_256' THEN '256'
-          END
-
-          IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', PASSWORD = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
-          SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqlbackup N''-SQL "' + REPLACE(@CurrentCommand,'''','''''') + '"''' + ' IF @ReturnCode <> 0 RAISERROR(''Error performing SQLBackup backup.'', 16, 1)'
-        END
-
-        IF @BackupSoftware = 'SQLSAFE'
-        BEGIN
-          SET @CurrentDatabaseContext = 'master'
-
-          SET @CurrentCommandType = 'xp_ss_backup'
-
-          SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_backup @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
-
-          SELECT @CurrentCommand += ', ' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) = 1 THEN '@filename' ELSE '@backupfile' END + ' = N''' + REPLACE(FilePath,'''','''''') + ''''
-          FROM @CurrentFiles
-          WHERE Mirror = 0
-          ORDER BY FilePath ASC
-
-          SELECT @CurrentCommand += ', @mirrorfile = N''' + REPLACE(FilePath,'''','''''') + ''''
-          FROM @CurrentFiles
-          WHERE Mirror = 1
-          ORDER BY FilePath ASC
-
-          SET @CurrentCommand += ', @backuptype = ' + CASE WHEN @CurrentBackupType = 'FULL' THEN '''Full''' WHEN @CurrentBackupType = 'DIFF' THEN '''Differential''' WHEN @CurrentBackupType = 'LOG' THEN '''Log''' END
-          IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ', @readwritefilegroups = 1'
-          SET @CurrentCommand += ', @checksum = ' + CASE WHEN @Checksum = 'Y' THEN '1' WHEN @Checksum = 'N' THEN '0' END
-          SET @CurrentCommand += ', @copyonly = ' + CASE WHEN @CopyOnly = 'Y' THEN '1' WHEN @CopyOnly = 'N' THEN '0' END
-          IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', @compressionlevel = ' + CAST(@CompressionLevelNumeric AS nvarchar)
-          IF @Threads IS NOT NULL SET @CurrentCommand += ', @threads = ' + CAST(@Threads AS nvarchar)
-          IF @Init = 'Y' SET @CurrentCommand += ', @overwrite = 1'
-          IF @Description IS NOT NULL SET @CurrentCommand += ', @desc = N''' + REPLACE(@Description,'''','''''') + ''''
-
-          IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', @encryptiontype = N''' + CASE
-          WHEN @EncryptionAlgorithm = 'AES_128' THEN 'AES128'
-          WHEN @EncryptionAlgorithm = 'AES_256' THEN 'AES256'
-          END + ''''
-
-          IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptedbackuppassword = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
-          SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing SQLsafe backup.'', 16, 1)'
-        END
-
-        IF @BackupSoftware = 'DATA_DOMAIN_BOOST'
-        BEGIN
-          SET @CurrentDatabaseContext = 'master'
-
-          SET @CurrentCommandType = 'emc_run_backup'
-
-          SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.emc_run_backup '''
-
-          SET @CurrentCommand += ' -c ' + CASE WHEN @Cluster IS NOT NULL AND @CurrentAvailabilityGroup IS NOT NULL THEN @Cluster ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar) END
-
-          SET @CurrentCommand += ' -l ' + CASE
-          WHEN @CurrentBackupType = 'FULL' THEN 'full'
-          WHEN @CurrentBackupType = 'DIFF' THEN 'diff'
-          WHEN @CurrentBackupType = 'LOG' THEN 'incr'
-          END
-
-          IF @NoRecovery = 'Y' SET @CurrentCommand += ' -H'
-
-          IF @CleanupTime IS NOT NULL SET @CurrentCommand += ' -y +' + CAST(@CleanupTime/24 + CASE WHEN @CleanupTime%24 > 0 THEN 1 ELSE 0 END AS nvarchar) + 'd'
-
-          IF @Checksum = 'Y' SET @CurrentCommand += ' -k'
-
-          SET @CurrentCommand += ' -S ' + CAST(@CurrentNumberOfFiles AS nvarchar)
-
-          IF @Description IS NOT NULL SET @CurrentCommand += ' -b "' + REPLACE(@Description,'''','''''') + '"'
-
-          IF @BufferCount IS NOT NULL SET @CurrentCommand += ' -O "BUFFERCOUNT=' + CAST(@BufferCount AS nvarchar) + '"'
-
-          IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' -O "READ_WRITE_FILEGROUPS"'
-
-          IF @DataDomainBoostHost IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_HOST=' + REPLACE(@DataDomainBoostHost,'''','''''') + '"'
-          IF @DataDomainBoostUser IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_USER=' + REPLACE(@DataDomainBoostUser,'''','''''') + '"'
-          IF @DataDomainBoostDevicePath IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DEVICE_PATH=' + REPLACE(@DataDomainBoostDevicePath,'''','''''') + '"'
-          IF @DataDomainBoostLockboxPath IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_LOCKBOX_PATH=' + REPLACE(@DataDomainBoostLockboxPath,'''','''''') + '"'
-          SET @CurrentCommand += ' -a "NSR_SKIP_NON_BACKUPABLE_STATE_DB=TRUE"'
-          SET @CurrentCommand += ' -a "BACKUP_PROMOTION=NONE"'
-          IF @CopyOnly = 'Y' SET @CurrentCommand += ' -a "NSR_COPY_ONLY=TRUE"'
-          IF @BackupSetName IS NOT NULL SET @CurrentCommand += ' -N "' + REPLACE(@BackupSetName,'''','''''') + '"'
-
-          IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentCommand += ' "MSSQL'
-          IF SERVERPROPERTY('InstanceName') IS NOT NULL SET @CurrentCommand += ' "MSSQL$' + CAST(SERVERPROPERTY('InstanceName') AS nvarchar)
-          SET @CurrentCommand += ':' + REPLACE(REPLACE(@CurrentDatabaseName,'''',''''''),'.','\.') + '"'
-
-          SET @CurrentCommand += ''''
-
-          SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing Data Domain Boost backup.'', 16, 1)'
-        END
-
-        EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
-        SET @Error = @@ERROR
-        IF @Error <> 0 SET @CurrentCommandOutput = @Error
-        IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
-        SET @CurrentBackupOutput = @CurrentCommandOutput
-      END
-
-      -- Verify the backup
-      IF @CurrentBackupOutput = 0 AND @Verify = 'Y'
-      BEGIN
-        WHILE (1 = 1)
-        BEGIN
-          SELECT TOP 1 @CurrentBackupSetID = ID,
-                       @CurrentIsMirror = Mirror
-          FROM @CurrentBackupSet
-          WHERE VerifyCompleted = 0
-          ORDER BY ID ASC
-
-          IF @@ROWCOUNT = 0
-          BEGIN
-            BREAK
-          END
-
-          IF @BackupSoftware IS NULL
-          BEGIN
-            SET @CurrentDatabaseContext = 'master'
-
-            SET @CurrentCommandType = 'RESTORE_VERIFYONLY'
-
-            SET @CurrentCommand = 'RESTORE VERIFYONLY FROM'
-
-            SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
-            FROM @CurrentFiles
-            WHERE Mirror = @CurrentIsMirror
-            ORDER BY FilePath ASC
+              SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
+              FROM @CurrentFiles
+              WHERE Mirror = 1
+              ORDER BY FilePath ASC
+            END
 
             SET @CurrentCommand += ' WITH '
             IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
             IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+
+            IF @Version >= 10
+            BEGIN
+              SET @CurrentCommand += CASE WHEN @Compress = 'Y' AND (@CurrentIsEncrypted = 0 OR (@CurrentIsEncrypted = 1 AND ((@Version >= 13 AND @CurrentMaxTransferSize >= 65537) OR @Version >= 15.0404316 OR SERVERPROPERTY('EngineEdition') = 8))) THEN ', COMPRESSION' ELSE ', NO_COMPRESSION' END
+            END
+
+            IF @Compress = 'Y' AND @CompressionAlgorithm IS NOT NULL
+            BEGIN
+              SET @CurrentCommand += ' (ALGORITHM = ' + @CompressionAlgorithm + CASE WHEN @CompressionLevel IS NOT NULL THEN ', LEVEL = ' + @CompressionLevel ELSE '' END + ')'
+            END
+
+            IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
+
+            IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
+            BEGIN
+              SET @CurrentCommand += ', FORMAT'
+            END
+
+            IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
+            IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
+            IF @Init = 'Y' SET @CurrentCommand += ', INIT'
+            IF @Format = 'Y' SET @CurrentCommand += ', FORMAT'
+            IF @BlockSize IS NOT NULL SET @CurrentCommand += ', BLOCKSIZE = ' + CAST(@BlockSize AS nvarchar)
+            IF @BufferCount IS NOT NULL SET @CurrentCommand += ', BUFFERCOUNT = ' + CAST(@BufferCount AS nvarchar)
+            IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', MAXTRANSFERSIZE = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
+            IF @Description IS NOT NULL SET @CurrentCommand += ', DESCRIPTION = N''' + REPLACE(@Description,'''','''''') + ''''
+            IF @BackupSetName IS NOT NULL SET @CurrentCommand += ', NAME = N''' + REPLACE(@BackupSetName,'''','''''') + ''''
             IF @Stats IS NOT NULL SET @CurrentCommand += ', STATS = ' + CAST(@Stats AS nvarchar)
-            IF @BackupOptions IS NOT NULL SET @CurrentCommand += ', RESTORE_OPTIONS = N''' + REPLACE(@BackupOptions,'''','''''') + ''''
+            IF @BackupOptions IS NOT NULL SET @CurrentCommand += ', BACKUP_OPTIONS = N''' + REPLACE(@BackupOptions,'''','''''') + ''''
+            IF @Encrypt = 'Y' SET @CurrentCommand += ', ENCRYPTION (ALGORITHM = ' + UPPER(@EncryptionAlgorithm) + ', '
+            IF @Encrypt = 'Y' AND @ServerCertificate IS NOT NULL SET @CurrentCommand += 'SERVER CERTIFICATE = ' + QUOTENAME(@ServerCertificate)
+            IF @Encrypt = 'Y' AND @ServerAsymmetricKey IS NOT NULL SET @CurrentCommand += 'SERVER ASYMMETRIC KEY = ' + QUOTENAME(@ServerAsymmetricKey)
+            IF @Encrypt = 'Y' SET @CurrentCommand += ')'
             IF @URL IS NOT NULL AND @Credential IS NOT NULL SET @CurrentCommand += ', CREDENTIAL = N''' + REPLACE(@Credential,'''','''''') + ''''
+            IF @ExpireDate IS NOT NULL SET @CurrentCommand += ', EXPIREDATE = ''' + CONVERT(nvarchar, @ExpireDate, 21) + ''''
+            IF @RetainDays IS NOT NULL SET @CurrentCommand += ', RETAINDAYS = ' + CAST(@RetainDays AS nvarchar)
           END
 
           IF @BackupSoftware = 'LITESPEED'
           BEGIN
             SET @CurrentDatabaseContext = 'master'
 
-            SET @CurrentCommandType = 'xp_restore_verifyonly'
+            SELECT @CurrentCommandType = CASE
+            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'xp_backup_database'
+            WHEN @CurrentBackupType = 'LOG' THEN 'xp_backup_log'
+            END
 
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_restore_verifyonly'
+            SELECT @CurrentCommand = CASE
+            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_backup_database @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
+            WHEN @CurrentBackupType = 'LOG' THEN 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_backup_log @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
+            END
 
-            SELECT @CurrentCommand += ' @filename = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
+            SELECT @CurrentCommand += ', @filename = N''' + REPLACE(FilePath,'''','''''') + ''''
             FROM @CurrentFiles
-            WHERE Mirror = @CurrentIsMirror
+            WHERE Mirror = 0
             ORDER BY FilePath ASC
+
+            IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
+            BEGIN
+              SELECT @CurrentCommand += ', @mirror = N''' + REPLACE(FilePath,'''','''''') + ''''
+              FROM @CurrentFiles
+              WHERE Mirror = 1
+              ORDER BY FilePath ASC
+            END
 
             SET @CurrentCommand += ', @with = '''
             IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
             IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+            IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
+            IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
+            IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
+            IF @BlockSize IS NOT NULL SET @CurrentCommand += ', BLOCKSIZE = ' + CAST(@BlockSize AS nvarchar)
             SET @CurrentCommand += ''''
-            IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptionkey = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ', @read_write_filegroups = 1'
+            IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', @compressionlevel = ' + CAST(@CompressionLevelNumeric AS nvarchar)
+            IF @AdaptiveCompression IS NOT NULL SET @CurrentCommand += ', @adaptivecompression = ''' + CASE WHEN @AdaptiveCompression = 'SIZE' THEN 'Size' WHEN @AdaptiveCompression = 'SPEED' THEN 'Speed' END + ''''
+            IF @BufferCount IS NOT NULL SET @CurrentCommand += ', @buffercount = ' + CAST(@BufferCount AS nvarchar)
+            IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', @maxtransfersize = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
+            IF @Threads IS NOT NULL SET @CurrentCommand += ', @threads = ' + CAST(@Threads AS nvarchar)
+            IF @Init = 'Y' SET @CurrentCommand += ', @init = 1'
+            IF @Format = 'Y' SET @CurrentCommand += ', @format = 1'
+            IF @Throttle IS NOT NULL SET @CurrentCommand += ', @throttle = ' + CAST(@Throttle AS nvarchar)
+            IF @Description IS NOT NULL SET @CurrentCommand += ', @desc = N''' + REPLACE(@Description,'''','''''') + ''''
+            IF @ObjectLevelRecoveryMap = 'Y' SET @CurrentCommand += ', @olrmap = 1'
+            IF @ExpireDate IS NOT NULL SET @CurrentCommand += ', @expiration = ''' + CONVERT(nvarchar, @ExpireDate, 21) + ''''
+            IF @RetainDays IS NOT NULL SET @CurrentCommand += ', @retaindays = ' + CAST(@RetainDays AS nvarchar)
 
-            SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error verifying LiteSpeed backup.'', 16, 1)'
+            IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', @cryptlevel = ' + CASE
+            WHEN @EncryptionAlgorithm = 'RC2_40' THEN '0'
+            WHEN @EncryptionAlgorithm = 'RC2_56' THEN '1'
+            WHEN @EncryptionAlgorithm = 'RC2_112' THEN '2'
+            WHEN @EncryptionAlgorithm = 'RC2_128' THEN '3'
+            WHEN @EncryptionAlgorithm = 'TRIPLE_DES_3KEY' THEN '4'
+            WHEN @EncryptionAlgorithm = 'RC4_128' THEN '5'
+            WHEN @EncryptionAlgorithm = 'AES_128' THEN '6'
+            WHEN @EncryptionAlgorithm = 'AES_192' THEN '7'
+            WHEN @EncryptionAlgorithm = 'AES_256' THEN '8'
+            END
+
+            IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptionkey = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+            SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing LiteSpeed backup.'', 16, 1)'
           END
 
           IF @BackupSoftware = 'SQLBACKUP'
@@ -4237,167 +4100,365 @@ BEGIN
 
             SET @CurrentCommandType = 'sqlbackup'
 
-            SET @CurrentCommand = 'RESTORE VERIFYONLY FROM'
+            SELECT @CurrentCommand = CASE
+            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP DATABASE ' + QUOTENAME(@CurrentDatabaseName)
+            WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP LOG ' + QUOTENAME(@CurrentDatabaseName)
+            END
+
+            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' READ_WRITE_FILEGROUPS'
+
+            SET @CurrentCommand += ' TO'
 
             SELECT @CurrentCommand += ' DISK = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
             FROM @CurrentFiles
-            WHERE Mirror = @CurrentIsMirror
+            WHERE Mirror = 0
             ORDER BY FilePath ASC
 
             SET @CurrentCommand += ' WITH '
+
+            IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
+            BEGIN
+              SET @CurrentCommand += ' MIRRORFILE' + ' = N''' + REPLACE((SELECT FilePath FROM @CurrentFiles WHERE Mirror = 1),'''','''''') + ''', '
+            END
+
             IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
             IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
-            IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', PASSWORD = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+            IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
+            IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
+            IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
+            IF @Init = 'Y' SET @CurrentCommand += ', INIT'
+            IF @Format = 'Y' SET @CurrentCommand += ', FORMAT'
+            IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', COMPRESSION = ' + CAST(@CompressionLevelNumeric AS nvarchar)
+            IF @Threads IS NOT NULL SET @CurrentCommand += ', THREADCOUNT = ' + CAST(@Threads AS nvarchar)
+            IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', MAXTRANSFERSIZE = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
+            IF @Description IS NOT NULL SET @CurrentCommand += ', DESCRIPTION = N''' + REPLACE(@Description,'''','''''') + ''''
 
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqlbackup N''-SQL "' + REPLACE(@CurrentCommand,'''','''''') + '"''' + ' IF @ReturnCode <> 0 RAISERROR(''Error verifying SQLBackup backup.'', 16, 1)'
+            IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', KEYSIZE = ' + CASE
+            WHEN @EncryptionAlgorithm = 'AES_128' THEN '128'
+            WHEN @EncryptionAlgorithm = 'AES_256' THEN '256'
+            END
+
+            IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', PASSWORD = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqlbackup N''-SQL "' + REPLACE(@CurrentCommand,'''','''''') + '"''' + ' IF @ReturnCode <> 0 RAISERROR(''Error performing SQLBackup backup.'', 16, 1)'
           END
 
           IF @BackupSoftware = 'SQLSAFE'
           BEGIN
             SET @CurrentDatabaseContext = 'master'
 
-            SET @CurrentCommandType = 'xp_ss_verify'
+            SET @CurrentCommandType = 'xp_ss_backup'
 
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_verify @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
+            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_backup @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
 
             SELECT @CurrentCommand += ', ' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) = 1 THEN '@filename' ELSE '@backupfile' END + ' = N''' + REPLACE(FilePath,'''','''''') + ''''
             FROM @CurrentFiles
-            WHERE Mirror = @CurrentIsMirror
+            WHERE Mirror = 0
             ORDER BY FilePath ASC
 
-            SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error verifying SQLsafe backup.'', 16, 1)'
+            SELECT @CurrentCommand += ', @mirrorfile = N''' + REPLACE(FilePath,'''','''''') + ''''
+            FROM @CurrentFiles
+            WHERE Mirror = 1
+            ORDER BY FilePath ASC
+
+            SET @CurrentCommand += ', @backuptype = ' + CASE WHEN @CurrentBackupType = 'FULL' THEN '''Full''' WHEN @CurrentBackupType = 'DIFF' THEN '''Differential''' WHEN @CurrentBackupType = 'LOG' THEN '''Log''' END
+            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ', @readwritefilegroups = 1'
+            SET @CurrentCommand += ', @checksum = ' + CASE WHEN @Checksum = 'Y' THEN '1' WHEN @Checksum = 'N' THEN '0' END
+            SET @CurrentCommand += ', @copyonly = ' + CASE WHEN @CopyOnly = 'Y' THEN '1' WHEN @CopyOnly = 'N' THEN '0' END
+            IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', @compressionlevel = ' + CAST(@CompressionLevelNumeric AS nvarchar)
+            IF @Threads IS NOT NULL SET @CurrentCommand += ', @threads = ' + CAST(@Threads AS nvarchar)
+            IF @Init = 'Y' SET @CurrentCommand += ', @overwrite = 1'
+            IF @Description IS NOT NULL SET @CurrentCommand += ', @desc = N''' + REPLACE(@Description,'''','''''') + ''''
+
+            IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', @encryptiontype = N''' + CASE
+            WHEN @EncryptionAlgorithm = 'AES_128' THEN 'AES128'
+            WHEN @EncryptionAlgorithm = 'AES_256' THEN 'AES256'
+            END + ''''
+
+            IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptedbackuppassword = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+            SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing SQLsafe backup.'', 16, 1)'
+          END
+
+          IF @BackupSoftware = 'DATA_DOMAIN_BOOST'
+          BEGIN
+            SET @CurrentDatabaseContext = 'master'
+
+            SET @CurrentCommandType = 'emc_run_backup'
+
+            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.emc_run_backup '''
+
+            SET @CurrentCommand += ' -c ' + CASE WHEN @Cluster IS NOT NULL AND @CurrentAvailabilityGroup IS NOT NULL THEN @Cluster ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar) END
+
+            SET @CurrentCommand += ' -l ' + CASE
+            WHEN @CurrentBackupType = 'FULL' THEN 'full'
+            WHEN @CurrentBackupType = 'DIFF' THEN 'diff'
+            WHEN @CurrentBackupType = 'LOG' THEN 'incr'
+            END
+
+            IF @NoRecovery = 'Y' SET @CurrentCommand += ' -H'
+
+            IF @CleanupTime IS NOT NULL SET @CurrentCommand += ' -y +' + CAST(@CleanupTime/24 + CASE WHEN @CleanupTime%24 > 0 THEN 1 ELSE 0 END AS nvarchar) + 'd'
+
+            IF @Checksum = 'Y' SET @CurrentCommand += ' -k'
+
+            SET @CurrentCommand += ' -S ' + CAST(@CurrentNumberOfFiles AS nvarchar)
+
+            IF @Description IS NOT NULL SET @CurrentCommand += ' -b "' + REPLACE(@Description,'''','''''') + '"'
+
+            IF @BufferCount IS NOT NULL SET @CurrentCommand += ' -O "BUFFERCOUNT=' + CAST(@BufferCount AS nvarchar) + '"'
+
+            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' -O "READ_WRITE_FILEGROUPS"'
+
+            IF @DataDomainBoostHost IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_HOST=' + REPLACE(@DataDomainBoostHost,'''','''''') + '"'
+            IF @DataDomainBoostUser IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_USER=' + REPLACE(@DataDomainBoostUser,'''','''''') + '"'
+            IF @DataDomainBoostDevicePath IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DEVICE_PATH=' + REPLACE(@DataDomainBoostDevicePath,'''','''''') + '"'
+            IF @DataDomainBoostLockboxPath IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_LOCKBOX_PATH=' + REPLACE(@DataDomainBoostLockboxPath,'''','''''') + '"'
+            SET @CurrentCommand += ' -a "NSR_SKIP_NON_BACKUPABLE_STATE_DB=TRUE"'
+            SET @CurrentCommand += ' -a "BACKUP_PROMOTION=NONE"'
+            IF @CopyOnly = 'Y' SET @CurrentCommand += ' -a "NSR_COPY_ONLY=TRUE"'
+            IF @BackupSetName IS NOT NULL SET @CurrentCommand += ' -N "' + REPLACE(@BackupSetName,'''','''''') + '"'
+
+            IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentCommand += ' "MSSQL'
+            IF SERVERPROPERTY('InstanceName') IS NOT NULL SET @CurrentCommand += ' "MSSQL$' + CAST(SERVERPROPERTY('InstanceName') AS nvarchar)
+            SET @CurrentCommand += ':' + REPLACE(REPLACE(@CurrentDatabaseName,'''',''''''),'.','\.') + '"'
+
+            SET @CurrentCommand += ''''
+
+            SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing Data Domain Boost backup.'', 16, 1)'
           END
 
           EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
           SET @Error = @@ERROR
           IF @Error <> 0 SET @CurrentCommandOutput = @Error
           IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
-
-          UPDATE @CurrentBackupSet
-          SET VerifyCompleted = 1,
-              VerifyOutput = @CurrentCommandOutput
-          WHERE ID = @CurrentBackupSetID
-
-          SET @CurrentBackupSetID = NULL
-          SET @CurrentIsMirror = NULL
-
-          SET @CurrentDatabaseContext = NULL
-          SET @CurrentCommand = NULL
-          SET @CurrentCommandOutput = NULL
-          SET @CurrentCommandType = NULL
+          SET @CurrentBackupOutput = @CurrentCommandOutput
         END
-      END
 
-      IF @CleanupMode = 'AFTER_BACKUP'
-      BEGIN
-        INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
-        SELECT DATEADD(hh,-(@CleanupTime),SYSDATETIME()), 0
-
-        IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 0 OR Mirror IS NULL) AND CleanupDate IS NULL)
+        -- Verify the backup
+        IF @CurrentBackupOutput = 0 AND @Verify = 'Y'
         BEGIN
-          UPDATE @CurrentDirectories
-          SET CleanupDate = (SELECT MIN(CleanupDate)
-                             FROM @CurrentCleanupDates
-                             WHERE (Mirror = 0 OR Mirror IS NULL)),
-              CleanupMode = 'AFTER_BACKUP'
-          WHERE Mirror = 0
+          WHILE (1 = 1)
+          BEGIN
+            SELECT TOP 1 @CurrentBackupSetID = ID,
+                         @CurrentIsMirror = Mirror
+            FROM @CurrentBackupSet
+            WHERE VerifyCompleted = 0
+            ORDER BY ID ASC
+
+            IF @@ROWCOUNT = 0
+            BEGIN
+              BREAK
+            END
+
+            IF @BackupSoftware IS NULL
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'RESTORE_VERIFYONLY'
+
+              SET @CurrentCommand = 'RESTORE VERIFYONLY FROM'
+
+              SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
+              FROM @CurrentFiles
+              WHERE Mirror = @CurrentIsMirror
+              ORDER BY FilePath ASC
+
+              SET @CurrentCommand += ' WITH '
+              IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
+              IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+              IF @Stats IS NOT NULL SET @CurrentCommand += ', STATS = ' + CAST(@Stats AS nvarchar)
+              IF @BackupOptions IS NOT NULL SET @CurrentCommand += ', RESTORE_OPTIONS = N''' + REPLACE(@BackupOptions,'''','''''') + ''''
+              IF @URL IS NOT NULL AND @Credential IS NOT NULL SET @CurrentCommand += ', CREDENTIAL = N''' + REPLACE(@Credential,'''','''''') + ''''
+            END
+
+            IF @BackupSoftware = 'LITESPEED'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_restore_verifyonly'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_restore_verifyonly'
+
+              SELECT @CurrentCommand += ' @filename = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
+              FROM @CurrentFiles
+              WHERE Mirror = @CurrentIsMirror
+              ORDER BY FilePath ASC
+
+              SET @CurrentCommand += ', @with = '''
+              IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
+              IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+              SET @CurrentCommand += ''''
+              IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptionkey = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+
+              SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error verifying LiteSpeed backup.'', 16, 1)'
+            END
+
+            IF @BackupSoftware = 'SQLBACKUP'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'sqlbackup'
+
+              SET @CurrentCommand = 'RESTORE VERIFYONLY FROM'
+
+              SELECT @CurrentCommand += ' DISK = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
+              FROM @CurrentFiles
+              WHERE Mirror = @CurrentIsMirror
+              ORDER BY FilePath ASC
+
+              SET @CurrentCommand += ' WITH '
+              IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
+              IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+              IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', PASSWORD = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqlbackup N''-SQL "' + REPLACE(@CurrentCommand,'''','''''') + '"''' + ' IF @ReturnCode <> 0 RAISERROR(''Error verifying SQLBackup backup.'', 16, 1)'
+            END
+
+            IF @BackupSoftware = 'SQLSAFE'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_ss_verify'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_verify @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
+
+              SELECT @CurrentCommand += ', ' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) = 1 THEN '@filename' ELSE '@backupfile' END + ' = N''' + REPLACE(FilePath,'''','''''') + ''''
+              FROM @CurrentFiles
+              WHERE Mirror = @CurrentIsMirror
+              ORDER BY FilePath ASC
+
+              SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error verifying SQLsafe backup.'', 16, 1)'
+            END
+
+            EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
+            SET @Error = @@ERROR
+            IF @Error <> 0 SET @CurrentCommandOutput = @Error
+            IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
+
+            UPDATE @CurrentBackupSet
+            SET VerifyCompleted = 1,
+                VerifyOutput = @CurrentCommandOutput
+            WHERE ID = @CurrentBackupSetID
+
+            SET @CurrentBackupSetID = NULL
+            SET @CurrentIsMirror = NULL
+
+            SET @CurrentDatabaseContext = NULL
+            SET @CurrentCommand = NULL
+            SET @CurrentCommandOutput = NULL
+            SET @CurrentCommandType = NULL
+          END
         END
-      END
 
-      IF @MirrorCleanupMode = 'AFTER_BACKUP'
-      BEGIN
-        INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
-        SELECT DATEADD(hh,-(@MirrorCleanupTime),SYSDATETIME()), 1
-
-        IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 1 OR Mirror IS NULL) AND CleanupDate IS NULL)
+        IF @CleanupMode = 'AFTER_BACKUP'
         BEGIN
-          UPDATE @CurrentDirectories
-          SET CleanupDate = (SELECT MIN(CleanupDate)
-                             FROM @CurrentCleanupDates
-                             WHERE (Mirror = 1 OR Mirror IS NULL)),
-              CleanupMode = 'AFTER_BACKUP'
-          WHERE Mirror = 1
-        END
-      END
+          INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
+          SELECT DATEADD(hh,-(@CleanupTime),SYSDATETIME()), 0
 
-      -- Delete old backup files, after backup
-      IF ((@CurrentBackupOutput = 0 AND @Verify = 'N')
-      OR (@CurrentBackupOutput = 0 AND @Verify = 'Y' AND NOT EXISTS (SELECT * FROM @CurrentBackupSet WHERE VerifyOutput <> 0 OR VerifyOutput IS NULL)))
-      AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
-      AND @CurrentBackupType = @BackupType
-      BEGIN
-        WHILE (1 = 1)
+          IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 0 OR Mirror IS NULL) AND CleanupDate IS NULL)
+          BEGIN
+            UPDATE @CurrentDirectories
+            SET CleanupDate = (SELECT MIN(CleanupDate)
+                               FROM @CurrentCleanupDates
+                               WHERE (Mirror = 0 OR Mirror IS NULL)),
+                CleanupMode = 'AFTER_BACKUP'
+            WHERE Mirror = 0
+          END
+        END
+
+        IF @MirrorCleanupMode = 'AFTER_BACKUP'
         BEGIN
-          SELECT TOP 1 @CurrentDirectoryID = ID,
-                       @CurrentDirectoryPath = DirectoryPath,
-                       @CurrentCleanupDate = CleanupDate
-          FROM @CurrentDirectories
-          WHERE CleanupDate IS NOT NULL
-          AND CleanupMode = 'AFTER_BACKUP'
-          AND CleanupCompleted = 0
-          ORDER BY ID ASC
+          INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
+          SELECT DATEADD(hh,-(@MirrorCleanupTime),SYSDATETIME()), 1
 
-          IF @@ROWCOUNT = 0
+          IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 1 OR Mirror IS NULL) AND CleanupDate IS NULL)
           BEGIN
-            BREAK
+            UPDATE @CurrentDirectories
+            SET CleanupDate = (SELECT MIN(CleanupDate)
+                               FROM @CurrentCleanupDates
+                               WHERE (Mirror = 1 OR Mirror IS NULL)),
+                CleanupMode = 'AFTER_BACKUP'
+            WHERE Mirror = 1
           END
-
-          IF @BackupSoftware IS NULL
-          BEGIN
-            SET @CurrentDatabaseContext = 'master'
-
-            SET @CurrentCommandType = 'xp_delete_file'
-
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_delete_file 0, N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + @CurrentFileExtension + ''', ''' + CONVERT(nvarchar(19),@CurrentCleanupDate,126) + ''' IF @ReturnCode <> 0 RAISERROR(''Error deleting files.'', 16, 1)'
-          END
-
-          IF @BackupSoftware = 'LITESPEED'
-          BEGIN
-            SET @CurrentDatabaseContext = 'master'
-
-            SET @CurrentCommandType = 'xp_slssqlmaint'
-
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_slssqlmaint N''-MAINTDEL -DELFOLDER "' + REPLACE(@CurrentDirectoryPath,'''','''''') + '" -DELEXTENSION "' + @CurrentFileExtension + '" -DELUNIT "' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + '" -DELUNITTYPE "minutes" -DELUSEAGE'' IF @ReturnCode <> 0 RAISERROR(''Error deleting LiteSpeed backup files.'', 16, 1)'
-          END
-
-          IF @BackupSoftware = 'SQLBACKUP'
-          BEGIN
-            SET @CurrentDatabaseContext = 'master'
-
-            SET @CurrentCommandType = 'sqbutility'
-
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqbutility 1032, N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''', N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + CASE WHEN @CurrentBackupType = 'FULL' THEN 'D' WHEN @CurrentBackupType = 'DIFF' THEN 'I' WHEN @CurrentBackupType = 'LOG' THEN 'L' END + ''', ''' + CAST(DATEDIFF(hh,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'h'', ' + ISNULL('''' + REPLACE(@EncryptionKey,'''','''''') + '''','NULL') + ' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLBackup backup files.'', 16, 1)'
-          END
-
-          IF @BackupSoftware = 'SQLSAFE'
-          BEGIN
-            SET @CurrentDatabaseContext = 'master'
-
-            SET @CurrentCommandType = 'xp_ss_delete'
-
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_delete @filename = N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + '\*.' + @CurrentFileExtension + ''', @age = ''' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'Minutes'' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLsafe backup files.'', 16, 1)'
-          END
-
-          EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
-          SET @Error = @@ERROR
-          IF @Error <> 0 SET @CurrentCommandOutput = @Error
-          IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
-
-          UPDATE @CurrentDirectories
-          SET CleanupCompleted = 1,
-              CleanupOutput = @CurrentCommandOutput
-          WHERE ID = @CurrentDirectoryID
-
-          SET @CurrentDirectoryID = NULL
-          SET @CurrentDirectoryPath = NULL
-          SET @CurrentCleanupDate = NULL
-
-          SET @CurrentDatabaseContext = NULL
-          SET @CurrentCommand = NULL
-          SET @CurrentCommandOutput = NULL
-          SET @CurrentCommandType = NULL
         END
-      END
+
+        -- Delete old backup files, after backup
+        IF ((@CurrentBackupOutput = 0 AND @Verify = 'N')
+        OR (@CurrentBackupOutput = 0 AND @Verify = 'Y' AND NOT EXISTS (SELECT * FROM @CurrentBackupSet WHERE VerifyOutput <> 0 OR VerifyOutput IS NULL)))
+        AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
+        AND @CurrentBackupType = @BackupType
+        BEGIN
+          WHILE (1 = 1)
+          BEGIN
+            SELECT TOP 1 @CurrentDirectoryID = ID,
+                         @CurrentDirectoryPath = DirectoryPath,
+                         @CurrentCleanupDate = CleanupDate
+            FROM @CurrentDirectories
+            WHERE CleanupDate IS NOT NULL
+            AND CleanupMode = 'AFTER_BACKUP'
+            AND CleanupCompleted = 0
+            ORDER BY ID ASC
+
+            IF @@ROWCOUNT = 0
+            BEGIN
+              BREAK
+            END
+
+            IF @BackupSoftware IS NULL
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_delete_file'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_delete_file 0, N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + @CurrentFileExtension + ''', ''' + CONVERT(nvarchar(19),@CurrentCleanupDate,126) + ''' IF @ReturnCode <> 0 RAISERROR(''Error deleting files.'', 16, 1)'
+            END
+
+            IF @BackupSoftware = 'LITESPEED'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_slssqlmaint'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_slssqlmaint N''-MAINTDEL -DELFOLDER "' + REPLACE(@CurrentDirectoryPath,'''','''''') + '" -DELEXTENSION "' + @CurrentFileExtension + '" -DELUNIT "' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + '" -DELUNITTYPE "minutes" -DELUSEAGE'' IF @ReturnCode <> 0 RAISERROR(''Error deleting LiteSpeed backup files.'', 16, 1)'
+            END
+
+            IF @BackupSoftware = 'SQLBACKUP'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'sqbutility'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqbutility 1032, N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''', N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + CASE WHEN @CurrentBackupType = 'FULL' THEN 'D' WHEN @CurrentBackupType = 'DIFF' THEN 'I' WHEN @CurrentBackupType = 'LOG' THEN 'L' END + ''', ''' + CAST(DATEDIFF(hh,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'h'', ' + ISNULL('''' + REPLACE(@EncryptionKey,'''','''''') + '''','NULL') + ' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLBackup backup files.'', 16, 1)'
+            END
+
+            IF @BackupSoftware = 'SQLSAFE'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_ss_delete'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_delete @filename = N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + '\*.' + @CurrentFileExtension + ''', @age = ''' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'Minutes'' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLsafe backup files.'', 16, 1)'
+            END
+
+            EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
+            SET @Error = @@ERROR
+            IF @Error <> 0 SET @CurrentCommandOutput = @Error
+            IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
+
+            UPDATE @CurrentDirectories
+            SET CleanupCompleted = 1,
+                CleanupOutput = @CurrentCommandOutput
+            WHERE ID = @CurrentDirectoryID
+
+            SET @CurrentDirectoryID = NULL
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentCleanupDate = NULL
+
+            SET @CurrentDatabaseContext = NULL
+            SET @CurrentCommand = NULL
+            SET @CurrentCommandOutput = NULL
+            SET @CurrentCommandType = NULL
+          END
+        END
 
         UPDATE @tmpFileGroups
         SET Completed = 1
@@ -4423,9 +4484,9 @@ BEGIN
           BREAK
         END
 
-    END
+      END -- End of file group while loop
 
-    END
+    END -- End of database backup check
 
     IF @CurrentDatabaseState = 'SUSPECT'
     BEGIN
@@ -4495,7 +4556,7 @@ BEGIN
     SET @CurrentAllocatedExtentPageCount = NULL
     SET @CurrentModifiedExtentPageCount = NULL
 
-  END
+  END -- End of database while loop
 
   ----------------------------------------------------------------------------------------------------
   --// Log completing information                                                                 //--

--- a/DatabaseBackup.sql
+++ b/DatabaseBackup.sql
@@ -58,8 +58,8 @@ ALTER PROCEDURE [dbo].[DatabaseBackup]
 @DataDomainBoostUser nvarchar(max) = NULL,
 @DataDomainBoostDevicePath nvarchar(max) = NULL,
 @DataDomainBoostLockboxPath nvarchar(max) = NULL,
-@DirectoryStructure nvarchar(max) = '{ServerName}${InstanceName}{DirectorySeparator}{DatabaseName}{DirectorySeparator}{FileGroupName}{DirectorySeparator}{BackupType}_{Partial}_{CopyOnly}',
-@AvailabilityGroupDirectoryStructure nvarchar(max) = '{ClusterName}${AvailabilityGroupName}{DirectorySeparator}{DatabaseName}{DirectorySeparator}{FileGroupName}{DirectorySeparator}{BackupType}_{Partial}_{CopyOnly}',
+@DirectoryStructure nvarchar(max) = '{ServerName}${InstanceName}{DirectorySeparator}{DatabaseName}{DirectorySeparator}{FileGroupName}_{BackupType}_{Partial}_{CopyOnly}',
+@AvailabilityGroupDirectoryStructure nvarchar(max) = '{ClusterName}${AvailabilityGroupName}{DirectorySeparator}{DatabaseName}{DirectorySeparator}{FileGroupName}_{BackupType}_{Partial}_{CopyOnly}',
 @DirectoryStructureCase nvarchar(max) = NULL,
 @FileName nvarchar(max) = '{ServerName}${InstanceName}_{DatabaseName}_{FileGroupName}_{BackupType}_{Partial}_{CopyOnly}_{Year}{Month}{Day}_{Hour}{Minute}{Second}_{FileNumber}.{FileExtension}',
 @AvailabilityGroupFileName nvarchar(max) = '{ClusterName}${AvailabilityGroupName}_{DatabaseName}_{FileGroupName}_{BackupType}_{Partial}_{CopyOnly}_{Year}{Month}{Day}_{Hour}{Minute}{Second}_{FileNumber}.{FileExtension}',
@@ -92,7 +92,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-07 21:41:06                                                               //--
+  --// Version: 2025-06-08 12:16:23                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/DatabaseIntegrityCheck.sql
+++ b/DatabaseIntegrityCheck.sql
@@ -40,7 +40,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-08 20:41:55                                                               //--
+  --// Version: 2025-06-08 22:57:39                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/DatabaseIntegrityCheck.sql
+++ b/DatabaseIntegrityCheck.sql
@@ -40,7 +40,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-05-24 16:07:41                                                               //--
+  --// Version: 2025-06-07 21:41:06                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/DatabaseIntegrityCheck.sql
+++ b/DatabaseIntegrityCheck.sql
@@ -40,7 +40,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-07-08 19:42:27                                                               //--
+  --// Version: 2025-07-20 01:19:05                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/DatabaseIntegrityCheck.sql
+++ b/DatabaseIntegrityCheck.sql
@@ -40,7 +40,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-08 12:16:23                                                               //--
+  --// Version: 2025-06-08 20:41:55                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/DatabaseIntegrityCheck.sql
+++ b/DatabaseIntegrityCheck.sql
@@ -40,7 +40,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-08 22:57:39                                                               //--
+  --// Version: 2025-07-08 19:42:27                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/DatabaseIntegrityCheck.sql
+++ b/DatabaseIntegrityCheck.sql
@@ -40,7 +40,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-07 21:41:06                                                               //--
+  --// Version: 2025-06-08 12:16:23                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/IndexOptimize.sql
+++ b/IndexOptimize.sql
@@ -54,7 +54,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-05-24 16:07:41                                                               //--
+  --// Version: 2025-06-07 21:41:06                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/IndexOptimize.sql
+++ b/IndexOptimize.sql
@@ -54,7 +54,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-07-08 19:42:27                                                               //--
+  --// Version: 2025-07-20 01:19:05                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON
@@ -138,7 +138,8 @@ BEGIN
   DECLARE @CurrentIsImageText bit
   DECLARE @CurrentIsNewLOB bit
   DECLARE @CurrentIsFileStream bit
-  DECLARE @CurrentHasColumnstore bit
+  DECLARE @CurrentHasClusteredColumnstore bit
+  DECLARE @CurrentHasNonClusteredColumnstore bit
   DECLARE @CurrentIsComputed bit
   DECLARE @CurrentIsClusteredIndexComputed bit
   DECLARE @CurrentIsTimestamp bit
@@ -194,7 +195,8 @@ BEGIN
                                        IsImageText bit,
                                        IsNewLOB bit,
                                        IsFileStream bit,
-                                       HasColumnstore bit,
+                                       HasClusteredColumnstore bit,
+                                       HasNonClusteredColumnstore bit,
                                        IsComputed bit,
                                        IsClusteredIndexComputed bit,
                                        IsTimestamp bit,
@@ -1543,7 +1545,7 @@ BEGIN
       IF (EXISTS(SELECT * FROM @ActionsPreferred) OR @UpdateStatistics IS NOT NULL) AND (SYSDATETIME() < DATEADD(SECOND,@TimeLimit,@StartTime) OR @TimeLimit IS NULL)
       BEGIN
         SET @CurrentCommand = 'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;'
-                              + ' SELECT SchemaID, SchemaName, ObjectID, ObjectName, ObjectType, IsMemoryOptimized, IndexID, IndexName, IndexType, AllowPageLocks, HasFilter, IsImageText, IsNewLOB, IsFileStream, HasColumnstore, IsComputed, IsClusteredIndexComputed, IsTimestamp, OnReadOnlyFileGroup, ResumableIndexOperation, StatisticsID, StatisticsName, NoRecompute, IsIncremental, PartitionID, PartitionNumber, PartitionCount, [Order], Selected, Completed'
+                              + ' SELECT SchemaID, SchemaName, ObjectID, ObjectName, ObjectType, IsMemoryOptimized, IndexID, IndexName, IndexType, AllowPageLocks, HasFilter, IsImageText, IsNewLOB, IsFileStream, HasClusteredColumnstore, HasNonClusteredColumnstore, IsComputed, IsClusteredIndexComputed, IsTimestamp, OnReadOnlyFileGroup, ResumableIndexOperation, StatisticsID, StatisticsName, NoRecompute, IsIncremental, PartitionID, PartitionNumber, PartitionCount, [Order], Selected, Completed'
                               + ' FROM ('
 
         IF EXISTS(SELECT * FROM @ActionsPreferred) OR @UpdateStatistics IN('ALL','INDEX')
@@ -1567,7 +1569,9 @@ BEGIN
 
                                                     + ', CASE WHEN indexes.[type] = 1 AND EXISTS(SELECT * FROM sys.columns columns WHERE columns.[object_id] = objects.object_id  AND columns.is_filestream = 1) THEN 1 ELSE 0 END AS IsFileStream'
 
-                                                    + ', CASE WHEN EXISTS(SELECT * FROM sys.indexes indexes WHERE indexes.[object_id] = objects.object_id AND [type] IN(5,6)) THEN 1 ELSE 0 END AS HasColumnstore'
+                                                    + ', CASE WHEN EXISTS(SELECT * FROM sys.indexes indexes WHERE indexes.[object_id] = objects.object_id AND [type] = 5) THEN 1 ELSE 0 END AS HasClusteredColumnstore'
+
+                                                    + ', CASE WHEN EXISTS(SELECT * FROM sys.indexes indexes WHERE indexes.[object_id] = objects.object_id AND [type] = 6) THEN 1 ELSE 0 END AS HasNonClusteredColumnstore'
 
                                                     + ', CASE WHEN EXISTS(SELECT * FROM sys.index_columns index_columns INNER JOIN sys.columns columns ON index_columns.object_id = columns.object_id AND index_columns.column_id = columns.column_id WHERE (index_columns.key_ordinal > 0 OR index_columns.partition_ordinal > 0) AND columns.is_computed = 1 AND index_columns.object_id = indexes.object_id AND index_columns.index_id = indexes.index_id) THEN 1 ELSE 0 END AS IsComputed'
 
@@ -1628,7 +1632,8 @@ BEGIN
                                                     + ', NULL AS IsImageText'
                                                     + ', NULL AS IsNewLOB'
                                                     + ', NULL AS IsFileStream'
-                                                    + ', NULL AS HasColumnstore'
+                                                    + ', NULL AS HasClusteredColumnstore'
+                                                    + ', NULL AS HasNonClusteredColumnstore'
                                                     + ', NULL AS IsComputed'
                                                     + ', NULL AS IsClusteredIndexComputed'
                                                     + ', NULL AS IsTimestamp'
@@ -1677,7 +1682,8 @@ BEGIN
                                                       + ', NULL AS IsImageText'
                                                       + ', NULL AS IsNewLOB'
                                                       + ', NULL AS IsFileStream'
-                                                      + ', NULL AS HasColumnstore'
+                                                      + ', NULL AS HasClusteredColumnstore'
+                                                      + ', NULL AS HasNonClusteredColumnstore'
                                                       + ', NULL AS IsComputed'
                                                       + ', NULL AS IsClusteredIndexComputed'
                                                       + ', NULL AS IsTimestamp'
@@ -1707,7 +1713,7 @@ BEGIN
 
         SET @CurrentCommand = @CurrentCommand + ') IndexesStatistics'
 
-        INSERT INTO @tmpIndexesStatistics (SchemaID, SchemaName, ObjectID, ObjectName, ObjectType, IsMemoryOptimized, IndexID, IndexName, IndexType, AllowPageLocks, HasFilter, IsImageText, IsNewLOB, IsFileStream, HasColumnstore, IsComputed, IsClusteredIndexComputed, IsTimestamp, OnReadOnlyFileGroup, ResumableIndexOperation, StatisticsID, StatisticsName, [NoRecompute], IsIncremental, PartitionID, PartitionNumber, PartitionCount, [Order], Selected, Completed)
+        INSERT INTO @tmpIndexesStatistics (SchemaID, SchemaName, ObjectID, ObjectName, ObjectType, IsMemoryOptimized, IndexID, IndexName, IndexType, AllowPageLocks, HasFilter, IsImageText, IsNewLOB, IsFileStream, HasClusteredColumnstore, HasNonClusteredColumnstore, IsComputed, IsClusteredIndexComputed, IsTimestamp, OnReadOnlyFileGroup, ResumableIndexOperation, StatisticsID, StatisticsName, [NoRecompute], IsIncremental, PartitionID, PartitionNumber, PartitionCount, [Order], Selected, Completed)
         EXECUTE @CurrentDatabase_sp_executesql @stmt = @CurrentCommand
         SET @Error = @@ERROR
         IF @Error <> 0
@@ -1811,7 +1817,8 @@ BEGIN
                      @CurrentIsImageText = IsImageText,
                      @CurrentIsNewLOB = IsNewLOB,
                      @CurrentIsFileStream = IsFileStream,
-                     @CurrentHasColumnstore = HasColumnstore,
+                     @CurrentHasClusteredColumnstore = HasClusteredColumnstore,
+                     @CurrentHasNonClusteredColumnstore = HasNonClusteredColumnstore,
                      @CurrentIsComputed = IsComputed,
                      @CurrentIsClusteredIndexComputed = IsClusteredIndexComputed,
                      @CurrentIsTimestamp = IsTimestamp,
@@ -2015,8 +2022,9 @@ BEGIN
           AND NOT (@CurrentIndexType = 4)
           AND NOT (@CurrentIndexType = 5 AND @Version < 15)
           AND NOT (@CurrentIndexType = 6 AND @Version < 14)
-          AND NOT (@CurrentIndexType = 1 AND @CurrentHasColumnstore = 1 AND @Version < 13)
-          AND NOT (@CurrentIndexType = 2 AND @CurrentHasColumnstore = 1 AND @Version < 15)
+          AND NOT (@CurrentIndexType = 1 AND @CurrentHasNonClusteredColumnstore = 1 AND @Version < 13)
+          AND NOT (@CurrentIndexType = 2 AND @CurrentHasClusteredColumnstore = 1 AND @Version < 15)
+          AND NOT (@CurrentIndexType = 2 AND @CurrentHasNonClusteredColumnstore = 1 AND @Version < 13)
           BEGIN
             INSERT INTO @CurrentActionsAllowed ([Action])
             VALUES ('INDEX_REBUILD_ONLINE')
@@ -2104,7 +2112,8 @@ BEGIN
           SET @CurrentComment += 'ImageText: ' + CASE WHEN @CurrentIsImageText = 1 THEN 'Yes' WHEN @CurrentIsImageText = 0 THEN 'No' ELSE 'N/A' END + ', '
           SET @CurrentComment += 'NewLOB: ' + CASE WHEN @CurrentIsNewLOB = 1 THEN 'Yes' WHEN @CurrentIsNewLOB = 0 THEN 'No' ELSE 'N/A' END + ', '
           SET @CurrentComment += 'FileStream: ' + CASE WHEN @CurrentIsFileStream = 1 THEN 'Yes' WHEN @CurrentIsFileStream = 0 THEN 'No' ELSE 'N/A' END + ', '
-          IF @Version >= 11 SET @CurrentComment += 'HasColumnStore: ' + CASE WHEN @CurrentHasColumnstore = 1 THEN 'Yes' WHEN @CurrentHasColumnstore = 0 THEN 'No' ELSE 'N/A' END + ', '
+          IF @Version >= 12 AND @CurrentIndexType NOT IN(5, 6) SET @CurrentComment += 'HasClusteredColumnstore: ' + CASE WHEN @CurrentHasClusteredColumnstore = 1 THEN 'Yes' WHEN @CurrentHasClusteredColumnstore = 0 THEN 'No' ELSE 'N/A' END + ', '
+          IF @Version >= 11 AND @CurrentIndexType NOT IN(5, 6) SET @CurrentComment += 'HasNonClusteredColumnstore: ' + CASE WHEN @CurrentHasNonClusteredColumnstore = 1 THEN 'Yes' WHEN @CurrentHasNonClusteredColumnstore = 0 THEN 'No' ELSE 'N/A' END + ', '
           IF @Version >= 14 AND @Resumable = 'Y' SET @CurrentComment += 'Computed: ' + CASE WHEN @CurrentIsComputed = 1 THEN 'Yes' WHEN @CurrentIsComputed = 0 THEN 'No' ELSE 'N/A' END + ', '
           IF @Version >= 14 AND @Resumable = 'Y' AND @CurrentIndexType = 2 SET @CurrentComment += 'ClusteredIndexComputed: ' + CASE WHEN @CurrentIsClusteredIndexComputed = 1 THEN 'Yes' WHEN @CurrentIsClusteredIndexComputed = 0 THEN 'No' ELSE 'N/A' END + ', '
           IF @Version >= 14 AND @Resumable = 'Y' SET @CurrentComment += 'Timestamp: ' + CASE WHEN @CurrentIsTimestamp = 1 THEN 'Yes' WHEN @CurrentIsTimestamp = 0 THEN 'No' ELSE 'N/A' END + ', '
@@ -2386,7 +2395,8 @@ BEGIN
         SET @CurrentIsImageText = NULL
         SET @CurrentIsNewLOB = NULL
         SET @CurrentIsFileStream = NULL
-        SET @CurrentHasColumnstore = NULL
+        SET @CurrentHasClusteredColumnstore = NULL
+        SET @CurrentHasNonClusteredColumnstore = NULL
         SET @CurrentIsComputed = NULL
         SET @CurrentIsClusteredIndexComputed = NULL
         SET @CurrentIsTimestamp = NULL

--- a/IndexOptimize.sql
+++ b/IndexOptimize.sql
@@ -54,7 +54,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-08 12:16:23                                                               //--
+  --// Version: 2025-06-08 20:41:55                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/IndexOptimize.sql
+++ b/IndexOptimize.sql
@@ -54,7 +54,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-08 22:57:39                                                               //--
+  --// Version: 2025-07-08 19:42:27                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON
@@ -2014,9 +2014,9 @@ BEGIN
           AND NOT (@CurrentIndexType = 3)
           AND NOT (@CurrentIndexType = 4)
           AND NOT (@CurrentIndexType = 5 AND @Version < 15)
-          AND NOT (@CurrentIndexType = 6 AND @Version < 15)
+          AND NOT (@CurrentIndexType = 6 AND @Version < 14)
           AND NOT (@CurrentIndexType = 1 AND @CurrentHasColumnstore = 1 AND @Version < 13)
-          AND NOT (@CurrentIndexType = 2 AND @CurrentHasColumnstore = 1 AND @Version < 13)
+          AND NOT (@CurrentIndexType = 2 AND @CurrentHasColumnstore = 1 AND @Version < 15)
           BEGIN
             INSERT INTO @CurrentActionsAllowed ([Action])
             VALUES ('INDEX_REBUILD_ONLINE')

--- a/IndexOptimize.sql
+++ b/IndexOptimize.sql
@@ -54,7 +54,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-07 21:41:06                                                               //--
+  --// Version: 2025-06-08 12:16:23                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/IndexOptimize.sql
+++ b/IndexOptimize.sql
@@ -54,7 +54,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-08 20:41:55                                                               //--
+  --// Version: 2025-06-08 22:57:39                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/MaintenanceSolution.sql
+++ b/MaintenanceSolution.sql
@@ -10,7 +10,7 @@ License: https://ola.hallengren.com/license.html
 
 GitHub: https://github.com/olahallengren/sql-server-maintenance-solution
 
-Version: 2025-06-08 22:57:39
+Version: 2025-07-08 19:42:27
 
 You can contact me by e-mail at ola@hallengren.com.
 
@@ -137,7 +137,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-08 22:57:39                                                               //--
+  --// Version: 2025-07-08 19:42:27                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON
@@ -485,7 +485,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-08 22:57:39                                                               //--
+  --// Version: 2025-07-08 19:42:27                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON
@@ -574,6 +574,7 @@ BEGIN
   DECLARE @CurrentFGID int
   DECLARE @CurrentFileGroupID int
   DECLARE @CurrentFileGroupName nvarchar(max)
+  DECLARE @CurrentFileGroupType nvarchar(max)
   DECLARE @CurrentFileGroupExists bit
 
   DECLARE @Errors TABLE (ID int IDENTITY PRIMARY KEY,
@@ -622,6 +623,7 @@ BEGIN
   DECLARE @tmpFileGroups TABLE (ID int IDENTITY,
                                 FileGroupID int,
                                 FileGroupName nvarchar(max),
+                                [Type] nvarchar(max),
                                 StartPosition int,
                                 [Order] int,
                                 Selected bit,
@@ -2938,12 +2940,6 @@ BEGIN
     SELECT 'The value for the parameter @DatabasesInParallel is not supported.', 16, 2
   END
 
-  IF @DatabasesInParallel = 'Y' AND @FileGroups IS NOT NULL
-  BEGIN
-    INSERT INTO @Errors ([Message], Severity, [State])
-    SELECT 'The value for the parameter @DatabasesInParallel is not supported. This option is not supported with file group backup.', 16, 3
-  END
-
   ----------------------------------------------------------------------------------------------------
 
   IF @LogToTable NOT IN('Y','N') OR @LogToTable IS NULL
@@ -3295,9 +3291,9 @@ BEGIN
     -- Select filegroups
     IF @FileGroups IS NOT NULL
     BEGIN
-      SET @CurrentCommand = 'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED; SELECT data_space_id AS FileGroupID, name AS FileGroupName, 0 AS [Order], 0 AS Selected, 0 AS Completed FROM ' + QUOTENAME(@CurrentDatabaseName) + '.sys.filegroups filegroups WHERE [type] <> ''FX'' ORDER BY CASE WHEN filegroups.name = ''PRIMARY'' THEN 1 ELSE 0 END DESC, filegroups.name ASC'
+      SET @CurrentCommand = 'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED; SELECT data_space_id AS FileGroupID, name AS FileGroupName, [type], 0 AS [Order], 0 AS Selected, 0 AS Completed FROM ' + QUOTENAME(@CurrentDatabaseName) + '.sys.filegroups filegroups ORDER BY CASE WHEN filegroups.name = ''PRIMARY'' THEN 1 ELSE 0 END DESC, filegroups.name ASC'
 
-      INSERT INTO @tmpFileGroups (FileGroupID, FileGroupName, [Order], Selected, Completed)
+      INSERT INTO @tmpFileGroups (FileGroupID, FileGroupName, [Type], [Order], Selected, Completed)
       EXECUTE sp_executesql @statement = @CurrentCommand
       SET @Error = @@ERROR
       IF @Error <> 0 SET @ReturnCode = @Error
@@ -3589,6 +3585,19 @@ BEGIN
       RAISERROR('%s',10,1,@DatabaseMessage) WITH NOWAIT
     END
 
+    IF EXISTS (SELECT * FROM @tmpFileGroups WHERE [Type] = 'FX')
+    BEGIN
+      IF (EXISTS (SELECT * FROM @tmpFileGroups WHERE [Type] = 'FX' AND Selected = 1)
+      AND NOT EXISTS (SELECT * FROM @tmpFileGroups WHERE FileGroupName = 'PRIMARY' AND Selected = 1))
+      OR (EXISTS (SELECT * FROM @tmpFileGroups WHERE FileGroupName = 'PRIMARY' AND Selected = 1)
+      AND NOT EXISTS (SELECT * FROM @tmpFileGroups WHERE [Type] = 'FX' AND Selected = 1))
+      BEGIN
+        SET @ErrorMessage = + 'The primary and memory-optimized filegroups must be backed up together.'
+        RAISERROR(@ErrorMessage,16,1) WITH NOWAIT
+        SET @Error = @@ERROR
+      END
+    END
+
     RAISERROR(@EmptyLine,10,1) WITH NOWAIT
 
     IF @CurrentDatabaseState = 'ONLINE'
@@ -3609,7 +3618,7 @@ BEGIN
     AND NOT (@CurrentBackupType = 'LOG' AND @LogSizeSinceLastLogBackup IS NOT NULL AND @TimeSinceLastLogBackup IS NOT NULL AND NOT(@CurrentLogSizeSinceLastLogBackup >= @LogSizeSinceLastLogBackup OR @CurrentLogSizeSinceLastLogBackup IS NULL OR DATEDIFF(SECOND,@CurrentLastLogBackup,SYSDATETIME()) >= @TimeSinceLastLogBackup OR @CurrentLastLogBackup IS NULL))
     AND NOT (@CurrentBackupType = 'LOG' AND @Updateability = 'READ_ONLY' AND @BackupSoftware = 'DATA_DOMAIN_BOOST')
     AND NOT (@CurrentBackupType = 'DIFF' AND @MinDatabaseSizeForDifferentialBackup IS NOT NULL AND (COALESCE(CAST(@CurrentAllocatedExtentPageCount AS bigint) * 8192, CAST(@CurrentDatabaseSize AS bigint) * 8192) < CAST(@MinDatabaseSizeForDifferentialBackup AS bigint) * 1024 * 1024))
-    AND NOT (@FileGroups IS NOT NULL AND @CurrentDatabaseName IN ('master','msdb','model'))
+    AND @Error = 0
     BEGIN
 
       WHILE (1 = 1)
@@ -3619,7 +3628,8 @@ BEGIN
         BEGIN
           SELECT TOP 1 @CurrentFGID = ID,
                        @CurrentFileGroupID = FileGroupID,
-                       @CurrentFileGroupName = FileGroupName
+                       @CurrentFileGroupName = FileGroupName,
+                       @CurrentFileGroupType = [Type]
           FROM @tmpFileGroups
           WHERE Selected = 1
           AND Completed = 0
@@ -3632,7 +3642,7 @@ BEGIN
 
           -- Does the filegroup exist?
           SET @CurrentCommand = ''
-          SET @CurrentCommand = @CurrentCommand + 'IF EXISTS(SELECT * FROM ' + QUOTENAME(@CurrentDatabaseName) + '.sys.filegroups filegroups WHERE [type] <> ''FX'' AND filegroups.data_space_id = @ParamFileGroupID AND filegroups.[name] = @ParamFileGroupName) BEGIN SET @ParamFileGroupExists = 1 END'
+          SET @CurrentCommand = @CurrentCommand + 'IF EXISTS(SELECT * FROM ' + QUOTENAME(@CurrentDatabaseName) + '.sys.filegroups filegroups WHERE filegroups.data_space_id = @ParamFileGroupID AND filegroups.[name] = @ParamFileGroupName) BEGIN SET @ParamFileGroupExists = 1 END'
 
           EXECUTE sp_executesql @statement = @CurrentCommand, @params = N'@ParamFileGroupID int, @ParamFileGroupName sysname, @ParamFileGroupExists bit OUTPUT', @ParamFileGroupID = @CurrentFileGroupID, @ParamFileGroupName = @CurrentFileGroupName, @ParamFileGroupExists = @CurrentFileGroupExists OUTPUT
           SET @Error = @@ERROR
@@ -3649,687 +3659,583 @@ BEGIN
           END
         END
 
-        IF @CurrentFileGroupExists = 1 OR @CurrentFileGroupExists IS NULL
+        IF @CurrentBackupType = 'LOG' AND (@CleanupTime IS NOT NULL OR @MirrorCleanupTime IS NOT NULL)
         BEGIN
+          SELECT @CurrentLatestBackup = MAX(backup_start_date)
+          FROM msdb.dbo.backupset
+          WHERE ([type] IN('D','I')
+          OR ([type] = 'L' AND last_lsn < @CurrentDifferentialBaseLSN))
+          AND is_damaged = 0
+          AND [database_name] = @CurrentDatabaseName
+        END
 
-          IF @CurrentBackupType = 'LOG' AND (@CleanupTime IS NOT NULL OR @MirrorCleanupTime IS NOT NULL)
-          BEGIN
-            SELECT @CurrentLatestBackup = MAX(backup_start_date)
-            FROM msdb.dbo.backupset
-            WHERE ([type] IN('D','I')
-            OR ([type] = 'L' AND last_lsn < @CurrentDifferentialBaseLSN))
-            AND is_damaged = 0
-            AND [database_name] = @CurrentDatabaseName
-          END
+        SET @CurrentDate = SYSDATETIME()
+        SET @CurrentDateUTC = SYSUTCDATETIME()
 
-          SET @CurrentDate = SYSDATETIME()
-          SET @CurrentDateUTC = SYSUTCDATETIME()
+        INSERT INTO @CurrentCleanupDates (CleanupDate)
+        SELECT @CurrentDate
 
+        IF @CurrentBackupType = 'LOG'
+        BEGIN
           INSERT INTO @CurrentCleanupDates (CleanupDate)
-          SELECT @CurrentDate
+          SELECT @CurrentLatestBackup
+        END
 
-          IF @CurrentBackupType = 'LOG'
+        SELECT @CurrentDirectoryStructure = CASE
+        WHEN @CurrentAvailabilityGroup IS NOT NULL THEN @AvailabilityGroupDirectoryStructure
+        ELSE @DirectoryStructure
+        END
+
+        IF @CurrentDirectoryStructure IS NOT NULL
+        BEGIN
+        -- Directory structure - remove tokens that are not needed
+          IF @CurrentFileGroupName IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}','')
+          IF @ReadWriteFileGroups = 'N' SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Partial}','')
+          IF @CopyOnly = 'N' SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{CopyOnly}','')
+          IF @Cluster IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}','')
+          IF @CurrentAvailabilityGroup IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}','')
+          IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}','')
+          IF @@SERVICENAME IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServiceName}','')
+          IF @Description IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Description}','')
+          IF @BackupSetName IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupSetName}','')
+
+          IF @Directory IS NULL AND @MirrorDirectory IS NULL AND @URL IS NULL AND @DefaultDirectory LIKE '%' + '.' + @@SERVICENAME + @DirectorySeparator + 'MSSQL' + @DirectorySeparator + 'Backup'
           BEGIN
-            INSERT INTO @CurrentCleanupDates (CleanupDate)
-            SELECT @CurrentLatestBackup
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServerName}','')
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}','')
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}','')
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}','')
           END
-
-          SELECT @CurrentDirectoryStructure = CASE
-          WHEN @CurrentAvailabilityGroup IS NOT NULL THEN @AvailabilityGroupDirectoryStructure
-          ELSE @DirectoryStructure
-          END
-
-          IF @CurrentDirectoryStructure IS NOT NULL
-          BEGIN
-          -- Directory structure - remove tokens that are not needed
-            IF @CurrentFileGroupName IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}','')
-            IF @ReadWriteFileGroups = 'N' SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Partial}','')
-            IF @CopyOnly = 'N' SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{CopyOnly}','')
-            IF @Cluster IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}','')
-            IF @CurrentAvailabilityGroup IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}','')
-            IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}','')
-            IF @@SERVICENAME IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServiceName}','')
-            IF @Description IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Description}','')
-            IF @BackupSetName IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupSetName}','')
-
-            IF @Directory IS NULL AND @MirrorDirectory IS NULL AND @URL IS NULL AND @DefaultDirectory LIKE '%' + '.' + @@SERVICENAME + @DirectorySeparator + 'MSSQL' + @DirectorySeparator + 'Backup'
-            BEGIN
-              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServerName}','')
-              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}','')
-              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}','')
-              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}','')
-            END
-
-            WHILE (@Updated = 1 OR @Updated IS NULL)
-            BEGIN
-              SET @Updated = 0
-
-              IF CHARINDEX('\',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'\','{DirectorySeparator}')
-                SET @Updated = 1
-              END
-
-              IF CHARINDEX('/',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'/','{DirectorySeparator}')
-                SET @Updated = 1
-              END
-
-              IF CHARINDEX('__',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'__','_')
-                SET @Updated = 1
-              END
-
-              IF CHARINDEX('--',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'--','-')
-                SET @Updated = 1
-              END
-
-              IF CHARINDEX('{DirectorySeparator}{DirectorySeparator}',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}{DirectorySeparator}','{DirectorySeparator}')
-                SET @Updated = 1
-              END
-
-              IF CHARINDEX('{DirectorySeparator}$',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}$','{DirectorySeparator}')
-                SET @Updated = 1
-              END
-              IF CHARINDEX('${DirectorySeparator}',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'${DirectorySeparator}','{DirectorySeparator}')
-                SET @Updated = 1
-              END
-
-              IF CHARINDEX('{DirectorySeparator}_',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}_','{DirectorySeparator}')
-                SET @Updated = 1
-              END
-              IF CHARINDEX('_{DirectorySeparator}',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'_{DirectorySeparator}','{DirectorySeparator}')
-                SET @Updated = 1
-              END
-
-              IF CHARINDEX('{DirectorySeparator}-',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}-','{DirectorySeparator}')
-                SET @Updated = 1
-              END
-              IF CHARINDEX('-{DirectorySeparator}',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'-{DirectorySeparator}','{DirectorySeparator}')
-                SET @Updated = 1
-              END
-
-              IF CHARINDEX('_$',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'_$','_')
-                SET @Updated = 1
-              END
-              IF CHARINDEX('$_',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'$_','_')
-                SET @Updated = 1
-              END
-
-              IF CHARINDEX('-$',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'-$','-')
-                SET @Updated = 1
-              END
-              IF CHARINDEX('$-',@CurrentDirectoryStructure) > 0
-              BEGIN
-                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'$-','-')
-                SET @Updated = 1
-              END
-
-              IF LEFT(@CurrentDirectoryStructure,1) = '_'
-              BEGIN
-                SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-                SET @Updated = 1
-              END
-              IF RIGHT(@CurrentDirectoryStructure,1) = '_'
-              BEGIN
-                SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-                SET @Updated = 1
-              END
-
-              IF LEFT(@CurrentDirectoryStructure,1) = '-'
-              BEGIN
-                SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-                SET @Updated = 1
-              END
-              IF RIGHT(@CurrentDirectoryStructure,1) = '-'
-              BEGIN
-                SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-                SET @Updated = 1
-              END
-
-              IF LEFT(@CurrentDirectoryStructure,1) = '$'
-              BEGIN
-                SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-                SET @Updated = 1
-              END
-              IF RIGHT(@CurrentDirectoryStructure,1) = '$'
-              BEGIN
-                SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-                SET @Updated = 1
-              END
-
-              IF LEFT(@CurrentDirectoryStructure,20) = '{DirectorySeparator}'
-              BEGIN
-                SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 20)
-                SET @Updated = 1
-              END
-              IF RIGHT(@CurrentDirectoryStructure,20) = '{DirectorySeparator}'
-              BEGIN
-                SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 20)
-                SET @Updated = 1
-              END
-            END
-
-            SET @Updated = NULL
-
-            -- Directory structure - replace tokens with real values
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}',@DirectorySeparator)
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServerName}',CASE WHEN SERVERPROPERTY('EngineEdition') = 8 THEN LEFT(CAST(SERVERPROPERTY('ServerName') AS nvarchar(max)),CHARINDEX('.',CAST(SERVERPROPERTY('ServerName') AS nvarchar(max))) - 1) ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar(max)) END)
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}',ISNULL(CAST(SERVERPROPERTY('InstanceName') AS nvarchar(max)),''))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServiceName}',ISNULL(@@SERVICENAME,''))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}',ISNULL(@Cluster,''))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}',ISNULL(@CurrentAvailabilityGroup,''))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DatabaseName}',@CurrentDatabaseNameFS)
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}',ISNULL(@CurrentFileGroupName,''))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupType}',@CurrentBackupType)
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Partial}','PARTIAL')
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{CopyOnly}','COPY_ONLY')
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Description}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@Description,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupSetName}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@BackupSetName,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Year}',CAST(DATEPART(YEAR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Month}',RIGHT('0' + CAST(DATEPART(MONTH,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Day}',RIGHT('0' + CAST(DATEPART(DAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Week}',RIGHT('0' + CAST(DATEPART(WEEK,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Weekday}',DATENAME(WEEKDAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Hour}',RIGHT('0' + CAST(DATEPART(HOUR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Minute}',RIGHT('0' + CAST(DATEPART(MINUTE,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Second}',RIGHT('0' + CAST(DATEPART(SECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Millisecond}',RIGHT('00' + CAST(DATEPART(MILLISECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),3))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Microsecond}',RIGHT('00000' + CAST(DATEPART(MICROSECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),6))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{MajorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMajorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4)))
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{MinorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMinorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3)))
-          END
-
-          IF @DirectoryStructureCase IS NOT NULL
-          BEGIN
-            SET @CurrentDirectoryStructure = CASE WHEN @DirectoryStructureCase = 'LOWER' THEN LOWER(@CurrentDirectoryStructure)
-                                                  WHEN @DirectoryStructureCase = 'UPPER' THEN UPPER(@CurrentDirectoryStructure) END
-          END
-
-          INSERT INTO @CurrentDirectories (ID, DirectoryPath, Mirror, DirectoryNumber, CreateCompleted, CleanupCompleted)
-          SELECT ROW_NUMBER() OVER (ORDER BY ID),
-                 DirectoryPath + CASE WHEN DirectoryPath = 'NUL' THEN '' WHEN @CurrentDirectoryStructure IS NOT NULL THEN @DirectorySeparator + @CurrentDirectoryStructure ELSE '' END,
-                 Mirror,
-                 ROW_NUMBER() OVER (PARTITION BY Mirror ORDER BY ID ASC),
-                 0,
-                 0
-          FROM @Directories
-          ORDER BY ID ASC
-
-          INSERT INTO @CurrentURLs (ID, DirectoryPath, Mirror, DirectoryNumber)
-          SELECT ROW_NUMBER() OVER (ORDER BY ID),
-                 DirectoryPath + CASE WHEN @CurrentDirectoryStructure IS NOT NULL THEN @DirectorySeparator + @CurrentDirectoryStructure ELSE '' END,
-                 Mirror,
-                 ROW_NUMBER() OVER (PARTITION BY Mirror ORDER BY ID ASC)
-          FROM @URLs
-          ORDER BY ID ASC
-
-          SELECT @CurrentDatabaseFileName = CASE
-          WHEN @CurrentAvailabilityGroup IS NOT NULL THEN @AvailabilityGroupFileName
-          ELSE @FileName
-          END
-
-          -- File name - remove tokens that are not needed
-          IF @CurrentFileGroupName IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}','')
-          IF @ReadWriteFileGroups = 'N' SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Partial}','')
-          IF @CopyOnly = 'N' SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{CopyOnly}','')
-          IF @Cluster IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ClusterName}','')
-          IF @CurrentAvailabilityGroup IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{AvailabilityGroupName}','')
-          IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{InstanceName}','')
-          IF @@SERVICENAME IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServiceName}','')
-          IF @Description IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Description}','')
-          IF @BackupSetName IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupSetName}','')
-          IF @CurrentNumberOfFiles = 1 SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileNumber}','')
-          IF @CurrentNumberOfFiles = 1 SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{NumberOfFiles}','')
 
           WHILE (@Updated = 1 OR @Updated IS NULL)
           BEGIN
             SET @Updated = 0
 
-            IF CHARINDEX('__',@CurrentDatabaseFileName) > 0
+            IF CHARINDEX('\',@CurrentDirectoryStructure) > 0
             BEGIN
-              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'__','_')
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'\','{DirectorySeparator}')
               SET @Updated = 1
             END
 
-            IF CHARINDEX('--',@CurrentDatabaseFileName) > 0
+            IF CHARINDEX('/',@CurrentDirectoryStructure) > 0
             BEGIN
-              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'--','-')
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'/','{DirectorySeparator}')
               SET @Updated = 1
             END
 
-            IF CHARINDEX('_$',@CurrentDatabaseFileName) > 0
+            IF CHARINDEX('__',@CurrentDirectoryStructure) > 0
             BEGIN
-              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'_$','_')
-              SET @Updated = 1
-            END
-            IF CHARINDEX('$_',@CurrentDatabaseFileName) > 0
-            BEGIN
-              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'$_','_')
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'__','_')
               SET @Updated = 1
             END
 
-            IF CHARINDEX('-$',@CurrentDatabaseFileName) > 0
+            IF CHARINDEX('--',@CurrentDirectoryStructure) > 0
             BEGIN
-              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'-$','-')
-              SET @Updated = 1
-            END
-            IF CHARINDEX('$-',@CurrentDatabaseFileName) > 0
-            BEGIN
-              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'$-','-')
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'--','-')
               SET @Updated = 1
             END
 
-            IF CHARINDEX('_.',@CurrentDatabaseFileName) > 0
+            IF CHARINDEX('{DirectorySeparator}{DirectorySeparator}',@CurrentDirectoryStructure) > 0
             BEGIN
-              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'_.','.')
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}{DirectorySeparator}','{DirectorySeparator}')
               SET @Updated = 1
             END
 
-            IF CHARINDEX('-.',@CurrentDatabaseFileName) > 0
+            IF CHARINDEX('{DirectorySeparator}$',@CurrentDirectoryStructure) > 0
             BEGIN
-              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'-.','.')
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}$','{DirectorySeparator}')
+              SET @Updated = 1
+            END
+            IF CHARINDEX('${DirectorySeparator}',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'${DirectorySeparator}','{DirectorySeparator}')
               SET @Updated = 1
             END
 
-            IF CHARINDEX('of.',@CurrentDatabaseFileName) > 0
+            IF CHARINDEX('{DirectorySeparator}_',@CurrentDirectoryStructure) > 0
             BEGIN
-              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'of.','.')
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}_','{DirectorySeparator}')
+              SET @Updated = 1
+            END
+            IF CHARINDEX('_{DirectorySeparator}',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'_{DirectorySeparator}','{DirectorySeparator}')
               SET @Updated = 1
             END
 
-            IF LEFT(@CurrentDatabaseFileName,1) = '_'
+            IF CHARINDEX('{DirectorySeparator}-',@CurrentDirectoryStructure) > 0
             BEGIN
-              SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}-','{DirectorySeparator}')
               SET @Updated = 1
             END
-            IF RIGHT(@CurrentDatabaseFileName,1) = '_'
+            IF CHARINDEX('-{DirectorySeparator}',@CurrentDirectoryStructure) > 0
             BEGIN
-              SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
-              SET @Updated = 1
-            END
-
-            IF LEFT(@CurrentDatabaseFileName,1) = '-'
-            BEGIN
-              SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
-              SET @Updated = 1
-            END
-            IF RIGHT(@CurrentDatabaseFileName,1) = '-'
-            BEGIN
-              SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'-{DirectorySeparator}','{DirectorySeparator}')
               SET @Updated = 1
             END
 
-            IF LEFT(@CurrentDatabaseFileName,1) = '$'
+            IF CHARINDEX('_$',@CurrentDirectoryStructure) > 0
             BEGIN
-              SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'_$','_')
               SET @Updated = 1
             END
-            IF RIGHT(@CurrentDatabaseFileName,1) = '$'
+            IF CHARINDEX('$_',@CurrentDirectoryStructure) > 0
             BEGIN
-              SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'$_','_')
+              SET @Updated = 1
+            END
+
+            IF CHARINDEX('-$',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'-$','-')
+              SET @Updated = 1
+            END
+            IF CHARINDEX('$-',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'$-','-')
+              SET @Updated = 1
+            END
+
+            IF LEFT(@CurrentDirectoryStructure,1) = '_'
+            BEGIN
+              SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+            IF RIGHT(@CurrentDirectoryStructure,1) = '_'
+            BEGIN
+              SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+
+            IF LEFT(@CurrentDirectoryStructure,1) = '-'
+            BEGIN
+              SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+            IF RIGHT(@CurrentDirectoryStructure,1) = '-'
+            BEGIN
+              SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+
+            IF LEFT(@CurrentDirectoryStructure,1) = '$'
+            BEGIN
+              SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+            IF RIGHT(@CurrentDirectoryStructure,1) = '$'
+            BEGIN
+              SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+
+            IF LEFT(@CurrentDirectoryStructure,20) = '{DirectorySeparator}'
+            BEGIN
+              SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 20)
+              SET @Updated = 1
+            END
+            IF RIGHT(@CurrentDirectoryStructure,20) = '{DirectorySeparator}'
+            BEGIN
+              SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 20)
               SET @Updated = 1
             END
           END
 
           SET @Updated = NULL
 
-          SELECT @CurrentFileExtension = CASE
-          WHEN @CurrentBackupType = 'FULL' THEN @FileExtensionFull
-          WHEN @CurrentBackupType = 'DIFF' THEN @FileExtensionDiff
-          WHEN @CurrentBackupType = 'LOG' THEN @FileExtensionLog
-          END
+          -- Directory structure - replace tokens with real values
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}',@DirectorySeparator)
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServerName}',CASE WHEN SERVERPROPERTY('EngineEdition') = 8 THEN LEFT(CAST(SERVERPROPERTY('ServerName') AS nvarchar(max)),CHARINDEX('.',CAST(SERVERPROPERTY('ServerName') AS nvarchar(max))) - 1) ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar(max)) END)
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}',ISNULL(CAST(SERVERPROPERTY('InstanceName') AS nvarchar(max)),''))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServiceName}',ISNULL(@@SERVICENAME,''))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}',ISNULL(@Cluster,''))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}',ISNULL(@CurrentAvailabilityGroup,''))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DatabaseName}',@CurrentDatabaseNameFS)
 
-          -- File name - replace tokens with real values
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServerName}',CASE WHEN SERVERPROPERTY('EngineEdition') = 8 THEN LEFT(CAST(SERVERPROPERTY('ServerName') AS nvarchar(max)),CHARINDEX('.',CAST(SERVERPROPERTY('ServerName') AS nvarchar(max))) - 1) ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar(max)) END)
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{InstanceName}',ISNULL(CAST(SERVERPROPERTY('InstanceName') AS nvarchar(max)),''))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServiceName}',ISNULL(@@SERVICENAME,''))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ClusterName}',ISNULL(@Cluster,''))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{AvailabilityGroupName}',ISNULL(@CurrentAvailabilityGroup,''))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}',ISNULL(@CurrentFileGroupName,''))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupType}',@CurrentBackupType)
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Partial}','PARTIAL')
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{CopyOnly}','COPY_ONLY')
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Description}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@Description,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupSetName}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@BackupSetName,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Year}',CAST(DATEPART(YEAR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Month}',RIGHT('0' + CAST(DATEPART(MONTH,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Day}',RIGHT('0' + CAST(DATEPART(DAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Week}',RIGHT('0' + CAST(DATEPART(WEEK,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Weekday}',DATENAME(WEEKDAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Hour}',RIGHT('0' + CAST(DATEPART(HOUR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Minute}',RIGHT('0' + CAST(DATEPART(MINUTE,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Second}',RIGHT('0' + CAST(DATEPART(SECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Millisecond}',RIGHT('00' + CAST(DATEPART(MILLISECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),3))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Microsecond}',RIGHT('00000' + CAST(DATEPART(MICROSECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),6))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{NumberOfFiles}',@CurrentNumberOfFiles)
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileExtension}',@CurrentFileExtension)
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{MajorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMajorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4)))
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{MinorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMinorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3)))
-
-          SELECT @CurrentMaxFilePathLength = CASE
-          WHEN EXISTS (SELECT * FROM @CurrentDirectories) THEN (SELECT MAX(LEN(DirectoryPath + @DirectorySeparator)) FROM @CurrentDirectories)
-          WHEN EXISTS (SELECT * FROM @CurrentURLs) THEN (SELECT MAX(LEN(DirectoryPath + @DirectorySeparator)) FROM @CurrentURLs)
-          END
-          + LEN(REPLACE(REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',@CurrentDatabaseNameFS), '{FileNumber}', CASE WHEN @CurrentNumberOfFiles >= 1 AND @CurrentNumberOfFiles <= 9 THEN '1' WHEN @CurrentNumberOfFiles >= 10 THEN '01' END))
-
-          -- The maximum length of a backup device is 259 characters
-          IF @CurrentMaxFilePathLength > 259
+          IF @CurrentFileGroupName = 'PRIMARY' AND EXISTS (SELECT * FROM @tmpFileGroups WHERE [type] = 'FX' AND Selected = 1)
           BEGIN
-            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',LEFT(@CurrentDatabaseNameFS,CASE WHEN (LEN(@CurrentDatabaseNameFS) + 259 - @CurrentMaxFilePathLength - 3) < 20 THEN 20 ELSE (LEN(@CurrentDatabaseNameFS) + 259 - @CurrentMaxFilePathLength - 3) END) + '...')
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}',ISNULL(@CurrentFileGroupName + '_' + (SELECT FileGroupName FROM @tmpFileGroups WHERE [type] = 'FX' AND Selected = 1),''))
           END
           ELSE
           BEGIN
-            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',@CurrentDatabaseNameFS)
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}',ISNULL(@CurrentFileGroupName,''))
           END
 
-          IF @FileNameCase IS NOT NULL
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupType}',@CurrentBackupType)
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Partial}','PARTIAL')
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{CopyOnly}','COPY_ONLY')
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Description}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@Description,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupSetName}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@BackupSetName,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Year}',CAST(DATEPART(YEAR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Month}',RIGHT('0' + CAST(DATEPART(MONTH,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Day}',RIGHT('0' + CAST(DATEPART(DAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Week}',RIGHT('0' + CAST(DATEPART(WEEK,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Weekday}',DATENAME(WEEKDAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Hour}',RIGHT('0' + CAST(DATEPART(HOUR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Minute}',RIGHT('0' + CAST(DATEPART(MINUTE,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Second}',RIGHT('0' + CAST(DATEPART(SECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Millisecond}',RIGHT('00' + CAST(DATEPART(MILLISECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),3))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Microsecond}',RIGHT('00000' + CAST(DATEPART(MICROSECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),6))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{MajorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMajorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4)))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{MinorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMinorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3)))
+        END
+
+        IF @DirectoryStructureCase IS NOT NULL
+        BEGIN
+          SET @CurrentDirectoryStructure = CASE WHEN @DirectoryStructureCase = 'LOWER' THEN LOWER(@CurrentDirectoryStructure)
+                                                WHEN @DirectoryStructureCase = 'UPPER' THEN UPPER(@CurrentDirectoryStructure) END
+        END
+
+        INSERT INTO @CurrentDirectories (ID, DirectoryPath, Mirror, DirectoryNumber, CreateCompleted, CleanupCompleted)
+        SELECT ROW_NUMBER() OVER (ORDER BY ID),
+               DirectoryPath + CASE WHEN DirectoryPath = 'NUL' THEN '' WHEN @CurrentDirectoryStructure IS NOT NULL THEN @DirectorySeparator + @CurrentDirectoryStructure ELSE '' END,
+               Mirror,
+               ROW_NUMBER() OVER (PARTITION BY Mirror ORDER BY ID ASC),
+               0,
+               0
+        FROM @Directories
+        ORDER BY ID ASC
+
+        INSERT INTO @CurrentURLs (ID, DirectoryPath, Mirror, DirectoryNumber)
+        SELECT ROW_NUMBER() OVER (ORDER BY ID),
+               DirectoryPath + CASE WHEN @CurrentDirectoryStructure IS NOT NULL THEN @DirectorySeparator + @CurrentDirectoryStructure ELSE '' END,
+               Mirror,
+               ROW_NUMBER() OVER (PARTITION BY Mirror ORDER BY ID ASC)
+        FROM @URLs
+        ORDER BY ID ASC
+
+        SELECT @CurrentDatabaseFileName = CASE
+        WHEN @CurrentAvailabilityGroup IS NOT NULL THEN @AvailabilityGroupFileName
+        ELSE @FileName
+        END
+
+        -- File name - remove tokens that are not needed
+        IF @CurrentFileGroupName IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}','')
+        IF @ReadWriteFileGroups = 'N' SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Partial}','')
+        IF @CopyOnly = 'N' SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{CopyOnly}','')
+        IF @Cluster IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ClusterName}','')
+        IF @CurrentAvailabilityGroup IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{AvailabilityGroupName}','')
+        IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{InstanceName}','')
+        IF @@SERVICENAME IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServiceName}','')
+        IF @Description IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Description}','')
+        IF @BackupSetName IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupSetName}','')
+        IF @CurrentNumberOfFiles = 1 SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileNumber}','')
+        IF @CurrentNumberOfFiles = 1 SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{NumberOfFiles}','')
+
+        WHILE (@Updated = 1 OR @Updated IS NULL)
+        BEGIN
+          SET @Updated = 0
+
+          IF CHARINDEX('__',@CurrentDatabaseFileName) > 0
           BEGIN
-            SET @CurrentDatabaseFileName = CASE WHEN @FileNameCase = 'LOWER' THEN LOWER(@CurrentDatabaseFileName)
-                                                WHEN @FileNameCase = 'UPPER' THEN UPPER(@CurrentDatabaseFileName) END
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'__','_')
+            SET @Updated = 1
           END
 
-          IF EXISTS (SELECT * FROM @CurrentDirectories WHERE Mirror = 0)
+          IF CHARINDEX('--',@CurrentDatabaseFileName) > 0
           BEGIN
-            SET @CurrentFileNumber = 0
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'--','-')
+            SET @Updated = 1
+          END
 
-            WHILE @CurrentFileNumber < @CurrentNumberOfFiles
+          IF CHARINDEX('_$',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'_$','_')
+            SET @Updated = 1
+          END
+          IF CHARINDEX('$_',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'$_','_')
+            SET @Updated = 1
+          END
+
+          IF CHARINDEX('-$',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'-$','-')
+            SET @Updated = 1
+          END
+          IF CHARINDEX('$-',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'$-','-')
+            SET @Updated = 1
+          END
+
+          IF CHARINDEX('_.',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'_.','.')
+            SET @Updated = 1
+          END
+
+          IF CHARINDEX('-.',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'-.','.')
+            SET @Updated = 1
+          END
+
+          IF CHARINDEX('of.',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'of.','.')
+            SET @Updated = 1
+          END
+
+          IF LEFT(@CurrentDatabaseFileName,1) = '_'
+          BEGIN
+            SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+          IF RIGHT(@CurrentDatabaseFileName,1) = '_'
+          BEGIN
+            SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+
+          IF LEFT(@CurrentDatabaseFileName,1) = '-'
+          BEGIN
+            SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+          IF RIGHT(@CurrentDatabaseFileName,1) = '-'
+          BEGIN
+            SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+
+          IF LEFT(@CurrentDatabaseFileName,1) = '$'
+          BEGIN
+            SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+          IF RIGHT(@CurrentDatabaseFileName,1) = '$'
+          BEGIN
+            SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+        END
+
+        SET @Updated = NULL
+
+        SELECT @CurrentFileExtension = CASE
+        WHEN @CurrentBackupType = 'FULL' THEN @FileExtensionFull
+        WHEN @CurrentBackupType = 'DIFF' THEN @FileExtensionDiff
+        WHEN @CurrentBackupType = 'LOG' THEN @FileExtensionLog
+        END
+
+        -- File name - replace tokens with real values
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServerName}',CASE WHEN SERVERPROPERTY('EngineEdition') = 8 THEN LEFT(CAST(SERVERPROPERTY('ServerName') AS nvarchar(max)),CHARINDEX('.',CAST(SERVERPROPERTY('ServerName') AS nvarchar(max))) - 1) ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar(max)) END)
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{InstanceName}',ISNULL(CAST(SERVERPROPERTY('InstanceName') AS nvarchar(max)),''))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServiceName}',ISNULL(@@SERVICENAME,''))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ClusterName}',ISNULL(@Cluster,''))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{AvailabilityGroupName}',ISNULL(@CurrentAvailabilityGroup,''))
+
+        IF @CurrentFileGroupName = 'PRIMARY' AND EXISTS (SELECT * FROM @tmpFileGroups WHERE [type] = 'FX' AND Selected = 1)
+        BEGIN
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}',ISNULL(@CurrentFileGroupName + '_' + (SELECT FileGroupName FROM @tmpFileGroups WHERE [type] = 'FX' AND Selected = 1),''))
+        END
+        ELSE
+        BEGIN
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}',ISNULL(@CurrentFileGroupName,''))
+        END
+
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupType}',@CurrentBackupType)
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Partial}','PARTIAL')
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{CopyOnly}','COPY_ONLY')
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Description}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@Description,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupSetName}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@BackupSetName,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Year}',CAST(DATEPART(YEAR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Month}',RIGHT('0' + CAST(DATEPART(MONTH,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Day}',RIGHT('0' + CAST(DATEPART(DAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Week}',RIGHT('0' + CAST(DATEPART(WEEK,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Weekday}',DATENAME(WEEKDAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Hour}',RIGHT('0' + CAST(DATEPART(HOUR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Minute}',RIGHT('0' + CAST(DATEPART(MINUTE,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Second}',RIGHT('0' + CAST(DATEPART(SECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Millisecond}',RIGHT('00' + CAST(DATEPART(MILLISECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),3))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Microsecond}',RIGHT('00000' + CAST(DATEPART(MICROSECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),6))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{NumberOfFiles}',@CurrentNumberOfFiles)
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileExtension}',@CurrentFileExtension)
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{MajorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMajorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4)))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{MinorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMinorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3)))
+
+        SELECT @CurrentMaxFilePathLength = CASE
+        WHEN EXISTS (SELECT * FROM @CurrentDirectories) THEN (SELECT MAX(LEN(DirectoryPath + @DirectorySeparator)) FROM @CurrentDirectories)
+        WHEN EXISTS (SELECT * FROM @CurrentURLs) THEN (SELECT MAX(LEN(DirectoryPath + @DirectorySeparator)) FROM @CurrentURLs)
+        END
+        + LEN(REPLACE(REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',@CurrentDatabaseNameFS), '{FileNumber}', CASE WHEN @CurrentNumberOfFiles >= 1 AND @CurrentNumberOfFiles <= 9 THEN '1' WHEN @CurrentNumberOfFiles >= 10 THEN '01' END))
+
+        -- The maximum length of a backup device is 259 characters
+        IF @CurrentMaxFilePathLength > 259
+        BEGIN
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',LEFT(@CurrentDatabaseNameFS,CASE WHEN (LEN(@CurrentDatabaseNameFS) + 259 - @CurrentMaxFilePathLength - 3) < 20 THEN 20 ELSE (LEN(@CurrentDatabaseNameFS) + 259 - @CurrentMaxFilePathLength - 3) END) + '...')
+        END
+        ELSE
+        BEGIN
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',@CurrentDatabaseNameFS)
+        END
+
+        IF @FileNameCase IS NOT NULL
+        BEGIN
+          SET @CurrentDatabaseFileName = CASE WHEN @FileNameCase = 'LOWER' THEN LOWER(@CurrentDatabaseFileName)
+                                              WHEN @FileNameCase = 'UPPER' THEN UPPER(@CurrentDatabaseFileName) END
+        END
+
+        IF EXISTS (SELECT * FROM @CurrentDirectories WHERE Mirror = 0)
+        BEGIN
+          SET @CurrentFileNumber = 0
+
+          WHILE @CurrentFileNumber < @CurrentNumberOfFiles
+          BEGIN
+            SET @CurrentFileNumber = @CurrentFileNumber + 1
+
+            SELECT @CurrentDirectoryPath = DirectoryPath
+            FROM @CurrentDirectories
+            WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 0) + 1
+            AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 0)
+            AND Mirror = 0
+
+            SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles >= 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) END)
+
+            IF @CurrentDirectoryPath = 'NUL'
             BEGIN
-              SET @CurrentFileNumber = @CurrentFileNumber + 1
-
-              SELECT @CurrentDirectoryPath = DirectoryPath
-              FROM @CurrentDirectories
-              WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 0) + 1
-              AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 0)
-              AND Mirror = 0
-
-              SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles >= 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) END)
-
-              IF @CurrentDirectoryPath = 'NUL'
-              BEGIN
-                SET @CurrentFilePath = 'NUL'
-              END
-              ELSE
-              BEGIN
-                SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
-              END
-
-              INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
-              SELECT 'DISK', @CurrentFilePath, 0
-
-              SET @CurrentDirectoryPath = NULL
-              SET @CurrentFileName = NULL
-              SET @CurrentFilePath = NULL
+              SET @CurrentFilePath = 'NUL'
             END
-
-            INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
-            SELECT 0, 0
-          END
-
-          IF EXISTS (SELECT * FROM @CurrentDirectories WHERE Mirror = 1)
-          BEGIN
-            SET @CurrentFileNumber = 0
-
-            WHILE @CurrentFileNumber < @CurrentNumberOfFiles
+            ELSE
             BEGIN
-              SET @CurrentFileNumber = @CurrentFileNumber + 1
-
-              SELECT @CurrentDirectoryPath = DirectoryPath
-              FROM @CurrentDirectories
-              WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 1) + 1
-              AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 1)
-              AND Mirror = 1
-
-              SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
-
               SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
-
-              INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
-              SELECT 'DISK', @CurrentFilePath, 1
-
-              SET @CurrentDirectoryPath = NULL
-              SET @CurrentFileName = NULL
-              SET @CurrentFilePath = NULL
             END
 
-            INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
-            SELECT 1, 0
+            INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
+            SELECT 'DISK', @CurrentFilePath, 0
+
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentFileName = NULL
+            SET @CurrentFilePath = NULL
           END
 
-          IF EXISTS (SELECT * FROM @CurrentURLs WHERE Mirror = 0)
+          INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
+          SELECT 0, 0
+        END
+
+        IF EXISTS (SELECT * FROM @CurrentDirectories WHERE Mirror = 1)
+        BEGIN
+          SET @CurrentFileNumber = 0
+
+          WHILE @CurrentFileNumber < @CurrentNumberOfFiles
           BEGIN
-            SET @CurrentFileNumber = 0
+            SET @CurrentFileNumber = @CurrentFileNumber + 1
 
-            WHILE @CurrentFileNumber < @CurrentNumberOfFiles
+            SELECT @CurrentDirectoryPath = DirectoryPath
+            FROM @CurrentDirectories
+            WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 1) + 1
+            AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 1)
+            AND Mirror = 1
+
+            SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
+
+            SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
+
+            INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
+            SELECT 'DISK', @CurrentFilePath, 1
+
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentFileName = NULL
+            SET @CurrentFilePath = NULL
+          END
+
+          INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
+          SELECT 1, 0
+        END
+
+        IF EXISTS (SELECT * FROM @CurrentURLs WHERE Mirror = 0)
+        BEGIN
+          SET @CurrentFileNumber = 0
+
+          WHILE @CurrentFileNumber < @CurrentNumberOfFiles
+          BEGIN
+            SET @CurrentFileNumber = @CurrentFileNumber + 1
+
+            SELECT @CurrentDirectoryPath = DirectoryPath
+            FROM @CurrentURLs
+            WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0) + 1
+            AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0)
+            AND Mirror = 0
+
+            SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
+
+            SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
+
+            INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
+            SELECT 'URL', @CurrentFilePath, 0
+
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentFileName = NULL
+            SET @CurrentFilePath = NULL
+          END
+
+          INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
+          SELECT 0, 0
+        END
+
+        IF EXISTS (SELECT * FROM @CurrentURLs WHERE Mirror = 1)
+        BEGIN
+          SET @CurrentFileNumber = 0
+
+          WHILE @CurrentFileNumber < @CurrentNumberOfFiles
+          BEGIN
+            SET @CurrentFileNumber = @CurrentFileNumber + 1
+
+            SELECT @CurrentDirectoryPath = DirectoryPath
+            FROM @CurrentURLs
+            WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0) + 1
+            AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0)
+            AND Mirror = 1
+
+            SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
+
+            SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
+
+            INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
+            SELECT 'URL', @CurrentFilePath, 1
+
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentFileName = NULL
+            SET @CurrentFilePath = NULL
+          END
+
+          INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
+          SELECT 1, 0
+        END
+
+        -- Create directory
+        IF @HostPlatform = 'Windows'
+        AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
+        AND NOT EXISTS(SELECT * FROM @CurrentDirectories WHERE DirectoryPath = 'NUL' OR DirectoryPath IN(SELECT DirectoryPath FROM @Directories))
+        BEGIN
+          WHILE (1 = 1)
+          BEGIN
+            SELECT TOP 1 @CurrentDirectoryID = ID,
+                         @CurrentDirectoryPath = DirectoryPath
+            FROM @CurrentDirectories
+            WHERE CreateCompleted = 0
+            ORDER BY ID ASC
+
+            IF @@ROWCOUNT = 0
             BEGIN
-              SET @CurrentFileNumber = @CurrentFileNumber + 1
-
-              SELECT @CurrentDirectoryPath = DirectoryPath
-              FROM @CurrentURLs
-              WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0) + 1
-              AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0)
-              AND Mirror = 0
-
-              SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
-
-              SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
-
-              INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
-              SELECT 'URL', @CurrentFilePath, 0
-
-              SET @CurrentDirectoryPath = NULL
-              SET @CurrentFileName = NULL
-              SET @CurrentFilePath = NULL
+              BREAK
             END
 
-            INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
-            SELECT 0, 0
-          END
-
-          IF EXISTS (SELECT * FROM @CurrentURLs WHERE Mirror = 1)
-          BEGIN
-            SET @CurrentFileNumber = 0
-
-            WHILE @CurrentFileNumber < @CurrentNumberOfFiles
+            IF @DirectoryCheck = 'Y'
             BEGIN
-              SET @CurrentFileNumber = @CurrentFileNumber + 1
-
-              SELECT @CurrentDirectoryPath = DirectoryPath
-              FROM @CurrentURLs
-              WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0) + 1
-              AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0)
-              AND Mirror = 1
-
-              SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
-
-              SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
-
-              INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
-              SELECT 'URL', @CurrentFilePath, 1
-
-              SET @CurrentDirectoryPath = NULL
-              SET @CurrentFileName = NULL
-              SET @CurrentFilePath = NULL
+              INSERT INTO @DirectoryInfo (FileExists, FileIsADirectory, ParentDirectoryExists)
+              EXECUTE [master].dbo.xp_fileexist @CurrentDirectoryPath
             END
 
-            INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
-            SELECT 1, 0
-          END
-
-          -- Create directory
-          IF @HostPlatform = 'Windows'
-          AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
-          AND NOT EXISTS(SELECT * FROM @CurrentDirectories WHERE DirectoryPath = 'NUL' OR DirectoryPath IN(SELECT DirectoryPath FROM @Directories))
-          BEGIN
-            WHILE (1 = 1)
+            IF NOT EXISTS (SELECT * FROM @DirectoryInfo WHERE FileExists = 0 AND FileIsADirectory = 1 AND ParentDirectoryExists = 1)
             BEGIN
-              SELECT TOP 1 @CurrentDirectoryID = ID,
-                           @CurrentDirectoryPath = DirectoryPath
-              FROM @CurrentDirectories
-              WHERE CreateCompleted = 0
-              ORDER BY ID ASC
+              SET @CurrentDatabaseContext = 'master'
 
-              IF @@ROWCOUNT = 0
-              BEGIN
-                BREAK
-              END
+              SET @CurrentCommandType = 'xp_create_subdir'
 
-              IF @DirectoryCheck = 'Y'
-              BEGIN
-                INSERT INTO @DirectoryInfo (FileExists, FileIsADirectory, ParentDirectoryExists)
-                EXECUTE [master].dbo.xp_fileexist @CurrentDirectoryPath
-              END
-
-              IF NOT EXISTS (SELECT * FROM @DirectoryInfo WHERE FileExists = 0 AND FileIsADirectory = 1 AND ParentDirectoryExists = 1)
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'xp_create_subdir'
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_create_subdir N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''' IF @ReturnCode <> 0 RAISERROR(''Error creating directory.'', 16, 1)'
-
-                EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
-                SET @Error = @@ERROR
-                IF @Error <> 0 SET @CurrentCommandOutput = @Error
-                IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
-
-                UPDATE @CurrentDirectories
-                SET CreateCompleted = 1,
-                    CreateOutput = @CurrentCommandOutput
-                WHERE ID = @CurrentDirectoryID
-              END
-              ELSE
-              BEGIN
-                UPDATE @CurrentDirectories
-                SET CreateCompleted = 1,
-                    CreateOutput = 0
-                WHERE ID = @CurrentDirectoryID
-              END
-
-              SET @CurrentDirectoryID = NULL
-              SET @CurrentDirectoryPath = NULL
-
-              SET @CurrentDatabaseContext = NULL
-              SET @CurrentCommand = NULL
-              SET @CurrentCommandOutput = NULL
-              SET @CurrentCommandType = NULL
-
-              DELETE FROM @DirectoryInfo
-            END
-          END
-
-          IF @CleanupMode = 'BEFORE_BACKUP'
-          BEGIN
-            INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
-            SELECT DATEADD(hh,-(@CleanupTime),SYSDATETIME()), 0
-
-            IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 0 OR Mirror IS NULL) AND CleanupDate IS NULL)
-            BEGIN
-              UPDATE @CurrentDirectories
-              SET CleanupDate = (SELECT MIN(CleanupDate)
-                                 FROM @CurrentCleanupDates
-                                 WHERE (Mirror = 0 OR Mirror IS NULL)),
-                  CleanupMode = 'BEFORE_BACKUP'
-              WHERE Mirror = 0
-            END
-          END
-
-          IF @MirrorCleanupMode = 'BEFORE_BACKUP'
-          BEGIN
-            INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
-            SELECT DATEADD(hh,-(@MirrorCleanupTime),SYSDATETIME()), 1
-
-            IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 1 OR Mirror IS NULL) AND CleanupDate IS NULL)
-            BEGIN
-              UPDATE @CurrentDirectories
-              SET CleanupDate = (SELECT MIN(CleanupDate)
-                                 FROM @CurrentCleanupDates
-                                 WHERE (Mirror = 1 OR Mirror IS NULL)),
-                  CleanupMode = 'BEFORE_BACKUP'
-              WHERE Mirror = 1
-            END
-          END
-
-          -- Delete old backup files, before backup
-          IF (NOT EXISTS (SELECT * FROM @CurrentDirectories WHERE CreateOutput <> 0 OR CreateOutput IS NULL) OR @HostPlatform = 'Linux')
-          AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
-          AND @CurrentBackupType = @BackupType
-          BEGIN
-            WHILE (1 = 1)
-            BEGIN
-              SELECT TOP 1 @CurrentDirectoryID = ID,
-                           @CurrentDirectoryPath = DirectoryPath,
-                           @CurrentCleanupDate = CleanupDate
-              FROM @CurrentDirectories
-              WHERE CleanupDate IS NOT NULL
-              AND CleanupMode = 'BEFORE_BACKUP'
-              AND CleanupCompleted = 0
-              ORDER BY ID ASC
-
-              IF @@ROWCOUNT = 0
-              BEGIN
-                BREAK
-              END
-
-              IF @BackupSoftware IS NULL
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'xp_delete_file'
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_delete_file 0, N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + @CurrentFileExtension + ''', ''' + CONVERT(nvarchar(19),@CurrentCleanupDate,126) + ''' IF @ReturnCode <> 0 RAISERROR(''Error deleting files.'', 16, 1)'
-              END
-
-              IF @BackupSoftware = 'LITESPEED'
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'xp_slssqlmaint'
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_slssqlmaint N''-MAINTDEL -DELFOLDER "' + REPLACE(@CurrentDirectoryPath,'''','''''') + '" -DELEXTENSION "' + @CurrentFileExtension + '" -DELUNIT "' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + '" -DELUNITTYPE "minutes" -DELUSEAGE'' IF @ReturnCode <> 0 RAISERROR(''Error deleting LiteSpeed backup files.'', 16, 1)'
-              END
-
-              IF @BackupSoftware = 'SQLBACKUP'
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'sqbutility'
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqbutility 1032, N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''', N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + CASE WHEN @CurrentBackupType = 'FULL' THEN 'D' WHEN @CurrentBackupType = 'DIFF' THEN 'I' WHEN @CurrentBackupType = 'LOG' THEN 'L' END + ''', ''' + CAST(DATEDIFF(hh,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'h'', ' + ISNULL('''' + REPLACE(@EncryptionKey,'''','''''') + '''','NULL') + ' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLBackup backup files.'', 16, 1)'
-              END
-
-              IF @BackupSoftware = 'SQLSAFE'
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'xp_ss_delete'
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_delete @filename = N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + '\*.' + @CurrentFileExtension + ''', @age = ''' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'Minutes'' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLsafe backup files.'', 16, 1)'
-              END
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_create_subdir N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''' IF @ReturnCode <> 0 RAISERROR(''Error creating directory.'', 16, 1)'
 
               EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
               SET @Error = @@ERROR
@@ -4337,164 +4243,486 @@ BEGIN
               IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
 
               UPDATE @CurrentDirectories
-              SET CleanupCompleted = 1,
-                  CleanupOutput = @CurrentCommandOutput
+              SET CreateCompleted = 1,
+                  CreateOutput = @CurrentCommandOutput
               WHERE ID = @CurrentDirectoryID
-
-              SET @CurrentDirectoryID = NULL
-              SET @CurrentDirectoryPath = NULL
-              SET @CurrentCleanupDate = NULL
-
-              SET @CurrentDatabaseContext = NULL
-              SET @CurrentCommand = NULL
-              SET @CurrentCommandOutput = NULL
-              SET @CurrentCommandType = NULL
             END
-          END
+            ELSE
+            BEGIN
+              UPDATE @CurrentDirectories
+              SET CreateCompleted = 1,
+                  CreateOutput = 0
+              WHERE ID = @CurrentDirectoryID
+            END
 
-          -- Perform a backup
-          IF NOT EXISTS (SELECT * FROM @CurrentDirectories WHERE DirectoryPath <> 'NUL' AND DirectoryPath NOT IN(SELECT DirectoryPath FROM @Directories) AND (CreateOutput <> 0 OR CreateOutput IS NULL))
-          OR @HostPlatform = 'Linux'
+            SET @CurrentDirectoryID = NULL
+            SET @CurrentDirectoryPath = NULL
+
+            SET @CurrentDatabaseContext = NULL
+            SET @CurrentCommand = NULL
+            SET @CurrentCommandOutput = NULL
+            SET @CurrentCommandType = NULL
+
+            DELETE FROM @DirectoryInfo
+          END
+        END
+
+        IF @CleanupMode = 'BEFORE_BACKUP'
+        BEGIN
+          INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
+          SELECT DATEADD(hh,-(@CleanupTime),SYSDATETIME()), 0
+
+          IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 0 OR Mirror IS NULL) AND CleanupDate IS NULL)
           BEGIN
+            UPDATE @CurrentDirectories
+            SET CleanupDate = (SELECT MIN(CleanupDate)
+                               FROM @CurrentCleanupDates
+                               WHERE (Mirror = 0 OR Mirror IS NULL)),
+                CleanupMode = 'BEFORE_BACKUP'
+            WHERE Mirror = 0
+          END
+        END
+
+        IF @MirrorCleanupMode = 'BEFORE_BACKUP'
+        BEGIN
+          INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
+          SELECT DATEADD(hh,-(@MirrorCleanupTime),SYSDATETIME()), 1
+
+          IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 1 OR Mirror IS NULL) AND CleanupDate IS NULL)
+          BEGIN
+            UPDATE @CurrentDirectories
+            SET CleanupDate = (SELECT MIN(CleanupDate)
+                               FROM @CurrentCleanupDates
+                               WHERE (Mirror = 1 OR Mirror IS NULL)),
+                CleanupMode = 'BEFORE_BACKUP'
+            WHERE Mirror = 1
+          END
+        END
+
+        -- Delete old backup files, before backup
+        IF (NOT EXISTS (SELECT * FROM @CurrentDirectories WHERE CreateOutput <> 0 OR CreateOutput IS NULL) OR @HostPlatform = 'Linux')
+        AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
+        AND @CurrentBackupType = @BackupType
+        BEGIN
+          WHILE (1 = 1)
+          BEGIN
+            SELECT TOP 1 @CurrentDirectoryID = ID,
+                         @CurrentDirectoryPath = DirectoryPath,
+                         @CurrentCleanupDate = CleanupDate
+            FROM @CurrentDirectories
+            WHERE CleanupDate IS NOT NULL
+            AND CleanupMode = 'BEFORE_BACKUP'
+            AND CleanupCompleted = 0
+            ORDER BY ID ASC
+
+            IF @@ROWCOUNT = 0
+            BEGIN
+              BREAK
+            END
+
             IF @BackupSoftware IS NULL
             BEGIN
               SET @CurrentDatabaseContext = 'master'
 
-              SELECT @CurrentCommandType = CASE
-              WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP_DATABASE'
-              WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP_LOG'
-              END
+              SET @CurrentCommandType = 'xp_delete_file'
 
-              SELECT @CurrentCommand = CASE
-              WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP DATABASE ' + QUOTENAME(@CurrentDatabaseName)
-              WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP LOG ' + QUOTENAME(@CurrentDatabaseName)
-              END
-
-              IF @FileGroups IS NOT NULL SET @CurrentCommand += ' FILEGROUP = ''' + @CurrentFileGroupName + ''''
-
-              IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' READ_WRITE_FILEGROUPS'
-
-              SET @CurrentCommand += ' TO'
-
-              SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
-              FROM @CurrentFiles
-              WHERE Mirror = 0
-              ORDER BY FilePath ASC
-
-              IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
-              BEGIN
-                SET @CurrentCommand += ' MIRROR TO'
-
-                SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
-                FROM @CurrentFiles
-                WHERE Mirror = 1
-                ORDER BY FilePath ASC
-              END
-
-              SET @CurrentCommand += ' WITH '
-              IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
-              IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
-
-              IF @Version >= 10
-              BEGIN
-                SET @CurrentCommand += CASE WHEN @Compress = 'Y' AND (@CurrentIsEncrypted = 0 OR (@CurrentIsEncrypted = 1 AND ((@Version >= 13 AND @CurrentMaxTransferSize >= 65537) OR @Version >= 15.0404316 OR SERVERPROPERTY('EngineEdition') = 8))) THEN ', COMPRESSION' ELSE ', NO_COMPRESSION' END
-              END
-
-              IF @Compress = 'Y' AND @CompressionAlgorithm IS NOT NULL
-              BEGIN
-                SET @CurrentCommand += ' (ALGORITHM = ' + @CompressionAlgorithm + CASE WHEN @CompressionLevel IS NOT NULL THEN ', LEVEL = ' + @CompressionLevel ELSE '' END + ')'
-              END
-
-              IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
-
-              IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
-              BEGIN
-                SET @CurrentCommand += ', FORMAT'
-              END
-
-              IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
-              IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
-              IF @Init = 'Y' SET @CurrentCommand += ', INIT'
-              IF @Format = 'Y' SET @CurrentCommand += ', FORMAT'
-              IF @BlockSize IS NOT NULL SET @CurrentCommand += ', BLOCKSIZE = ' + CAST(@BlockSize AS nvarchar)
-              IF @BufferCount IS NOT NULL SET @CurrentCommand += ', BUFFERCOUNT = ' + CAST(@BufferCount AS nvarchar)
-              IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', MAXTRANSFERSIZE = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
-              IF @Description IS NOT NULL SET @CurrentCommand += ', DESCRIPTION = N''' + REPLACE(@Description,'''','''''') + ''''
-              IF @BackupSetName IS NOT NULL SET @CurrentCommand += ', NAME = N''' + REPLACE(@BackupSetName,'''','''''') + ''''
-              IF @Stats IS NOT NULL SET @CurrentCommand += ', STATS = ' + CAST(@Stats AS nvarchar)
-              IF @BackupOptions IS NOT NULL SET @CurrentCommand += ', BACKUP_OPTIONS = N''' + REPLACE(@BackupOptions,'''','''''') + ''''
-              IF @Encrypt = 'Y' SET @CurrentCommand += ', ENCRYPTION (ALGORITHM = ' + UPPER(@EncryptionAlgorithm) + ', '
-              IF @Encrypt = 'Y' AND @ServerCertificate IS NOT NULL SET @CurrentCommand += 'SERVER CERTIFICATE = ' + QUOTENAME(@ServerCertificate)
-              IF @Encrypt = 'Y' AND @ServerAsymmetricKey IS NOT NULL SET @CurrentCommand += 'SERVER ASYMMETRIC KEY = ' + QUOTENAME(@ServerAsymmetricKey)
-              IF @Encrypt = 'Y' SET @CurrentCommand += ')'
-              IF @URL IS NOT NULL AND @Credential IS NOT NULL SET @CurrentCommand += ', CREDENTIAL = N''' + REPLACE(@Credential,'''','''''') + ''''
-              IF @ExpireDate IS NOT NULL SET @CurrentCommand += ', EXPIREDATE = ''' + CONVERT(nvarchar, @ExpireDate, 21) + ''''
-              IF @RetainDays IS NOT NULL SET @CurrentCommand += ', RETAINDAYS = ' + CAST(@RetainDays AS nvarchar)
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_delete_file 0, N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + @CurrentFileExtension + ''', ''' + CONVERT(nvarchar(19),@CurrentCleanupDate,126) + ''' IF @ReturnCode <> 0 RAISERROR(''Error deleting files.'', 16, 1)'
             END
 
             IF @BackupSoftware = 'LITESPEED'
             BEGIN
               SET @CurrentDatabaseContext = 'master'
 
-              SELECT @CurrentCommandType = CASE
-              WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'xp_backup_database'
-              WHEN @CurrentBackupType = 'LOG' THEN 'xp_backup_log'
-              END
+              SET @CurrentCommandType = 'xp_slssqlmaint'
 
-              SELECT @CurrentCommand = CASE
-              WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_backup_database @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
-              WHEN @CurrentBackupType = 'LOG' THEN 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_backup_log @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
-              END
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_slssqlmaint N''-MAINTDEL -DELFOLDER "' + REPLACE(@CurrentDirectoryPath,'''','''''') + '" -DELEXTENSION "' + @CurrentFileExtension + '" -DELUNIT "' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + '" -DELUNITTYPE "minutes" -DELUSEAGE'' IF @ReturnCode <> 0 RAISERROR(''Error deleting LiteSpeed backup files.'', 16, 1)'
+            END
 
-              SELECT @CurrentCommand += ', @filename = N''' + REPLACE(FilePath,'''','''''') + ''''
+            IF @BackupSoftware = 'SQLBACKUP'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'sqbutility'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqbutility 1032, N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''', N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + CASE WHEN @CurrentBackupType = 'FULL' THEN 'D' WHEN @CurrentBackupType = 'DIFF' THEN 'I' WHEN @CurrentBackupType = 'LOG' THEN 'L' END + ''', ''' + CAST(DATEDIFF(hh,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'h'', ' + ISNULL('''' + REPLACE(@EncryptionKey,'''','''''') + '''','NULL') + ' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLBackup backup files.'', 16, 1)'
+            END
+
+            IF @BackupSoftware = 'SQLSAFE'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_ss_delete'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_delete @filename = N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + '\*.' + @CurrentFileExtension + ''', @age = ''' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'Minutes'' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLsafe backup files.'', 16, 1)'
+            END
+
+            EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
+            SET @Error = @@ERROR
+            IF @Error <> 0 SET @CurrentCommandOutput = @Error
+            IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
+
+            UPDATE @CurrentDirectories
+            SET CleanupCompleted = 1,
+                CleanupOutput = @CurrentCommandOutput
+            WHERE ID = @CurrentDirectoryID
+
+            SET @CurrentDirectoryID = NULL
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentCleanupDate = NULL
+
+            SET @CurrentDatabaseContext = NULL
+            SET @CurrentCommand = NULL
+            SET @CurrentCommandOutput = NULL
+            SET @CurrentCommandType = NULL
+          END
+        END
+
+        -- Perform a backup
+        IF NOT EXISTS (SELECT * FROM @CurrentDirectories WHERE DirectoryPath <> 'NUL' AND DirectoryPath NOT IN(SELECT DirectoryPath FROM @Directories) AND (CreateOutput <> 0 OR CreateOutput IS NULL))
+        OR @HostPlatform = 'Linux'
+        BEGIN
+          IF @BackupSoftware IS NULL
+          BEGIN
+            SET @CurrentDatabaseContext = 'master'
+
+            SELECT @CurrentCommandType = CASE
+            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP_DATABASE'
+            WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP_LOG'
+            END
+
+            SELECT @CurrentCommand = CASE
+            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP DATABASE ' + QUOTENAME(@CurrentDatabaseName)
+            WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP LOG ' + QUOTENAME(@CurrentDatabaseName)
+            END
+
+            IF @FileGroups IS NOT NULL SET @CurrentCommand += ' FILEGROUP = ''' + @CurrentFileGroupName + ''''
+
+            IF @CurrentFileGroupName = 'PRIMARY' AND EXISTS (SELECT * FROM @tmpFileGroups WHERE [type] = 'FX' AND Selected = 1)
+            BEGIN
+              SET @CurrentCommand += ', FILEGROUP = ''' + (SELECT FileGroupName FROM @tmpFileGroups WHERE [type] = 'FX') + ''''
+            END
+
+            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' READ_WRITE_FILEGROUPS'
+
+            SET @CurrentCommand += ' TO'
+
+            SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
+            FROM @CurrentFiles
+            WHERE Mirror = 0
+            ORDER BY FilePath ASC
+
+            IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
+            BEGIN
+              SET @CurrentCommand += ' MIRROR TO'
+
+              SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
               FROM @CurrentFiles
-              WHERE Mirror = 0
+              WHERE Mirror = 1
+              ORDER BY FilePath ASC
+            END
+
+            SET @CurrentCommand += ' WITH '
+            IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
+            IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+
+            IF @Version >= 10
+            BEGIN
+              SET @CurrentCommand += CASE WHEN @Compress = 'Y' AND (@CurrentIsEncrypted = 0 OR (@CurrentIsEncrypted = 1 AND ((@Version >= 13 AND @CurrentMaxTransferSize >= 65537) OR @Version >= 15.0404316 OR SERVERPROPERTY('EngineEdition') = 8))) THEN ', COMPRESSION' ELSE ', NO_COMPRESSION' END
+            END
+
+            IF @Compress = 'Y' AND @CompressionAlgorithm IS NOT NULL
+            BEGIN
+              SET @CurrentCommand += ' (ALGORITHM = ' + @CompressionAlgorithm + CASE WHEN @CompressionLevel IS NOT NULL THEN ', LEVEL = ' + @CompressionLevel ELSE '' END + ')'
+            END
+
+            IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
+
+            IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
+            BEGIN
+              SET @CurrentCommand += ', FORMAT'
+            END
+
+            IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
+            IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
+            IF @Init = 'Y' SET @CurrentCommand += ', INIT'
+            IF @Format = 'Y' SET @CurrentCommand += ', FORMAT'
+            IF @BlockSize IS NOT NULL SET @CurrentCommand += ', BLOCKSIZE = ' + CAST(@BlockSize AS nvarchar)
+            IF @BufferCount IS NOT NULL SET @CurrentCommand += ', BUFFERCOUNT = ' + CAST(@BufferCount AS nvarchar)
+            IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', MAXTRANSFERSIZE = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
+            IF @Description IS NOT NULL SET @CurrentCommand += ', DESCRIPTION = N''' + REPLACE(@Description,'''','''''') + ''''
+            IF @BackupSetName IS NOT NULL SET @CurrentCommand += ', NAME = N''' + REPLACE(@BackupSetName,'''','''''') + ''''
+            IF @Stats IS NOT NULL SET @CurrentCommand += ', STATS = ' + CAST(@Stats AS nvarchar)
+            IF @BackupOptions IS NOT NULL SET @CurrentCommand += ', BACKUP_OPTIONS = N''' + REPLACE(@BackupOptions,'''','''''') + ''''
+            IF @Encrypt = 'Y' SET @CurrentCommand += ', ENCRYPTION (ALGORITHM = ' + UPPER(@EncryptionAlgorithm) + ', '
+            IF @Encrypt = 'Y' AND @ServerCertificate IS NOT NULL SET @CurrentCommand += 'SERVER CERTIFICATE = ' + QUOTENAME(@ServerCertificate)
+            IF @Encrypt = 'Y' AND @ServerAsymmetricKey IS NOT NULL SET @CurrentCommand += 'SERVER ASYMMETRIC KEY = ' + QUOTENAME(@ServerAsymmetricKey)
+            IF @Encrypt = 'Y' SET @CurrentCommand += ')'
+            IF @URL IS NOT NULL AND @Credential IS NOT NULL SET @CurrentCommand += ', CREDENTIAL = N''' + REPLACE(@Credential,'''','''''') + ''''
+            IF @ExpireDate IS NOT NULL SET @CurrentCommand += ', EXPIREDATE = ''' + CONVERT(nvarchar, @ExpireDate, 21) + ''''
+            IF @RetainDays IS NOT NULL SET @CurrentCommand += ', RETAINDAYS = ' + CAST(@RetainDays AS nvarchar)
+          END
+
+          IF @BackupSoftware = 'LITESPEED'
+          BEGIN
+            SET @CurrentDatabaseContext = 'master'
+
+            SELECT @CurrentCommandType = CASE
+            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'xp_backup_database'
+            WHEN @CurrentBackupType = 'LOG' THEN 'xp_backup_log'
+            END
+
+            SELECT @CurrentCommand = CASE
+            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_backup_database @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
+            WHEN @CurrentBackupType = 'LOG' THEN 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_backup_log @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
+            END
+
+            SELECT @CurrentCommand += ', @filename = N''' + REPLACE(FilePath,'''','''''') + ''''
+            FROM @CurrentFiles
+            WHERE Mirror = 0
+            ORDER BY FilePath ASC
+
+            IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
+            BEGIN
+              SELECT @CurrentCommand += ', @mirror = N''' + REPLACE(FilePath,'''','''''') + ''''
+              FROM @CurrentFiles
+              WHERE Mirror = 1
+              ORDER BY FilePath ASC
+            END
+
+            SET @CurrentCommand += ', @with = '''
+            IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
+            IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+            IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
+            IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
+            IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
+            IF @BlockSize IS NOT NULL SET @CurrentCommand += ', BLOCKSIZE = ' + CAST(@BlockSize AS nvarchar)
+            SET @CurrentCommand += ''''
+            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ', @read_write_filegroups = 1'
+            IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', @compressionlevel = ' + CAST(@CompressionLevelNumeric AS nvarchar)
+            IF @AdaptiveCompression IS NOT NULL SET @CurrentCommand += ', @adaptivecompression = ''' + CASE WHEN @AdaptiveCompression = 'SIZE' THEN 'Size' WHEN @AdaptiveCompression = 'SPEED' THEN 'Speed' END + ''''
+            IF @BufferCount IS NOT NULL SET @CurrentCommand += ', @buffercount = ' + CAST(@BufferCount AS nvarchar)
+            IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', @maxtransfersize = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
+            IF @Threads IS NOT NULL SET @CurrentCommand += ', @threads = ' + CAST(@Threads AS nvarchar)
+            IF @Init = 'Y' SET @CurrentCommand += ', @init = 1'
+            IF @Format = 'Y' SET @CurrentCommand += ', @format = 1'
+            IF @Throttle IS NOT NULL SET @CurrentCommand += ', @throttle = ' + CAST(@Throttle AS nvarchar)
+            IF @Description IS NOT NULL SET @CurrentCommand += ', @desc = N''' + REPLACE(@Description,'''','''''') + ''''
+            IF @ObjectLevelRecoveryMap = 'Y' SET @CurrentCommand += ', @olrmap = 1'
+            IF @ExpireDate IS NOT NULL SET @CurrentCommand += ', @expiration = ''' + CONVERT(nvarchar, @ExpireDate, 21) + ''''
+            IF @RetainDays IS NOT NULL SET @CurrentCommand += ', @retaindays = ' + CAST(@RetainDays AS nvarchar)
+
+            IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', @cryptlevel = ' + CASE
+            WHEN @EncryptionAlgorithm = 'RC2_40' THEN '0'
+            WHEN @EncryptionAlgorithm = 'RC2_56' THEN '1'
+            WHEN @EncryptionAlgorithm = 'RC2_112' THEN '2'
+            WHEN @EncryptionAlgorithm = 'RC2_128' THEN '3'
+            WHEN @EncryptionAlgorithm = 'TRIPLE_DES_3KEY' THEN '4'
+            WHEN @EncryptionAlgorithm = 'RC4_128' THEN '5'
+            WHEN @EncryptionAlgorithm = 'AES_128' THEN '6'
+            WHEN @EncryptionAlgorithm = 'AES_192' THEN '7'
+            WHEN @EncryptionAlgorithm = 'AES_256' THEN '8'
+            END
+
+            IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptionkey = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+            SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing LiteSpeed backup.'', 16, 1)'
+          END
+
+          IF @BackupSoftware = 'SQLBACKUP'
+          BEGIN
+            SET @CurrentDatabaseContext = 'master'
+
+            SET @CurrentCommandType = 'sqlbackup'
+
+            SELECT @CurrentCommand = CASE
+            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP DATABASE ' + QUOTENAME(@CurrentDatabaseName)
+            WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP LOG ' + QUOTENAME(@CurrentDatabaseName)
+            END
+
+            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' READ_WRITE_FILEGROUPS'
+
+            SET @CurrentCommand += ' TO'
+
+            SELECT @CurrentCommand += ' DISK = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
+            FROM @CurrentFiles
+            WHERE Mirror = 0
+            ORDER BY FilePath ASC
+
+            SET @CurrentCommand += ' WITH '
+
+            IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
+            BEGIN
+              SET @CurrentCommand += ' MIRRORFILE' + ' = N''' + REPLACE((SELECT FilePath FROM @CurrentFiles WHERE Mirror = 1),'''','''''') + ''', '
+            END
+
+            IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
+            IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+            IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
+            IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
+            IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
+            IF @Init = 'Y' SET @CurrentCommand += ', INIT'
+            IF @Format = 'Y' SET @CurrentCommand += ', FORMAT'
+            IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', COMPRESSION = ' + CAST(@CompressionLevelNumeric AS nvarchar)
+            IF @Threads IS NOT NULL SET @CurrentCommand += ', THREADCOUNT = ' + CAST(@Threads AS nvarchar)
+            IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', MAXTRANSFERSIZE = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
+            IF @Description IS NOT NULL SET @CurrentCommand += ', DESCRIPTION = N''' + REPLACE(@Description,'''','''''') + ''''
+
+            IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', KEYSIZE = ' + CASE
+            WHEN @EncryptionAlgorithm = 'AES_128' THEN '128'
+            WHEN @EncryptionAlgorithm = 'AES_256' THEN '256'
+            END
+
+            IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', PASSWORD = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqlbackup N''-SQL "' + REPLACE(@CurrentCommand,'''','''''') + '"''' + ' IF @ReturnCode <> 0 RAISERROR(''Error performing SQLBackup backup.'', 16, 1)'
+          END
+
+          IF @BackupSoftware = 'SQLSAFE'
+          BEGIN
+            SET @CurrentDatabaseContext = 'master'
+
+            SET @CurrentCommandType = 'xp_ss_backup'
+
+            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_backup @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
+
+            SELECT @CurrentCommand += ', ' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) = 1 THEN '@filename' ELSE '@backupfile' END + ' = N''' + REPLACE(FilePath,'''','''''') + ''''
+            FROM @CurrentFiles
+            WHERE Mirror = 0
+            ORDER BY FilePath ASC
+
+            SELECT @CurrentCommand += ', @mirrorfile = N''' + REPLACE(FilePath,'''','''''') + ''''
+            FROM @CurrentFiles
+            WHERE Mirror = 1
+            ORDER BY FilePath ASC
+
+            SET @CurrentCommand += ', @backuptype = ' + CASE WHEN @CurrentBackupType = 'FULL' THEN '''Full''' WHEN @CurrentBackupType = 'DIFF' THEN '''Differential''' WHEN @CurrentBackupType = 'LOG' THEN '''Log''' END
+            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ', @readwritefilegroups = 1'
+            SET @CurrentCommand += ', @checksum = ' + CASE WHEN @Checksum = 'Y' THEN '1' WHEN @Checksum = 'N' THEN '0' END
+            SET @CurrentCommand += ', @copyonly = ' + CASE WHEN @CopyOnly = 'Y' THEN '1' WHEN @CopyOnly = 'N' THEN '0' END
+            IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', @compressionlevel = ' + CAST(@CompressionLevelNumeric AS nvarchar)
+            IF @Threads IS NOT NULL SET @CurrentCommand += ', @threads = ' + CAST(@Threads AS nvarchar)
+            IF @Init = 'Y' SET @CurrentCommand += ', @overwrite = 1'
+            IF @Description IS NOT NULL SET @CurrentCommand += ', @desc = N''' + REPLACE(@Description,'''','''''') + ''''
+
+            IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', @encryptiontype = N''' + CASE
+            WHEN @EncryptionAlgorithm = 'AES_128' THEN 'AES128'
+            WHEN @EncryptionAlgorithm = 'AES_256' THEN 'AES256'
+            END + ''''
+
+            IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptedbackuppassword = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+            SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing SQLsafe backup.'', 16, 1)'
+          END
+
+          IF @BackupSoftware = 'DATA_DOMAIN_BOOST'
+          BEGIN
+            SET @CurrentDatabaseContext = 'master'
+
+            SET @CurrentCommandType = 'emc_run_backup'
+
+            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.emc_run_backup '''
+
+            SET @CurrentCommand += ' -c ' + CASE WHEN @Cluster IS NOT NULL AND @CurrentAvailabilityGroup IS NOT NULL THEN @Cluster ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar) END
+
+            SET @CurrentCommand += ' -l ' + CASE
+            WHEN @CurrentBackupType = 'FULL' THEN 'full'
+            WHEN @CurrentBackupType = 'DIFF' THEN 'diff'
+            WHEN @CurrentBackupType = 'LOG' THEN 'incr'
+            END
+
+            IF @NoRecovery = 'Y' SET @CurrentCommand += ' -H'
+
+            IF @CleanupTime IS NOT NULL SET @CurrentCommand += ' -y +' + CAST(@CleanupTime/24 + CASE WHEN @CleanupTime%24 > 0 THEN 1 ELSE 0 END AS nvarchar) + 'd'
+
+            IF @Checksum = 'Y' SET @CurrentCommand += ' -k'
+
+            SET @CurrentCommand += ' -S ' + CAST(@CurrentNumberOfFiles AS nvarchar)
+
+            IF @Description IS NOT NULL SET @CurrentCommand += ' -b "' + REPLACE(@Description,'''','''''') + '"'
+
+            IF @BufferCount IS NOT NULL SET @CurrentCommand += ' -O "BUFFERCOUNT=' + CAST(@BufferCount AS nvarchar) + '"'
+
+            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' -O "READ_WRITE_FILEGROUPS"'
+
+            IF @DataDomainBoostHost IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_HOST=' + REPLACE(@DataDomainBoostHost,'''','''''') + '"'
+            IF @DataDomainBoostUser IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_USER=' + REPLACE(@DataDomainBoostUser,'''','''''') + '"'
+            IF @DataDomainBoostDevicePath IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DEVICE_PATH=' + REPLACE(@DataDomainBoostDevicePath,'''','''''') + '"'
+            IF @DataDomainBoostLockboxPath IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_LOCKBOX_PATH=' + REPLACE(@DataDomainBoostLockboxPath,'''','''''') + '"'
+            SET @CurrentCommand += ' -a "NSR_SKIP_NON_BACKUPABLE_STATE_DB=TRUE"'
+            SET @CurrentCommand += ' -a "BACKUP_PROMOTION=NONE"'
+            IF @CopyOnly = 'Y' SET @CurrentCommand += ' -a "NSR_COPY_ONLY=TRUE"'
+            IF @BackupSetName IS NOT NULL SET @CurrentCommand += ' -N "' + REPLACE(@BackupSetName,'''','''''') + '"'
+
+            IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentCommand += ' "MSSQL'
+            IF SERVERPROPERTY('InstanceName') IS NOT NULL SET @CurrentCommand += ' "MSSQL$' + CAST(SERVERPROPERTY('InstanceName') AS nvarchar)
+            SET @CurrentCommand += ':' + REPLACE(REPLACE(@CurrentDatabaseName,'''',''''''),'.','\.') + '"'
+
+            SET @CurrentCommand += ''''
+
+            SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing Data Domain Boost backup.'', 16, 1)'
+          END
+
+          EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
+          SET @Error = @@ERROR
+          IF @Error <> 0 SET @CurrentCommandOutput = @Error
+          IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
+          SET @CurrentBackupOutput = @CurrentCommandOutput
+        END
+
+        -- Verify the backup
+        IF @CurrentBackupOutput = 0 AND @Verify = 'Y'
+        BEGIN
+          WHILE (1 = 1)
+          BEGIN
+            SELECT TOP 1 @CurrentBackupSetID = ID,
+                         @CurrentIsMirror = Mirror
+            FROM @CurrentBackupSet
+            WHERE VerifyCompleted = 0
+            ORDER BY ID ASC
+
+            IF @@ROWCOUNT = 0
+            BEGIN
+              BREAK
+            END
+
+            IF @BackupSoftware IS NULL
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'RESTORE_VERIFYONLY'
+
+              SET @CurrentCommand = 'RESTORE VERIFYONLY FROM'
+
+              SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
+              FROM @CurrentFiles
+              WHERE Mirror = @CurrentIsMirror
               ORDER BY FilePath ASC
 
-              IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
-              BEGIN
-                SELECT @CurrentCommand += ', @mirror = N''' + REPLACE(FilePath,'''','''''') + ''''
-                FROM @CurrentFiles
-                WHERE Mirror = 1
-                ORDER BY FilePath ASC
-              END
+              SET @CurrentCommand += ' WITH '
+              IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
+              IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+              IF @Stats IS NOT NULL SET @CurrentCommand += ', STATS = ' + CAST(@Stats AS nvarchar)
+              IF @BackupOptions IS NOT NULL SET @CurrentCommand += ', RESTORE_OPTIONS = N''' + REPLACE(@BackupOptions,'''','''''') + ''''
+              IF @URL IS NOT NULL AND @Credential IS NOT NULL SET @CurrentCommand += ', CREDENTIAL = N''' + REPLACE(@Credential,'''','''''') + ''''
+            END
+
+            IF @BackupSoftware = 'LITESPEED'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_restore_verifyonly'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_restore_verifyonly'
+
+              SELECT @CurrentCommand += ' @filename = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
+              FROM @CurrentFiles
+              WHERE Mirror = @CurrentIsMirror
+              ORDER BY FilePath ASC
 
               SET @CurrentCommand += ', @with = '''
               IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
               IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
-              IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
-              IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
-              IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
-              IF @BlockSize IS NOT NULL SET @CurrentCommand += ', BLOCKSIZE = ' + CAST(@BlockSize AS nvarchar)
               SET @CurrentCommand += ''''
-              IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ', @read_write_filegroups = 1'
-              IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', @compressionlevel = ' + CAST(@CompressionLevelNumeric AS nvarchar)
-              IF @AdaptiveCompression IS NOT NULL SET @CurrentCommand += ', @adaptivecompression = ''' + CASE WHEN @AdaptiveCompression = 'SIZE' THEN 'Size' WHEN @AdaptiveCompression = 'SPEED' THEN 'Speed' END + ''''
-              IF @BufferCount IS NOT NULL SET @CurrentCommand += ', @buffercount = ' + CAST(@BufferCount AS nvarchar)
-              IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', @maxtransfersize = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
-              IF @Threads IS NOT NULL SET @CurrentCommand += ', @threads = ' + CAST(@Threads AS nvarchar)
-              IF @Init = 'Y' SET @CurrentCommand += ', @init = 1'
-              IF @Format = 'Y' SET @CurrentCommand += ', @format = 1'
-              IF @Throttle IS NOT NULL SET @CurrentCommand += ', @throttle = ' + CAST(@Throttle AS nvarchar)
-              IF @Description IS NOT NULL SET @CurrentCommand += ', @desc = N''' + REPLACE(@Description,'''','''''') + ''''
-              IF @ObjectLevelRecoveryMap = 'Y' SET @CurrentCommand += ', @olrmap = 1'
-              IF @ExpireDate IS NOT NULL SET @CurrentCommand += ', @expiration = ''' + CONVERT(nvarchar, @ExpireDate, 21) + ''''
-              IF @RetainDays IS NOT NULL SET @CurrentCommand += ', @retaindays = ' + CAST(@RetainDays AS nvarchar)
-
-              IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', @cryptlevel = ' + CASE
-              WHEN @EncryptionAlgorithm = 'RC2_40' THEN '0'
-              WHEN @EncryptionAlgorithm = 'RC2_56' THEN '1'
-              WHEN @EncryptionAlgorithm = 'RC2_112' THEN '2'
-              WHEN @EncryptionAlgorithm = 'RC2_128' THEN '3'
-              WHEN @EncryptionAlgorithm = 'TRIPLE_DES_3KEY' THEN '4'
-              WHEN @EncryptionAlgorithm = 'RC4_128' THEN '5'
-              WHEN @EncryptionAlgorithm = 'AES_128' THEN '6'
-              WHEN @EncryptionAlgorithm = 'AES_192' THEN '7'
-              WHEN @EncryptionAlgorithm = 'AES_256' THEN '8'
-              END
-
               IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptionkey = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
-              SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing LiteSpeed backup.'', 16, 1)'
+
+              SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error verifying LiteSpeed backup.'', 16, 1)'
             END
 
             IF @BackupSoftware = 'SQLBACKUP'
@@ -4503,373 +4731,182 @@ BEGIN
 
               SET @CurrentCommandType = 'sqlbackup'
 
-              SELECT @CurrentCommand = CASE
-              WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP DATABASE ' + QUOTENAME(@CurrentDatabaseName)
-              WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP LOG ' + QUOTENAME(@CurrentDatabaseName)
-              END
-
-              IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' READ_WRITE_FILEGROUPS'
-
-              SET @CurrentCommand += ' TO'
+              SET @CurrentCommand = 'RESTORE VERIFYONLY FROM'
 
               SELECT @CurrentCommand += ' DISK = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
               FROM @CurrentFiles
-              WHERE Mirror = 0
+              WHERE Mirror = @CurrentIsMirror
               ORDER BY FilePath ASC
 
               SET @CurrentCommand += ' WITH '
-
-              IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
-              BEGIN
-                SET @CurrentCommand += ' MIRRORFILE' + ' = N''' + REPLACE((SELECT FilePath FROM @CurrentFiles WHERE Mirror = 1),'''','''''') + ''', '
-              END
-
               IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
               IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
-              IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
-              IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
-              IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
-              IF @Init = 'Y' SET @CurrentCommand += ', INIT'
-              IF @Format = 'Y' SET @CurrentCommand += ', FORMAT'
-              IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', COMPRESSION = ' + CAST(@CompressionLevelNumeric AS nvarchar)
-              IF @Threads IS NOT NULL SET @CurrentCommand += ', THREADCOUNT = ' + CAST(@Threads AS nvarchar)
-              IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', MAXTRANSFERSIZE = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
-              IF @Description IS NOT NULL SET @CurrentCommand += ', DESCRIPTION = N''' + REPLACE(@Description,'''','''''') + ''''
-
-              IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', KEYSIZE = ' + CASE
-              WHEN @EncryptionAlgorithm = 'AES_128' THEN '128'
-              WHEN @EncryptionAlgorithm = 'AES_256' THEN '256'
-              END
-
               IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', PASSWORD = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
-              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqlbackup N''-SQL "' + REPLACE(@CurrentCommand,'''','''''') + '"''' + ' IF @ReturnCode <> 0 RAISERROR(''Error performing SQLBackup backup.'', 16, 1)'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqlbackup N''-SQL "' + REPLACE(@CurrentCommand,'''','''''') + '"''' + ' IF @ReturnCode <> 0 RAISERROR(''Error verifying SQLBackup backup.'', 16, 1)'
             END
 
             IF @BackupSoftware = 'SQLSAFE'
             BEGIN
               SET @CurrentDatabaseContext = 'master'
 
-              SET @CurrentCommandType = 'xp_ss_backup'
+              SET @CurrentCommandType = 'xp_ss_verify'
 
-              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_backup @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_verify @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
 
               SELECT @CurrentCommand += ', ' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) = 1 THEN '@filename' ELSE '@backupfile' END + ' = N''' + REPLACE(FilePath,'''','''''') + ''''
               FROM @CurrentFiles
-              WHERE Mirror = 0
+              WHERE Mirror = @CurrentIsMirror
               ORDER BY FilePath ASC
 
-              SELECT @CurrentCommand += ', @mirrorfile = N''' + REPLACE(FilePath,'''','''''') + ''''
-              FROM @CurrentFiles
-              WHERE Mirror = 1
-              ORDER BY FilePath ASC
-
-              SET @CurrentCommand += ', @backuptype = ' + CASE WHEN @CurrentBackupType = 'FULL' THEN '''Full''' WHEN @CurrentBackupType = 'DIFF' THEN '''Differential''' WHEN @CurrentBackupType = 'LOG' THEN '''Log''' END
-              IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ', @readwritefilegroups = 1'
-              SET @CurrentCommand += ', @checksum = ' + CASE WHEN @Checksum = 'Y' THEN '1' WHEN @Checksum = 'N' THEN '0' END
-              SET @CurrentCommand += ', @copyonly = ' + CASE WHEN @CopyOnly = 'Y' THEN '1' WHEN @CopyOnly = 'N' THEN '0' END
-              IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', @compressionlevel = ' + CAST(@CompressionLevelNumeric AS nvarchar)
-              IF @Threads IS NOT NULL SET @CurrentCommand += ', @threads = ' + CAST(@Threads AS nvarchar)
-              IF @Init = 'Y' SET @CurrentCommand += ', @overwrite = 1'
-              IF @Description IS NOT NULL SET @CurrentCommand += ', @desc = N''' + REPLACE(@Description,'''','''''') + ''''
-
-              IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', @encryptiontype = N''' + CASE
-              WHEN @EncryptionAlgorithm = 'AES_128' THEN 'AES128'
-              WHEN @EncryptionAlgorithm = 'AES_256' THEN 'AES256'
-              END + ''''
-
-              IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptedbackuppassword = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
-              SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing SQLsafe backup.'', 16, 1)'
-            END
-
-            IF @BackupSoftware = 'DATA_DOMAIN_BOOST'
-            BEGIN
-              SET @CurrentDatabaseContext = 'master'
-
-              SET @CurrentCommandType = 'emc_run_backup'
-
-              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.emc_run_backup '''
-
-              SET @CurrentCommand += ' -c ' + CASE WHEN @Cluster IS NOT NULL AND @CurrentAvailabilityGroup IS NOT NULL THEN @Cluster ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar) END
-
-              SET @CurrentCommand += ' -l ' + CASE
-              WHEN @CurrentBackupType = 'FULL' THEN 'full'
-              WHEN @CurrentBackupType = 'DIFF' THEN 'diff'
-              WHEN @CurrentBackupType = 'LOG' THEN 'incr'
-              END
-
-              IF @NoRecovery = 'Y' SET @CurrentCommand += ' -H'
-
-              IF @CleanupTime IS NOT NULL SET @CurrentCommand += ' -y +' + CAST(@CleanupTime/24 + CASE WHEN @CleanupTime%24 > 0 THEN 1 ELSE 0 END AS nvarchar) + 'd'
-
-              IF @Checksum = 'Y' SET @CurrentCommand += ' -k'
-
-              SET @CurrentCommand += ' -S ' + CAST(@CurrentNumberOfFiles AS nvarchar)
-
-              IF @Description IS NOT NULL SET @CurrentCommand += ' -b "' + REPLACE(@Description,'''','''''') + '"'
-
-              IF @BufferCount IS NOT NULL SET @CurrentCommand += ' -O "BUFFERCOUNT=' + CAST(@BufferCount AS nvarchar) + '"'
-
-              IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' -O "READ_WRITE_FILEGROUPS"'
-
-              IF @DataDomainBoostHost IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_HOST=' + REPLACE(@DataDomainBoostHost,'''','''''') + '"'
-              IF @DataDomainBoostUser IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_USER=' + REPLACE(@DataDomainBoostUser,'''','''''') + '"'
-              IF @DataDomainBoostDevicePath IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DEVICE_PATH=' + REPLACE(@DataDomainBoostDevicePath,'''','''''') + '"'
-              IF @DataDomainBoostLockboxPath IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_LOCKBOX_PATH=' + REPLACE(@DataDomainBoostLockboxPath,'''','''''') + '"'
-              SET @CurrentCommand += ' -a "NSR_SKIP_NON_BACKUPABLE_STATE_DB=TRUE"'
-              SET @CurrentCommand += ' -a "BACKUP_PROMOTION=NONE"'
-              IF @CopyOnly = 'Y' SET @CurrentCommand += ' -a "NSR_COPY_ONLY=TRUE"'
-              IF @BackupSetName IS NOT NULL SET @CurrentCommand += ' -N "' + REPLACE(@BackupSetName,'''','''''') + '"'
-
-              IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentCommand += ' "MSSQL'
-              IF SERVERPROPERTY('InstanceName') IS NOT NULL SET @CurrentCommand += ' "MSSQL$' + CAST(SERVERPROPERTY('InstanceName') AS nvarchar)
-              SET @CurrentCommand += ':' + REPLACE(REPLACE(@CurrentDatabaseName,'''',''''''),'.','\.') + '"'
-
-              SET @CurrentCommand += ''''
-
-              SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing Data Domain Boost backup.'', 16, 1)'
+              SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error verifying SQLsafe backup.'', 16, 1)'
             END
 
             EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
             SET @Error = @@ERROR
             IF @Error <> 0 SET @CurrentCommandOutput = @Error
             IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
-            SET @CurrentBackupOutput = @CurrentCommandOutput
-          END
 
-          -- Verify the backup
-          IF @CurrentBackupOutput = 0 AND @Verify = 'Y'
+            UPDATE @CurrentBackupSet
+            SET VerifyCompleted = 1,
+                VerifyOutput = @CurrentCommandOutput
+            WHERE ID = @CurrentBackupSetID
+
+            SET @CurrentBackupSetID = NULL
+            SET @CurrentIsMirror = NULL
+
+            SET @CurrentDatabaseContext = NULL
+            SET @CurrentCommand = NULL
+            SET @CurrentCommandOutput = NULL
+            SET @CurrentCommandType = NULL
+          END
+        END
+
+        IF @CleanupMode = 'AFTER_BACKUP'
+        BEGIN
+          INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
+          SELECT DATEADD(hh,-(@CleanupTime),SYSDATETIME()), 0
+
+          IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 0 OR Mirror IS NULL) AND CleanupDate IS NULL)
           BEGIN
-            WHILE (1 = 1)
-            BEGIN
-              SELECT TOP 1 @CurrentBackupSetID = ID,
-                           @CurrentIsMirror = Mirror
-              FROM @CurrentBackupSet
-              WHERE VerifyCompleted = 0
-              ORDER BY ID ASC
-
-              IF @@ROWCOUNT = 0
-              BEGIN
-                BREAK
-              END
-
-              IF @BackupSoftware IS NULL
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'RESTORE_VERIFYONLY'
-
-                SET @CurrentCommand = 'RESTORE VERIFYONLY FROM'
-
-                SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
-                FROM @CurrentFiles
-                WHERE Mirror = @CurrentIsMirror
-                ORDER BY FilePath ASC
-
-                SET @CurrentCommand += ' WITH '
-                IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
-                IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
-                IF @Stats IS NOT NULL SET @CurrentCommand += ', STATS = ' + CAST(@Stats AS nvarchar)
-                IF @BackupOptions IS NOT NULL SET @CurrentCommand += ', RESTORE_OPTIONS = N''' + REPLACE(@BackupOptions,'''','''''') + ''''
-                IF @URL IS NOT NULL AND @Credential IS NOT NULL SET @CurrentCommand += ', CREDENTIAL = N''' + REPLACE(@Credential,'''','''''') + ''''
-              END
-
-              IF @BackupSoftware = 'LITESPEED'
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'xp_restore_verifyonly'
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_restore_verifyonly'
-
-                SELECT @CurrentCommand += ' @filename = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
-                FROM @CurrentFiles
-                WHERE Mirror = @CurrentIsMirror
-                ORDER BY FilePath ASC
-
-                SET @CurrentCommand += ', @with = '''
-                IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
-                IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
-                SET @CurrentCommand += ''''
-                IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptionkey = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
-
-                SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error verifying LiteSpeed backup.'', 16, 1)'
-              END
-
-              IF @BackupSoftware = 'SQLBACKUP'
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'sqlbackup'
-
-                SET @CurrentCommand = 'RESTORE VERIFYONLY FROM'
-
-                SELECT @CurrentCommand += ' DISK = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
-                FROM @CurrentFiles
-                WHERE Mirror = @CurrentIsMirror
-                ORDER BY FilePath ASC
-
-                SET @CurrentCommand += ' WITH '
-                IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
-                IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
-                IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', PASSWORD = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqlbackup N''-SQL "' + REPLACE(@CurrentCommand,'''','''''') + '"''' + ' IF @ReturnCode <> 0 RAISERROR(''Error verifying SQLBackup backup.'', 16, 1)'
-              END
-
-              IF @BackupSoftware = 'SQLSAFE'
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'xp_ss_verify'
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_verify @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
-
-                SELECT @CurrentCommand += ', ' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) = 1 THEN '@filename' ELSE '@backupfile' END + ' = N''' + REPLACE(FilePath,'''','''''') + ''''
-                FROM @CurrentFiles
-                WHERE Mirror = @CurrentIsMirror
-                ORDER BY FilePath ASC
-
-                SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error verifying SQLsafe backup.'', 16, 1)'
-              END
-
-              EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
-              SET @Error = @@ERROR
-              IF @Error <> 0 SET @CurrentCommandOutput = @Error
-              IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
-
-              UPDATE @CurrentBackupSet
-              SET VerifyCompleted = 1,
-                  VerifyOutput = @CurrentCommandOutput
-              WHERE ID = @CurrentBackupSetID
-
-              SET @CurrentBackupSetID = NULL
-              SET @CurrentIsMirror = NULL
-
-              SET @CurrentDatabaseContext = NULL
-              SET @CurrentCommand = NULL
-              SET @CurrentCommandOutput = NULL
-              SET @CurrentCommandType = NULL
-            END
+            UPDATE @CurrentDirectories
+            SET CleanupDate = (SELECT MIN(CleanupDate)
+                               FROM @CurrentCleanupDates
+                               WHERE (Mirror = 0 OR Mirror IS NULL)),
+                CleanupMode = 'AFTER_BACKUP'
+            WHERE Mirror = 0
           END
+        END
 
-          IF @CleanupMode = 'AFTER_BACKUP'
+        IF @MirrorCleanupMode = 'AFTER_BACKUP'
+        BEGIN
+          INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
+          SELECT DATEADD(hh,-(@MirrorCleanupTime),SYSDATETIME()), 1
+
+          IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 1 OR Mirror IS NULL) AND CleanupDate IS NULL)
           BEGIN
-            INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
-            SELECT DATEADD(hh,-(@CleanupTime),SYSDATETIME()), 0
-
-            IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 0 OR Mirror IS NULL) AND CleanupDate IS NULL)
-            BEGIN
-              UPDATE @CurrentDirectories
-              SET CleanupDate = (SELECT MIN(CleanupDate)
-                                 FROM @CurrentCleanupDates
-                                 WHERE (Mirror = 0 OR Mirror IS NULL)),
-                  CleanupMode = 'AFTER_BACKUP'
-              WHERE Mirror = 0
-            END
+            UPDATE @CurrentDirectories
+            SET CleanupDate = (SELECT MIN(CleanupDate)
+                               FROM @CurrentCleanupDates
+                               WHERE (Mirror = 1 OR Mirror IS NULL)),
+                CleanupMode = 'AFTER_BACKUP'
+            WHERE Mirror = 1
           END
+        END
 
-          IF @MirrorCleanupMode = 'AFTER_BACKUP'
+        -- Delete old backup files, after backup
+        IF ((@CurrentBackupOutput = 0 AND @Verify = 'N')
+        OR (@CurrentBackupOutput = 0 AND @Verify = 'Y' AND NOT EXISTS (SELECT * FROM @CurrentBackupSet WHERE VerifyOutput <> 0 OR VerifyOutput IS NULL)))
+        AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
+        AND @CurrentBackupType = @BackupType
+        BEGIN
+          WHILE (1 = 1)
           BEGIN
-            INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
-            SELECT DATEADD(hh,-(@MirrorCleanupTime),SYSDATETIME()), 1
+            SELECT TOP 1 @CurrentDirectoryID = ID,
+                         @CurrentDirectoryPath = DirectoryPath,
+                         @CurrentCleanupDate = CleanupDate
+            FROM @CurrentDirectories
+            WHERE CleanupDate IS NOT NULL
+            AND CleanupMode = 'AFTER_BACKUP'
+            AND CleanupCompleted = 0
+            ORDER BY ID ASC
 
-            IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 1 OR Mirror IS NULL) AND CleanupDate IS NULL)
+            IF @@ROWCOUNT = 0
             BEGIN
-              UPDATE @CurrentDirectories
-              SET CleanupDate = (SELECT MIN(CleanupDate)
-                                 FROM @CurrentCleanupDates
-                                 WHERE (Mirror = 1 OR Mirror IS NULL)),
-                  CleanupMode = 'AFTER_BACKUP'
-              WHERE Mirror = 1
+              BREAK
             END
-          END
 
-          -- Delete old backup files, after backup
-          IF ((@CurrentBackupOutput = 0 AND @Verify = 'N')
-          OR (@CurrentBackupOutput = 0 AND @Verify = 'Y' AND NOT EXISTS (SELECT * FROM @CurrentBackupSet WHERE VerifyOutput <> 0 OR VerifyOutput IS NULL)))
-          AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
-          AND @CurrentBackupType = @BackupType
-          BEGIN
-            WHILE (1 = 1)
+            IF @BackupSoftware IS NULL
             BEGIN
-              SELECT TOP 1 @CurrentDirectoryID = ID,
-                           @CurrentDirectoryPath = DirectoryPath,
-                           @CurrentCleanupDate = CleanupDate
-              FROM @CurrentDirectories
-              WHERE CleanupDate IS NOT NULL
-              AND CleanupMode = 'AFTER_BACKUP'
-              AND CleanupCompleted = 0
-              ORDER BY ID ASC
+              SET @CurrentDatabaseContext = 'master'
 
-              IF @@ROWCOUNT = 0
-              BEGIN
-                BREAK
-              END
+              SET @CurrentCommandType = 'xp_delete_file'
 
-              IF @BackupSoftware IS NULL
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'xp_delete_file'
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_delete_file 0, N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + @CurrentFileExtension + ''', ''' + CONVERT(nvarchar(19),@CurrentCleanupDate,126) + ''' IF @ReturnCode <> 0 RAISERROR(''Error deleting files.'', 16, 1)'
-              END
-
-              IF @BackupSoftware = 'LITESPEED'
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'xp_slssqlmaint'
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_slssqlmaint N''-MAINTDEL -DELFOLDER "' + REPLACE(@CurrentDirectoryPath,'''','''''') + '" -DELEXTENSION "' + @CurrentFileExtension + '" -DELUNIT "' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + '" -DELUNITTYPE "minutes" -DELUSEAGE'' IF @ReturnCode <> 0 RAISERROR(''Error deleting LiteSpeed backup files.'', 16, 1)'
-              END
-
-              IF @BackupSoftware = 'SQLBACKUP'
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'sqbutility'
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqbutility 1032, N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''', N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + CASE WHEN @CurrentBackupType = 'FULL' THEN 'D' WHEN @CurrentBackupType = 'DIFF' THEN 'I' WHEN @CurrentBackupType = 'LOG' THEN 'L' END + ''', ''' + CAST(DATEDIFF(hh,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'h'', ' + ISNULL('''' + REPLACE(@EncryptionKey,'''','''''') + '''','NULL') + ' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLBackup backup files.'', 16, 1)'
-              END
-
-              IF @BackupSoftware = 'SQLSAFE'
-              BEGIN
-                SET @CurrentDatabaseContext = 'master'
-
-                SET @CurrentCommandType = 'xp_ss_delete'
-
-                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_delete @filename = N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + '\*.' + @CurrentFileExtension + ''', @age = ''' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'Minutes'' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLsafe backup files.'', 16, 1)'
-              END
-
-              EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
-              SET @Error = @@ERROR
-              IF @Error <> 0 SET @CurrentCommandOutput = @Error
-              IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
-
-              UPDATE @CurrentDirectories
-              SET CleanupCompleted = 1,
-                  CleanupOutput = @CurrentCommandOutput
-              WHERE ID = @CurrentDirectoryID
-
-              SET @CurrentDirectoryID = NULL
-              SET @CurrentDirectoryPath = NULL
-              SET @CurrentCleanupDate = NULL
-
-              SET @CurrentDatabaseContext = NULL
-              SET @CurrentCommand = NULL
-              SET @CurrentCommandOutput = NULL
-              SET @CurrentCommandType = NULL
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_delete_file 0, N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + @CurrentFileExtension + ''', ''' + CONVERT(nvarchar(19),@CurrentCleanupDate,126) + ''' IF @ReturnCode <> 0 RAISERROR(''Error deleting files.'', 16, 1)'
             END
-          END
 
-        END -- End of file group check
+            IF @BackupSoftware = 'LITESPEED'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_slssqlmaint'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_slssqlmaint N''-MAINTDEL -DELFOLDER "' + REPLACE(@CurrentDirectoryPath,'''','''''') + '" -DELEXTENSION "' + @CurrentFileExtension + '" -DELUNIT "' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + '" -DELUNITTYPE "minutes" -DELUSEAGE'' IF @ReturnCode <> 0 RAISERROR(''Error deleting LiteSpeed backup files.'', 16, 1)'
+            END
+
+            IF @BackupSoftware = 'SQLBACKUP'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'sqbutility'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqbutility 1032, N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''', N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + CASE WHEN @CurrentBackupType = 'FULL' THEN 'D' WHEN @CurrentBackupType = 'DIFF' THEN 'I' WHEN @CurrentBackupType = 'LOG' THEN 'L' END + ''', ''' + CAST(DATEDIFF(hh,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'h'', ' + ISNULL('''' + REPLACE(@EncryptionKey,'''','''''') + '''','NULL') + ' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLBackup backup files.'', 16, 1)'
+            END
+
+            IF @BackupSoftware = 'SQLSAFE'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_ss_delete'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_delete @filename = N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + '\*.' + @CurrentFileExtension + ''', @age = ''' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'Minutes'' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLsafe backup files.'', 16, 1)'
+            END
+
+            EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
+            SET @Error = @@ERROR
+            IF @Error <> 0 SET @CurrentCommandOutput = @Error
+            IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
+
+            UPDATE @CurrentDirectories
+            SET CleanupCompleted = 1,
+                CleanupOutput = @CurrentCommandOutput
+            WHERE ID = @CurrentDirectoryID
+
+            SET @CurrentDirectoryID = NULL
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentCleanupDate = NULL
+
+            SET @CurrentDatabaseContext = NULL
+            SET @CurrentCommand = NULL
+            SET @CurrentCommandOutput = NULL
+            SET @CurrentCommandType = NULL
+          END
+        END
 
         UPDATE @tmpFileGroups
         SET Completed = 1
         WHERE Selected = 1
         AND Completed = 0
         AND ID = @CurrentFGID
+
+        IF @CurrentFileGroupName = 'PRIMARY' AND EXISTS (SELECT * FROM @tmpFileGroups WHERE [type] = 'FX' AND Selected = 1)
+        BEGIN
+          UPDATE @tmpFileGroups
+          SET Completed = 1
+          WHERE Selected = 1
+          AND Completed = 0
+          AND [type] = 'FX'
+        END
 
         SET @CurrentDatabaseContext = NULL
         SET @CurrentCommand = NULL
@@ -4961,6 +4998,8 @@ BEGIN
     SET @CurrentAllocatedExtentPageCount = NULL
     SET @CurrentModifiedExtentPageCount = NULL
 
+    DELETE FROM @tmpFileGroups
+
   END -- End of database while loop
 
   ----------------------------------------------------------------------------------------------------
@@ -5024,7 +5063,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-08 22:57:39                                                               //--
+  --// Version: 2025-07-08 19:42:27                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON
@@ -6923,7 +6962,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-08 22:57:39                                                               //--
+  --// Version: 2025-07-08 19:42:27                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON
@@ -8883,9 +8922,9 @@ BEGIN
           AND NOT (@CurrentIndexType = 3)
           AND NOT (@CurrentIndexType = 4)
           AND NOT (@CurrentIndexType = 5 AND @Version < 15)
-          AND NOT (@CurrentIndexType = 6 AND @Version < 15)
+          AND NOT (@CurrentIndexType = 6 AND @Version < 14)
           AND NOT (@CurrentIndexType = 1 AND @CurrentHasColumnstore = 1 AND @Version < 13)
-          AND NOT (@CurrentIndexType = 2 AND @CurrentHasColumnstore = 1 AND @Version < 13)
+          AND NOT (@CurrentIndexType = 2 AND @CurrentHasColumnstore = 1 AND @Version < 15)
           BEGIN
             INSERT INTO @CurrentActionsAllowed ([Action])
             VALUES ('INDEX_REBUILD_ONLINE')

--- a/MaintenanceSolution.sql
+++ b/MaintenanceSolution.sql
@@ -10,7 +10,7 @@ License: https://ola.hallengren.com/license.html
 
 GitHub: https://github.com/olahallengren/sql-server-maintenance-solution
 
-Version: 2025-05-24 16:07:41
+Version: 2025-06-07 21:41:06
 
 You can contact me by e-mail at ola@hallengren.com.
 
@@ -137,7 +137,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-05-24 16:07:41                                                               //--
+  --// Version: 2025-06-07 21:41:06                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON
@@ -451,11 +451,11 @@ ALTER PROCEDURE [dbo].[DatabaseBackup]
 @DataDomainBoostUser nvarchar(max) = NULL,
 @DataDomainBoostDevicePath nvarchar(max) = NULL,
 @DataDomainBoostLockboxPath nvarchar(max) = NULL,
-@DirectoryStructure nvarchar(max) = '{ServerName}${InstanceName}{DirectorySeparator}{DatabaseName}{DirectorySeparator}{BackupType}_{Partial}_{CopyOnly}',
-@AvailabilityGroupDirectoryStructure nvarchar(max) = '{ClusterName}${AvailabilityGroupName}{DirectorySeparator}{DatabaseName}{DirectorySeparator}{BackupType}_{Partial}_{CopyOnly}',
+@DirectoryStructure nvarchar(max) = '{ServerName}${InstanceName}{DirectorySeparator}{DatabaseName}{DirectorySeparator}{FileGroupName}{DirectorySeparator}{BackupType}_{Partial}_{CopyOnly}',
+@AvailabilityGroupDirectoryStructure nvarchar(max) = '{ClusterName}${AvailabilityGroupName}{DirectorySeparator}{DatabaseName}{DirectorySeparator}{FileGroupName}{DirectorySeparator}{BackupType}_{Partial}_{CopyOnly}',
 @DirectoryStructureCase nvarchar(max) = NULL,
-@FileName nvarchar(max) = '{ServerName}${InstanceName}_{DatabaseName}_{BackupType}_{Partial}_{CopyOnly}_{Year}{Month}{Day}_{Hour}{Minute}{Second}_{FileNumber}.{FileExtension}',
-@AvailabilityGroupFileName nvarchar(max) = '{ClusterName}${AvailabilityGroupName}_{DatabaseName}_{BackupType}_{Partial}_{CopyOnly}_{Year}{Month}{Day}_{Hour}{Minute}{Second}_{FileNumber}.{FileExtension}',
+@FileName nvarchar(max) = '{ServerName}${InstanceName}_{DatabaseName}_{FileGroupName}_{BackupType}_{Partial}_{CopyOnly}_{Year}{Month}{Day}_{Hour}{Minute}{Second}_{FileNumber}.{FileExtension}',
+@AvailabilityGroupFileName nvarchar(max) = '{ClusterName}${AvailabilityGroupName}_{DatabaseName}_{FileGroupName}_{BackupType}_{Partial}_{CopyOnly}_{Year}{Month}{Day}_{Hour}{Minute}{Second}_{FileNumber}.{FileExtension}',
 @FileNameCase nvarchar(max) = NULL,
 @TokenTimezone nvarchar(max) = 'LOCAL',
 @FileExtensionFull nvarchar(max) = NULL,
@@ -470,6 +470,7 @@ ALTER PROCEDURE [dbo].[DatabaseBackup]
 @Stats int = NULL,
 @ExpireDate datetime = NULL,
 @RetainDays int = NULL,
+@FileGroups nvarchar(max) = NULL,
 @StringDelimiter nvarchar(max) = ',',
 @DatabaseOrder nvarchar(max) = NULL,
 @DatabasesInParallel nvarchar(max) = 'N',
@@ -484,7 +485,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-05-24 16:07:41                                                               //--
+  --// Version: 2025-06-07 21:41:06                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON
@@ -570,6 +571,11 @@ BEGIN
   DECLARE @CurrentCommandOutput int
   DECLARE @CurrentCommandType nvarchar(max)
 
+  DECLARE @CurrentFGID int
+  DECLARE @CurrentFileGroupID int
+  DECLARE @CurrentFileGroupName nvarchar(max)
+  DECLARE @CurrentFileGroupExists bit
+
   DECLARE @Errors TABLE (ID int IDENTITY PRIMARY KEY,
                          [Message] nvarchar(max) NOT NULL,
                          Severity int NOT NULL,
@@ -613,6 +619,15 @@ BEGIN
   DECLARE @tmpDatabasesAvailabilityGroups TABLE (DatabaseName nvarchar(max),
                                                  AvailabilityGroupName nvarchar(max))
 
+  DECLARE @tmpFileGroups TABLE (ID int IDENTITY,
+                                FileGroupID int,
+                                FileGroupName nvarchar(max),
+                                StartPosition int,
+                                [Order] int,
+                                Selected bit,
+                                Completed bit,
+                                PRIMARY KEY(Selected, Completed, [Order], ID))
+
   DECLARE @SelectedDatabases TABLE (DatabaseName nvarchar(max),
                                     DatabaseType nvarchar(max),
                                     AvailabilityGroup nvarchar(max),
@@ -622,6 +637,11 @@ BEGIN
   DECLARE @SelectedAvailabilityGroups TABLE (AvailabilityGroupName nvarchar(max),
                                              StartPosition int,
                                              Selected bit)
+
+  DECLARE @SelectedFileGroups TABLE (DatabaseName nvarchar(max),
+                                     FileGroupName nvarchar(max),
+                                     StartPosition int,
+                                     Selected bit)
 
   DECLARE @CurrentBackupOutput bit
 
@@ -744,6 +764,7 @@ BEGIN
   SET @Parameters += ', @Stats = ' + ISNULL(CAST(@Stats AS nvarchar),'NULL')
   SET @Parameters += ', @ExpireDate = ' + ISNULL('''' + CONVERT(nvarchar, @ExpireDate, 21) + '''','NULL')
   SET @Parameters += ', @RetainDays = ' + ISNULL(CAST(@RetainDays AS nvarchar),'NULL')
+  SET @Parameters += ', @FileGroups = ' + ISNULL('''' + REPLACE(@FileGroups,'''','''''') + '''','NULL')
   SET @Parameters += ', @StringDelimiter = ' + ISNULL('''' + REPLACE(@StringDelimiter,'''','''''') + '''','NULL')
   SET @Parameters += ', @DatabaseOrder = ' + ISNULL('''' + REPLACE(@DatabaseOrder,'''','''''') + '''','NULL')
   SET @Parameters += ', @DatabasesInParallel = ' + ISNULL('''' + REPLACE(@DatabasesInParallel,'''','''''') + '''','NULL')
@@ -1077,6 +1098,58 @@ BEGIN
     INSERT INTO @Errors ([Message], Severity, [State])
     SELECT 'You can only specify one of the parameters @Databases and @AvailabilityGroups.', 16, 3
   END
+
+  ----------------------------------------------------------------------------------------------------
+  --// Select filegroups                                                                          //--
+  ----------------------------------------------------------------------------------------------------
+
+  SET @FileGroups = REPLACE(@FileGroups, CHAR(10), '')
+  SET @FileGroups = REPLACE(@FileGroups, CHAR(13), '')
+
+  WHILE CHARINDEX(', ',@FileGroups) > 0 SET @FileGroups = REPLACE(@FileGroups,', ',',')
+  WHILE CHARINDEX(' ,',@FileGroups) > 0 SET @FileGroups = REPLACE(@FileGroups,' ,',',')
+
+  SET @FileGroups = LTRIM(RTRIM(@FileGroups));
+
+  WITH FileGroups1 (StartPosition, EndPosition, FileGroupItem) AS
+  (
+  SELECT 1 AS StartPosition,
+         ISNULL(NULLIF(CHARINDEX(',', @FileGroups, 1), 0), LEN(@FileGroups) + 1) AS EndPosition,
+         SUBSTRING(@FileGroups, 1, ISNULL(NULLIF(CHARINDEX(',', @FileGroups, 1), 0), LEN(@FileGroups) + 1) - 1) AS FileGroupItem
+  WHERE @FileGroups IS NOT NULL
+  UNION ALL
+  SELECT CAST(EndPosition AS int) + 1 AS StartPosition,
+         ISNULL(NULLIF(CHARINDEX(',', @FileGroups, EndPosition + 1), 0), LEN(@FileGroups) + 1) AS EndPosition,
+         SUBSTRING(@FileGroups, EndPosition + 1, ISNULL(NULLIF(CHARINDEX(',', @FileGroups, EndPosition + 1), 0), LEN(@FileGroups) + 1) - EndPosition - 1) AS FileGroupItem
+  FROM FileGroups1
+  WHERE EndPosition < LEN(@FileGroups) + 1
+  ),
+  FileGroups2 (FileGroupItem, StartPosition, Selected) AS
+  (
+  SELECT CASE WHEN FileGroupItem LIKE '-%' THEN RIGHT(FileGroupItem,LEN(FileGroupItem) - 1) ELSE FileGroupItem END AS FileGroupItem,
+         StartPosition,
+         CASE WHEN FileGroupItem LIKE '-%' THEN 0 ELSE 1 END AS Selected
+  FROM FileGroups1
+  ),
+  FileGroups3 (FileGroupItem, StartPosition, Selected) AS
+  (
+  SELECT CASE WHEN FileGroupItem = 'ALL_FILEGROUPS' THEN '%.%' ELSE FileGroupItem END AS FileGroupItem,
+         StartPosition,
+         Selected
+  FROM FileGroups2
+  ),
+  FileGroups4 (DatabaseName, FileGroupName, StartPosition, Selected) AS
+  (
+  SELECT CASE WHEN PARSENAME(FileGroupItem,4) IS NULL AND PARSENAME(FileGroupItem,3) IS NULL THEN PARSENAME(FileGroupItem,2) ELSE NULL END AS DatabaseName,
+         CASE WHEN PARSENAME(FileGroupItem,4) IS NULL AND PARSENAME(FileGroupItem,3) IS NULL THEN PARSENAME(FileGroupItem,1) ELSE NULL END AS FileGroupName,
+         StartPosition,
+         Selected
+  FROM FileGroups3
+  )
+  INSERT INTO @SelectedFileGroups (DatabaseName, FileGroupName, StartPosition, Selected)
+  SELECT DatabaseName, FileGroupName, StartPosition, Selected
+  FROM FileGroups4
+  OPTION (MAXRECURSION 0);
 
   ----------------------------------------------------------------------------------------------------
   --// Check database names                                                                       //--
@@ -2579,7 +2652,7 @@ BEGIN
 
   ----------------------------------------------------------------------------------------------------
 
-  IF EXISTS (SELECT * FROM (SELECT REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(@DirectoryStructure,'{DirectorySeparator}',''),'{ServerName}',''),'{InstanceName}',''),'{ServiceName}',''),'{ClusterName}',''),'{AvailabilityGroupName}',''),'{DatabaseName}',''),'{BackupType}',''),'{Partial}',''),'{CopyOnly}',''),'{Description}',''),'{BackupSetName}',''),'{Year}',''),'{Month}',''),'{Day}',''),'{Week}',''),'{Weekday}',''),'{Hour}',''),'{Minute}',''),'{Second}',''),'{Millisecond}',''),'{Microsecond}',''),'{MajorVersion}',''),'{MinorVersion}','') AS DirectoryStructure) Temp WHERE DirectoryStructure LIKE '%{%' OR DirectoryStructure LIKE '%}%')
+  IF EXISTS (SELECT * FROM (SELECT REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(@DirectoryStructure,'{DirectorySeparator}',''),'{ServerName}',''),'{InstanceName}',''),'{ServiceName}',''),'{ClusterName}',''),'{AvailabilityGroupName}',''),'{DatabaseName}',''),'{FileGroupName}',''),'{BackupType}',''),'{Partial}',''),'{CopyOnly}',''),'{Description}',''),'{BackupSetName}',''),'{Year}',''),'{Month}',''),'{Day}',''),'{Week}',''),'{Weekday}',''),'{Hour}',''),'{Minute}',''),'{Second}',''),'{Millisecond}',''),'{Microsecond}',''),'{MajorVersion}',''),'{MinorVersion}','') AS DirectoryStructure) Temp WHERE DirectoryStructure LIKE '%{%' OR DirectoryStructure LIKE '%}%')
   BEGIN
     INSERT INTO @Errors ([Message], Severity, [State])
     SELECT 'The parameter @DirectoryStructure contains one or more tokens that are not supported.', 16, 1
@@ -2587,7 +2660,7 @@ BEGIN
 
   ----------------------------------------------------------------------------------------------------
 
-  IF EXISTS (SELECT * FROM (SELECT REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(@AvailabilityGroupDirectoryStructure,'{DirectorySeparator}',''),'{ServerName}',''),'{InstanceName}',''),'{ServiceName}',''),'{ClusterName}',''),'{AvailabilityGroupName}',''),'{DatabaseName}',''),'{BackupType}',''),'{Partial}',''),'{CopyOnly}',''),'{Description}',''),'{BackupSetName}',''),'{Year}',''),'{Month}',''),'{Day}',''),'{Week}',''),'{Weekday}',''),'{Hour}',''),'{Minute}',''),'{Second}',''),'{Millisecond}',''),'{Microsecond}',''),'{MajorVersion}',''),'{MinorVersion}','') AS AvailabilityGroupDirectoryStructure) Temp WHERE AvailabilityGroupDirectoryStructure LIKE '%{%' OR AvailabilityGroupDirectoryStructure LIKE '%}%')
+  IF EXISTS (SELECT * FROM (SELECT REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(@AvailabilityGroupDirectoryStructure,'{DirectorySeparator}',''),'{ServerName}',''),'{InstanceName}',''),'{ServiceName}',''),'{ClusterName}',''),'{AvailabilityGroupName}',''),'{DatabaseName}',''),'{FileGroupName}',''),'{BackupType}',''),'{Partial}',''),'{CopyOnly}',''),'{Description}',''),'{BackupSetName}',''),'{Year}',''),'{Month}',''),'{Day}',''),'{Week}',''),'{Weekday}',''),'{Hour}',''),'{Minute}',''),'{Second}',''),'{Millisecond}',''),'{Microsecond}',''),'{MajorVersion}',''),'{MinorVersion}','') AS AvailabilityGroupDirectoryStructure) Temp WHERE AvailabilityGroupDirectoryStructure LIKE '%{%' OR AvailabilityGroupDirectoryStructure LIKE '%}%')
   BEGIN
     INSERT INTO @Errors ([Message], Severity, [State])
     SELECT 'The parameter @AvailabilityGroupDirectoryStructure contains one or more tokens that are not supported.', 16, 1
@@ -2595,7 +2668,7 @@ BEGIN
 
   ----------------------------------------------------------------------------------------------------
 
-  IF EXISTS (SELECT * FROM (SELECT REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(@FileName,'{DirectorySeparator}',''),'{ServerName}',''),'{InstanceName}',''),'{ServiceName}',''),'{ClusterName}',''),'{AvailabilityGroupName}',''),'{DatabaseName}',''),'{BackupType}',''),'{Partial}',''),'{CopyOnly}',''),'{Description}',''),'{BackupSetName}',''),'{Year}',''),'{Month}',''),'{Day}',''),'{Week}',''),'{Weekday}',''),'{Hour}',''),'{Minute}',''),'{Second}',''),'{Millisecond}',''),'{Microsecond}',''),'{FileNumber}',''),'{NumberOfFiles}',''),'{FileExtension}',''),'{MajorVersion}',''),'{MinorVersion}','') AS [FileName]) Temp WHERE [FileName] LIKE '%{%' OR [FileName] LIKE '%}%')
+  IF EXISTS (SELECT * FROM (SELECT REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(@FileName,'{DirectorySeparator}',''),'{ServerName}',''),'{InstanceName}',''),'{ServiceName}',''),'{ClusterName}',''),'{AvailabilityGroupName}',''),'{DatabaseName}',''),'{FileGroupName}',''),'{BackupType}',''),'{Partial}',''),'{CopyOnly}',''),'{Description}',''),'{BackupSetName}',''),'{Year}',''),'{Month}',''),'{Day}',''),'{Week}',''),'{Weekday}',''),'{Hour}',''),'{Minute}',''),'{Second}',''),'{Millisecond}',''),'{Microsecond}',''),'{FileNumber}',''),'{NumberOfFiles}',''),'{FileExtension}',''),'{MajorVersion}',''),'{MinorVersion}','') AS [FileName]) Temp WHERE [FileName] LIKE '%{%' OR [FileName] LIKE '%}%')
   BEGIN
     INSERT INTO @Errors ([Message], Severity, [State])
     SELECT 'The parameter @FileName contains one or more tokens that are not supported.', 16, 1
@@ -2603,7 +2676,7 @@ BEGIN
 
   ----------------------------------------------------------------------------------------------------
 
-  IF EXISTS (SELECT * FROM (SELECT REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(@AvailabilityGroupFileName,'{DirectorySeparator}',''),'{ServerName}',''),'{InstanceName}',''),'{ServiceName}',''),'{ClusterName}',''),'{AvailabilityGroupName}',''),'{DatabaseName}',''),'{BackupType}',''),'{Partial}',''),'{CopyOnly}',''),'{Description}',''),'{BackupSetName}',''),'{Year}',''),'{Month}',''),'{Day}',''),'{Week}',''),'{Weekday}',''),'{Hour}',''),'{Minute}',''),'{Second}',''),'{Millisecond}',''),'{Microsecond}',''),'{FileNumber}',''),'{NumberOfFiles}',''),'{FileExtension}',''),'{MajorVersion}',''),'{MinorVersion}','') AS AvailabilityGroupFileName) Temp WHERE AvailabilityGroupFileName LIKE '%{%' OR AvailabilityGroupFileName LIKE '%}%')
+  IF EXISTS (SELECT * FROM (SELECT REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(@AvailabilityGroupFileName,'{DirectorySeparator}',''),'{ServerName}',''),'{InstanceName}',''),'{ServiceName}',''),'{ClusterName}',''),'{AvailabilityGroupName}',''),'{DatabaseName}',''),'{FileGroupName}',''),'{BackupType}',''),'{Partial}',''),'{CopyOnly}',''),'{Description}',''),'{BackupSetName}',''),'{Year}',''),'{Month}',''),'{Day}',''),'{Week}',''),'{Weekday}',''),'{Hour}',''),'{Minute}',''),'{Second}',''),'{Millisecond}',''),'{Microsecond}',''),'{FileNumber}',''),'{NumberOfFiles}',''),'{FileExtension}',''),'{MajorVersion}',''),'{MinorVersion}','') AS AvailabilityGroupFileName) Temp WHERE AvailabilityGroupFileName LIKE '%{%' OR AvailabilityGroupFileName LIKE '%}%')
   BEGIN
     INSERT INTO @Errors ([Message], Severity, [State])
     SELECT 'The parameter @AvailabilityGroupFileName contains one or more tokens that are not supported.', 16, 1
@@ -3151,6 +3224,73 @@ BEGIN
       BREAK
     END
 
+    -- Select filegroups
+    IF @FileGroups IS NOT NULL
+    BEGIN
+      SET @CurrentCommand = 'SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED; SELECT data_space_id AS FileGroupID, name AS FileGroupName, 0 AS [Order], 0 AS Selected, 0 AS Completed FROM ' + QUOTENAME(@CurrentDatabaseName) + '.sys.filegroups filegroups WHERE [type] <> ''FX'' ORDER BY CASE WHEN filegroups.name = ''PRIMARY'' THEN 1 ELSE 0 END DESC, filegroups.name ASC'
+
+      INSERT INTO @tmpFileGroups (FileGroupID, FileGroupName, [Order], Selected, Completed)
+      EXECUTE sp_executesql @statement = @CurrentCommand
+      SET @Error = @@ERROR
+      IF @Error <> 0 SET @ReturnCode = @Error
+
+      IF @FileGroups IS NULL
+      BEGIN
+        UPDATE tmpFileGroups
+        SET tmpFileGroups.Selected = 1
+        FROM @tmpFileGroups tmpFileGroups
+      END
+      ELSE
+      BEGIN
+        UPDATE tmpFileGroups
+        SET tmpFileGroups.Selected = SelectedFileGroups.Selected
+        FROM @tmpFileGroups tmpFileGroups
+        INNER JOIN @SelectedFileGroups SelectedFileGroups
+        ON @CurrentDatabaseName LIKE REPLACE(SelectedFileGroups.DatabaseName,'_','[_]') AND tmpFileGroups.FileGroupName LIKE REPLACE(SelectedFileGroups.FileGroupName,'_','[_]')
+        WHERE SelectedFileGroups.Selected = 1
+
+        UPDATE tmpFileGroups
+        SET tmpFileGroups.Selected = SelectedFileGroups.Selected
+        FROM @tmpFileGroups tmpFileGroups
+        INNER JOIN @SelectedFileGroups SelectedFileGroups
+        ON @CurrentDatabaseName LIKE REPLACE(SelectedFileGroups.DatabaseName,'_','[_]') AND tmpFileGroups.FileGroupName LIKE REPLACE(SelectedFileGroups.FileGroupName,'_','[_]')
+        WHERE SelectedFileGroups.Selected = 0
+
+        UPDATE tmpFileGroups
+        SET tmpFileGroups.StartPosition = SelectedFileGroups2.StartPosition
+        FROM @tmpFileGroups tmpFileGroups
+        INNER JOIN (SELECT tmpFileGroups.FileGroupName, MIN(SelectedFileGroups.StartPosition) AS StartPosition
+                    FROM @tmpFileGroups tmpFileGroups
+                    INNER JOIN @SelectedFileGroups SelectedFileGroups
+                    ON @CurrentDatabaseName LIKE REPLACE(SelectedFileGroups.DatabaseName,'_','[_]') AND tmpFileGroups.FileGroupName LIKE REPLACE(SelectedFileGroups.FileGroupName,'_','[_]')
+                    WHERE SelectedFileGroups.Selected = 1
+                    GROUP BY tmpFileGroups.FileGroupName) SelectedFileGroups2
+        ON tmpFileGroups.FileGroupName = SelectedFileGroups2.FileGroupName
+      END;
+
+      WITH tmpFileGroups AS (
+      SELECT FileGroupName, [Order], ROW_NUMBER() OVER (ORDER BY StartPosition ASC, FileGroupName ASC) AS RowNumber
+      FROM @tmpFileGroups tmpFileGroups
+      WHERE Selected = 1
+      )
+      UPDATE tmpFileGroups
+      SET [Order] = RowNumber
+
+      SET @ErrorMessage = ''
+      SELECT @ErrorMessage = @ErrorMessage + QUOTENAME(DatabaseName) + '.' + QUOTENAME(FileGroupName) + ', '
+      FROM @SelectedFileGroups SelectedFileGroups
+      WHERE DatabaseName = @CurrentDatabaseName
+      AND FileGroupName NOT LIKE '%[%]%'
+      AND NOT EXISTS (SELECT * FROM @tmpFileGroups WHERE FileGroupName = SelectedFileGroups.FileGroupName)
+      IF @@ROWCOUNT > 0
+      BEGIN
+        SET @ErrorMessage = 'The following file groups do not exist: ' + LEFT(@ErrorMessage,LEN(@ErrorMessage)-1) + '.' + CHAR(13) + CHAR(10) + ' '
+        RAISERROR(@ErrorMessage,16,1) WITH NOWAIT
+        SET @Error = @@ERROR
+      END
+
+    END
+
     SET @CurrentDatabase_sp_executesql = QUOTENAME(@CurrentDatabaseName) + '.sys.sp_executesql'
 
     BEGIN
@@ -3404,6 +3544,43 @@ BEGIN
     AND NOT (@CurrentBackupType = 'DIFF' AND @MinDatabaseSizeForDifferentialBackup IS NOT NULL AND (COALESCE(CAST(@CurrentAllocatedExtentPageCount AS bigint) * 8192, CAST(@CurrentDatabaseSize AS bigint) * 8192) < CAST(@MinDatabaseSizeForDifferentialBackup AS bigint) * 1024 * 1024))
     BEGIN
 
+    WHILE (1 = 1)
+    BEGIN
+
+      IF @FileGroups IS NOT NULL
+      BEGIN
+        SELECT TOP 1 @CurrentFGID = ID,
+                     @CurrentFileGroupID = FileGroupID,
+                     @CurrentFileGroupName = FileGroupName
+        FROM @tmpFileGroups
+        WHERE Selected = 1
+        AND Completed = 0
+        ORDER BY [Order] ASC
+
+        IF @@ROWCOUNT = 0
+        BEGIN
+          BREAK
+        END
+
+        -- Does the filegroup exist?
+        SET @CurrentCommand = ''
+        SET @CurrentCommand = @CurrentCommand + 'IF EXISTS(SELECT * FROM ' + QUOTENAME(@CurrentDatabaseName) + '.sys.filegroups filegroups WHERE [type] <> ''FX'' AND filegroups.data_space_id = @ParamFileGroupID AND filegroups.[name] = @ParamFileGroupName) BEGIN SET @ParamFileGroupExists = 1 END'
+
+        EXECUTE sp_executesql @statement = @CurrentCommand, @params = N'@ParamFileGroupID int, @ParamFileGroupName sysname, @ParamFileGroupExists bit OUTPUT', @ParamFileGroupID = @CurrentFileGroupID, @ParamFileGroupName = @CurrentFileGroupName, @ParamFileGroupExists = @CurrentFileGroupExists OUTPUT
+        SET @Error = @@ERROR
+        IF @Error = 0 AND @CurrentFileGroupExists IS NULL SET @CurrentFileGroupExists = 0
+        IF @Error = 1222
+        BEGIN
+          SET @ErrorMessage = 'The file group ' + QUOTENAME(@CurrentFileGroupName) + ' in the database ' + QUOTENAME(@CurrentDatabaseName) + ' is locked. It could not be checked if the filegroup exists.' + CHAR(13) + CHAR(10) + ' '
+          SET @ErrorMessage = REPLACE(@ErrorMessage,'%','%%')
+          RAISERROR(@ErrorMessage,16,1) WITH NOWAIT
+        END
+        IF @Error <> 0
+        BEGIN
+          SET @ReturnCode = @Error
+        END
+      END
+
       IF @CurrentBackupType = 'LOG' AND (@CleanupTime IS NOT NULL OR @MirrorCleanupTime IS NOT NULL)
       BEGIN
         SELECT @CurrentLatestBackup = MAX(backup_start_date)
@@ -3434,6 +3611,7 @@ BEGIN
       IF @CurrentDirectoryStructure IS NOT NULL
       BEGIN
       -- Directory structure - remove tokens that are not needed
+        IF @CurrentFileGroupName IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}','')
         IF @ReadWriteFileGroups = 'N' SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Partial}','')
         IF @CopyOnly = 'N' SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{CopyOnly}','')
         IF @Cluster IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}','')
@@ -3595,6 +3773,7 @@ BEGIN
         SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}',ISNULL(@Cluster,''))
         SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}',ISNULL(@CurrentAvailabilityGroup,''))
         SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DatabaseName}',@CurrentDatabaseNameFS)
+        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}',ISNULL(@CurrentFileGroupName,''))
         SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupType}',@CurrentBackupType)
         SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Partial}','PARTIAL')
         SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{CopyOnly}','COPY_ONLY')
@@ -3644,6 +3823,7 @@ BEGIN
       END
 
       -- File name - remove tokens that are not needed
+      IF @CurrentFileGroupName IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}','')
       IF @ReadWriteFileGroups = 'N' SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Partial}','')
       IF @CopyOnly = 'N' SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{CopyOnly}','')
       IF @Cluster IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ClusterName}','')
@@ -3759,6 +3939,7 @@ BEGIN
       SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServiceName}',ISNULL(@@SERVICENAME,''))
       SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ClusterName}',ISNULL(@Cluster,''))
       SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{AvailabilityGroupName}',ISNULL(@CurrentAvailabilityGroup,''))
+      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}',ISNULL(@CurrentFileGroupName,''))
       SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupType}',@CurrentBackupType)
       SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Partial}','PARTIAL')
       SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{CopyOnly}','COPY_ONLY')
@@ -4117,6 +4298,8 @@ BEGIN
           WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP DATABASE ' + QUOTENAME(@CurrentDatabaseName)
           WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP LOG ' + QUOTENAME(@CurrentDatabaseName)
           END
+
+          IF @FileGroups IS NOT NULL SET @CurrentCommand += ' FILEGROUP = ''' + @CurrentFileGroupName + ''''
 
           IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' READ_WRITE_FILEGROUPS'
 
@@ -4608,6 +4791,33 @@ BEGIN
           SET @CurrentCommandType = NULL
         END
       END
+
+        UPDATE @tmpFileGroups
+        SET Completed = 1
+        WHERE Selected = 1
+        AND Completed = 0
+        AND ID = @CurrentFGID
+
+        SET @CurrentDatabaseContext = NULL
+        SET @CurrentCommand = NULL
+        SET @CurrentCommandOutput = NULL
+        SET @CurrentCommandType = NULL
+
+        SET @CurrentBackupOutput = NULL
+
+        DELETE FROM @CurrentDirectories
+        DELETE FROM @CurrentURLs
+        DELETE FROM @CurrentFiles
+        DELETE FROM @CurrentCleanupDates
+        DELETE FROM @CurrentBackupSet
+
+        IF @FileGroups IS NULL
+        BEGIN
+          BREAK
+        END
+
+    END
+
     END
 
     IF @CurrentDatabaseState = 'SUSPECT'
@@ -4678,19 +4888,6 @@ BEGIN
     SET @CurrentAllocatedExtentPageCount = NULL
     SET @CurrentModifiedExtentPageCount = NULL
 
-    SET @CurrentDatabaseContext = NULL
-    SET @CurrentCommand = NULL
-    SET @CurrentCommandOutput = NULL
-    SET @CurrentCommandType = NULL
-
-    SET @CurrentBackupOutput = NULL
-
-    DELETE FROM @CurrentDirectories
-    DELETE FROM @CurrentURLs
-    DELETE FROM @CurrentFiles
-    DELETE FROM @CurrentCleanupDates
-    DELETE FROM @CurrentBackupSet
-
   END
 
   ----------------------------------------------------------------------------------------------------
@@ -4754,7 +4951,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-05-24 16:07:41                                                               //--
+  --// Version: 2025-06-07 21:41:06                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON
@@ -6653,7 +6850,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-05-24 16:07:41                                                               //--
+  --// Version: 2025-06-07 21:41:06                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/MaintenanceSolution.sql
+++ b/MaintenanceSolution.sql
@@ -10,7 +10,7 @@ License: https://ola.hallengren.com/license.html
 
 GitHub: https://github.com/olahallengren/sql-server-maintenance-solution
 
-Version: 2025-06-07 21:41:06
+Version: 2025-06-08 12:16:23
 
 You can contact me by e-mail at ola@hallengren.com.
 
@@ -137,7 +137,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-07 21:41:06                                                               //--
+  --// Version: 2025-06-08 12:16:23                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON
@@ -451,8 +451,8 @@ ALTER PROCEDURE [dbo].[DatabaseBackup]
 @DataDomainBoostUser nvarchar(max) = NULL,
 @DataDomainBoostDevicePath nvarchar(max) = NULL,
 @DataDomainBoostLockboxPath nvarchar(max) = NULL,
-@DirectoryStructure nvarchar(max) = '{ServerName}${InstanceName}{DirectorySeparator}{DatabaseName}{DirectorySeparator}{FileGroupName}{DirectorySeparator}{BackupType}_{Partial}_{CopyOnly}',
-@AvailabilityGroupDirectoryStructure nvarchar(max) = '{ClusterName}${AvailabilityGroupName}{DirectorySeparator}{DatabaseName}{DirectorySeparator}{FileGroupName}{DirectorySeparator}{BackupType}_{Partial}_{CopyOnly}',
+@DirectoryStructure nvarchar(max) = '{ServerName}${InstanceName}{DirectorySeparator}{DatabaseName}{DirectorySeparator}{FileGroupName}_{BackupType}_{Partial}_{CopyOnly}',
+@AvailabilityGroupDirectoryStructure nvarchar(max) = '{ClusterName}${AvailabilityGroupName}{DirectorySeparator}{DatabaseName}{DirectorySeparator}{FileGroupName}_{BackupType}_{Partial}_{CopyOnly}',
 @DirectoryStructureCase nvarchar(max) = NULL,
 @FileName nvarchar(max) = '{ServerName}${InstanceName}_{DatabaseName}_{FileGroupName}_{BackupType}_{Partial}_{CopyOnly}_{Year}{Month}{Day}_{Hour}{Minute}{Second}_{FileNumber}.{FileExtension}',
 @AvailabilityGroupFileName nvarchar(max) = '{ClusterName}${AvailabilityGroupName}_{DatabaseName}_{FileGroupName}_{BackupType}_{Partial}_{CopyOnly}_{Year}{Month}{Day}_{Hour}{Minute}{Second}_{FileNumber}.{FileExtension}',
@@ -485,7 +485,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-07 21:41:06                                                               //--
+  --// Version: 2025-06-08 12:16:23                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON
@@ -4951,7 +4951,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-07 21:41:06                                                               //--
+  --// Version: 2025-06-08 12:16:23                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON
@@ -6850,7 +6850,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-07 21:41:06                                                               //--
+  --// Version: 2025-06-08 12:16:23                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/MaintenanceSolution.sql
+++ b/MaintenanceSolution.sql
@@ -10,7 +10,7 @@ License: https://ola.hallengren.com/license.html
 
 GitHub: https://github.com/olahallengren/sql-server-maintenance-solution
 
-Version: 2025-06-08 20:41:55
+Version: 2025-06-08 22:57:39
 
 You can contact me by e-mail at ola@hallengren.com.
 
@@ -137,7 +137,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-08 20:41:55                                                               //--
+  --// Version: 2025-06-08 22:57:39                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON
@@ -485,7 +485,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-08 20:41:55                                                               //--
+  --// Version: 2025-06-08 22:57:39                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON
@@ -2938,6 +2938,12 @@ BEGIN
     SELECT 'The value for the parameter @DatabasesInParallel is not supported.', 16, 2
   END
 
+  IF @DatabasesInParallel = 'Y' AND @FileGroups IS NOT NULL
+  BEGIN
+    INSERT INTO @Errors ([Message], Severity, [State])
+    SELECT 'The value for the parameter @DatabasesInParallel is not supported. This option is not supported with file group backup.', 16, 3
+  END
+
   ----------------------------------------------------------------------------------------------------
 
   IF @LogToTable NOT IN('Y','N') OR @LogToTable IS NULL
@@ -3603,6 +3609,7 @@ BEGIN
     AND NOT (@CurrentBackupType = 'LOG' AND @LogSizeSinceLastLogBackup IS NOT NULL AND @TimeSinceLastLogBackup IS NOT NULL AND NOT(@CurrentLogSizeSinceLastLogBackup >= @LogSizeSinceLastLogBackup OR @CurrentLogSizeSinceLastLogBackup IS NULL OR DATEDIFF(SECOND,@CurrentLastLogBackup,SYSDATETIME()) >= @TimeSinceLastLogBackup OR @CurrentLastLogBackup IS NULL))
     AND NOT (@CurrentBackupType = 'LOG' AND @Updateability = 'READ_ONLY' AND @BackupSoftware = 'DATA_DOMAIN_BOOST')
     AND NOT (@CurrentBackupType = 'DIFF' AND @MinDatabaseSizeForDifferentialBackup IS NOT NULL AND (COALESCE(CAST(@CurrentAllocatedExtentPageCount AS bigint) * 8192, CAST(@CurrentDatabaseSize AS bigint) * 8192) < CAST(@MinDatabaseSizeForDifferentialBackup AS bigint) * 1024 * 1024))
+    AND NOT (@FileGroups IS NOT NULL AND @CurrentDatabaseName IN ('master','msdb','model'))
     BEGIN
 
       WHILE (1 = 1)
@@ -3642,565 +3649,687 @@ BEGIN
           END
         END
 
-        IF @CurrentBackupType = 'LOG' AND (@CleanupTime IS NOT NULL OR @MirrorCleanupTime IS NOT NULL)
+        IF @CurrentFileGroupExists = 1 OR @CurrentFileGroupExists IS NULL
         BEGIN
-          SELECT @CurrentLatestBackup = MAX(backup_start_date)
-          FROM msdb.dbo.backupset
-          WHERE ([type] IN('D','I')
-          OR ([type] = 'L' AND last_lsn < @CurrentDifferentialBaseLSN))
-          AND is_damaged = 0
-          AND [database_name] = @CurrentDatabaseName
-        END
 
-        SET @CurrentDate = SYSDATETIME()
-        SET @CurrentDateUTC = SYSUTCDATETIME()
-
-        INSERT INTO @CurrentCleanupDates (CleanupDate)
-        SELECT @CurrentDate
-
-        IF @CurrentBackupType = 'LOG'
-        BEGIN
-          INSERT INTO @CurrentCleanupDates (CleanupDate)
-          SELECT @CurrentLatestBackup
-        END
-
-        SELECT @CurrentDirectoryStructure = CASE
-        WHEN @CurrentAvailabilityGroup IS NOT NULL THEN @AvailabilityGroupDirectoryStructure
-        ELSE @DirectoryStructure
-        END
-
-        IF @CurrentDirectoryStructure IS NOT NULL
-        BEGIN
-        -- Directory structure - remove tokens that are not needed
-          IF @CurrentFileGroupName IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}','')
-          IF @ReadWriteFileGroups = 'N' SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Partial}','')
-          IF @CopyOnly = 'N' SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{CopyOnly}','')
-          IF @Cluster IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}','')
-          IF @CurrentAvailabilityGroup IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}','')
-          IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}','')
-          IF @@SERVICENAME IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServiceName}','')
-          IF @Description IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Description}','')
-          IF @BackupSetName IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupSetName}','')
-
-          IF @Directory IS NULL AND @MirrorDirectory IS NULL AND @URL IS NULL AND @DefaultDirectory LIKE '%' + '.' + @@SERVICENAME + @DirectorySeparator + 'MSSQL' + @DirectorySeparator + 'Backup'
+          IF @CurrentBackupType = 'LOG' AND (@CleanupTime IS NOT NULL OR @MirrorCleanupTime IS NOT NULL)
           BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServerName}','')
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}','')
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}','')
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}','')
+            SELECT @CurrentLatestBackup = MAX(backup_start_date)
+            FROM msdb.dbo.backupset
+            WHERE ([type] IN('D','I')
+            OR ([type] = 'L' AND last_lsn < @CurrentDifferentialBaseLSN))
+            AND is_damaged = 0
+            AND [database_name] = @CurrentDatabaseName
           END
+
+          SET @CurrentDate = SYSDATETIME()
+          SET @CurrentDateUTC = SYSUTCDATETIME()
+
+          INSERT INTO @CurrentCleanupDates (CleanupDate)
+          SELECT @CurrentDate
+
+          IF @CurrentBackupType = 'LOG'
+          BEGIN
+            INSERT INTO @CurrentCleanupDates (CleanupDate)
+            SELECT @CurrentLatestBackup
+          END
+
+          SELECT @CurrentDirectoryStructure = CASE
+          WHEN @CurrentAvailabilityGroup IS NOT NULL THEN @AvailabilityGroupDirectoryStructure
+          ELSE @DirectoryStructure
+          END
+
+          IF @CurrentDirectoryStructure IS NOT NULL
+          BEGIN
+          -- Directory structure - remove tokens that are not needed
+            IF @CurrentFileGroupName IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}','')
+            IF @ReadWriteFileGroups = 'N' SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Partial}','')
+            IF @CopyOnly = 'N' SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{CopyOnly}','')
+            IF @Cluster IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}','')
+            IF @CurrentAvailabilityGroup IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}','')
+            IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}','')
+            IF @@SERVICENAME IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServiceName}','')
+            IF @Description IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Description}','')
+            IF @BackupSetName IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupSetName}','')
+
+            IF @Directory IS NULL AND @MirrorDirectory IS NULL AND @URL IS NULL AND @DefaultDirectory LIKE '%' + '.' + @@SERVICENAME + @DirectorySeparator + 'MSSQL' + @DirectorySeparator + 'Backup'
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServerName}','')
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}','')
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}','')
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}','')
+            END
+
+            WHILE (@Updated = 1 OR @Updated IS NULL)
+            BEGIN
+              SET @Updated = 0
+
+              IF CHARINDEX('\',@CurrentDirectoryStructure) > 0
+              BEGIN
+                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'\','{DirectorySeparator}')
+                SET @Updated = 1
+              END
+
+              IF CHARINDEX('/',@CurrentDirectoryStructure) > 0
+              BEGIN
+                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'/','{DirectorySeparator}')
+                SET @Updated = 1
+              END
+
+              IF CHARINDEX('__',@CurrentDirectoryStructure) > 0
+              BEGIN
+                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'__','_')
+                SET @Updated = 1
+              END
+
+              IF CHARINDEX('--',@CurrentDirectoryStructure) > 0
+              BEGIN
+                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'--','-')
+                SET @Updated = 1
+              END
+
+              IF CHARINDEX('{DirectorySeparator}{DirectorySeparator}',@CurrentDirectoryStructure) > 0
+              BEGIN
+                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}{DirectorySeparator}','{DirectorySeparator}')
+                SET @Updated = 1
+              END
+
+              IF CHARINDEX('{DirectorySeparator}$',@CurrentDirectoryStructure) > 0
+              BEGIN
+                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}$','{DirectorySeparator}')
+                SET @Updated = 1
+              END
+              IF CHARINDEX('${DirectorySeparator}',@CurrentDirectoryStructure) > 0
+              BEGIN
+                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'${DirectorySeparator}','{DirectorySeparator}')
+                SET @Updated = 1
+              END
+
+              IF CHARINDEX('{DirectorySeparator}_',@CurrentDirectoryStructure) > 0
+              BEGIN
+                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}_','{DirectorySeparator}')
+                SET @Updated = 1
+              END
+              IF CHARINDEX('_{DirectorySeparator}',@CurrentDirectoryStructure) > 0
+              BEGIN
+                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'_{DirectorySeparator}','{DirectorySeparator}')
+                SET @Updated = 1
+              END
+
+              IF CHARINDEX('{DirectorySeparator}-',@CurrentDirectoryStructure) > 0
+              BEGIN
+                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}-','{DirectorySeparator}')
+                SET @Updated = 1
+              END
+              IF CHARINDEX('-{DirectorySeparator}',@CurrentDirectoryStructure) > 0
+              BEGIN
+                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'-{DirectorySeparator}','{DirectorySeparator}')
+                SET @Updated = 1
+              END
+
+              IF CHARINDEX('_$',@CurrentDirectoryStructure) > 0
+              BEGIN
+                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'_$','_')
+                SET @Updated = 1
+              END
+              IF CHARINDEX('$_',@CurrentDirectoryStructure) > 0
+              BEGIN
+                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'$_','_')
+                SET @Updated = 1
+              END
+
+              IF CHARINDEX('-$',@CurrentDirectoryStructure) > 0
+              BEGIN
+                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'-$','-')
+                SET @Updated = 1
+              END
+              IF CHARINDEX('$-',@CurrentDirectoryStructure) > 0
+              BEGIN
+                SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'$-','-')
+                SET @Updated = 1
+              END
+
+              IF LEFT(@CurrentDirectoryStructure,1) = '_'
+              BEGIN
+                SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+                SET @Updated = 1
+              END
+              IF RIGHT(@CurrentDirectoryStructure,1) = '_'
+              BEGIN
+                SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+                SET @Updated = 1
+              END
+
+              IF LEFT(@CurrentDirectoryStructure,1) = '-'
+              BEGIN
+                SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+                SET @Updated = 1
+              END
+              IF RIGHT(@CurrentDirectoryStructure,1) = '-'
+              BEGIN
+                SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+                SET @Updated = 1
+              END
+
+              IF LEFT(@CurrentDirectoryStructure,1) = '$'
+              BEGIN
+                SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+                SET @Updated = 1
+              END
+              IF RIGHT(@CurrentDirectoryStructure,1) = '$'
+              BEGIN
+                SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+                SET @Updated = 1
+              END
+
+              IF LEFT(@CurrentDirectoryStructure,20) = '{DirectorySeparator}'
+              BEGIN
+                SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 20)
+                SET @Updated = 1
+              END
+              IF RIGHT(@CurrentDirectoryStructure,20) = '{DirectorySeparator}'
+              BEGIN
+                SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 20)
+                SET @Updated = 1
+              END
+            END
+
+            SET @Updated = NULL
+
+            -- Directory structure - replace tokens with real values
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}',@DirectorySeparator)
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServerName}',CASE WHEN SERVERPROPERTY('EngineEdition') = 8 THEN LEFT(CAST(SERVERPROPERTY('ServerName') AS nvarchar(max)),CHARINDEX('.',CAST(SERVERPROPERTY('ServerName') AS nvarchar(max))) - 1) ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar(max)) END)
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}',ISNULL(CAST(SERVERPROPERTY('InstanceName') AS nvarchar(max)),''))
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServiceName}',ISNULL(@@SERVICENAME,''))
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}',ISNULL(@Cluster,''))
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}',ISNULL(@CurrentAvailabilityGroup,''))
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DatabaseName}',@CurrentDatabaseNameFS)
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}',ISNULL(@CurrentFileGroupName,''))
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupType}',@CurrentBackupType)
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Partial}','PARTIAL')
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{CopyOnly}','COPY_ONLY')
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Description}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@Description,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupSetName}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@BackupSetName,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Year}',CAST(DATEPART(YEAR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar))
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Month}',RIGHT('0' + CAST(DATEPART(MONTH,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Day}',RIGHT('0' + CAST(DATEPART(DAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Week}',RIGHT('0' + CAST(DATEPART(WEEK,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Weekday}',DATENAME(WEEKDAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END))
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Hour}',RIGHT('0' + CAST(DATEPART(HOUR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Minute}',RIGHT('0' + CAST(DATEPART(MINUTE,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Second}',RIGHT('0' + CAST(DATEPART(SECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Millisecond}',RIGHT('00' + CAST(DATEPART(MILLISECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),3))
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Microsecond}',RIGHT('00000' + CAST(DATEPART(MICROSECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),6))
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{MajorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMajorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4)))
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{MinorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMinorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3)))
+          END
+
+          IF @DirectoryStructureCase IS NOT NULL
+          BEGIN
+            SET @CurrentDirectoryStructure = CASE WHEN @DirectoryStructureCase = 'LOWER' THEN LOWER(@CurrentDirectoryStructure)
+                                                  WHEN @DirectoryStructureCase = 'UPPER' THEN UPPER(@CurrentDirectoryStructure) END
+          END
+
+          INSERT INTO @CurrentDirectories (ID, DirectoryPath, Mirror, DirectoryNumber, CreateCompleted, CleanupCompleted)
+          SELECT ROW_NUMBER() OVER (ORDER BY ID),
+                 DirectoryPath + CASE WHEN DirectoryPath = 'NUL' THEN '' WHEN @CurrentDirectoryStructure IS NOT NULL THEN @DirectorySeparator + @CurrentDirectoryStructure ELSE '' END,
+                 Mirror,
+                 ROW_NUMBER() OVER (PARTITION BY Mirror ORDER BY ID ASC),
+                 0,
+                 0
+          FROM @Directories
+          ORDER BY ID ASC
+
+          INSERT INTO @CurrentURLs (ID, DirectoryPath, Mirror, DirectoryNumber)
+          SELECT ROW_NUMBER() OVER (ORDER BY ID),
+                 DirectoryPath + CASE WHEN @CurrentDirectoryStructure IS NOT NULL THEN @DirectorySeparator + @CurrentDirectoryStructure ELSE '' END,
+                 Mirror,
+                 ROW_NUMBER() OVER (PARTITION BY Mirror ORDER BY ID ASC)
+          FROM @URLs
+          ORDER BY ID ASC
+
+          SELECT @CurrentDatabaseFileName = CASE
+          WHEN @CurrentAvailabilityGroup IS NOT NULL THEN @AvailabilityGroupFileName
+          ELSE @FileName
+          END
+
+          -- File name - remove tokens that are not needed
+          IF @CurrentFileGroupName IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}','')
+          IF @ReadWriteFileGroups = 'N' SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Partial}','')
+          IF @CopyOnly = 'N' SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{CopyOnly}','')
+          IF @Cluster IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ClusterName}','')
+          IF @CurrentAvailabilityGroup IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{AvailabilityGroupName}','')
+          IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{InstanceName}','')
+          IF @@SERVICENAME IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServiceName}','')
+          IF @Description IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Description}','')
+          IF @BackupSetName IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupSetName}','')
+          IF @CurrentNumberOfFiles = 1 SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileNumber}','')
+          IF @CurrentNumberOfFiles = 1 SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{NumberOfFiles}','')
 
           WHILE (@Updated = 1 OR @Updated IS NULL)
           BEGIN
             SET @Updated = 0
 
-            IF CHARINDEX('\',@CurrentDirectoryStructure) > 0
+            IF CHARINDEX('__',@CurrentDatabaseFileName) > 0
             BEGIN
-              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'\','{DirectorySeparator}')
+              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'__','_')
               SET @Updated = 1
             END
 
-            IF CHARINDEX('/',@CurrentDirectoryStructure) > 0
+            IF CHARINDEX('--',@CurrentDatabaseFileName) > 0
             BEGIN
-              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'/','{DirectorySeparator}')
+              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'--','-')
               SET @Updated = 1
             END
 
-            IF CHARINDEX('__',@CurrentDirectoryStructure) > 0
+            IF CHARINDEX('_$',@CurrentDatabaseFileName) > 0
             BEGIN
-              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'__','_')
+              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'_$','_')
+              SET @Updated = 1
+            END
+            IF CHARINDEX('$_',@CurrentDatabaseFileName) > 0
+            BEGIN
+              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'$_','_')
               SET @Updated = 1
             END
 
-            IF CHARINDEX('--',@CurrentDirectoryStructure) > 0
+            IF CHARINDEX('-$',@CurrentDatabaseFileName) > 0
             BEGIN
-              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'--','-')
+              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'-$','-')
+              SET @Updated = 1
+            END
+            IF CHARINDEX('$-',@CurrentDatabaseFileName) > 0
+            BEGIN
+              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'$-','-')
               SET @Updated = 1
             END
 
-            IF CHARINDEX('{DirectorySeparator}{DirectorySeparator}',@CurrentDirectoryStructure) > 0
+            IF CHARINDEX('_.',@CurrentDatabaseFileName) > 0
             BEGIN
-              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}{DirectorySeparator}','{DirectorySeparator}')
+              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'_.','.')
               SET @Updated = 1
             END
 
-            IF CHARINDEX('{DirectorySeparator}$',@CurrentDirectoryStructure) > 0
+            IF CHARINDEX('-.',@CurrentDatabaseFileName) > 0
             BEGIN
-              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}$','{DirectorySeparator}')
-              SET @Updated = 1
-            END
-            IF CHARINDEX('${DirectorySeparator}',@CurrentDirectoryStructure) > 0
-            BEGIN
-              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'${DirectorySeparator}','{DirectorySeparator}')
+              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'-.','.')
               SET @Updated = 1
             END
 
-            IF CHARINDEX('{DirectorySeparator}_',@CurrentDirectoryStructure) > 0
+            IF CHARINDEX('of.',@CurrentDatabaseFileName) > 0
             BEGIN
-              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}_','{DirectorySeparator}')
-              SET @Updated = 1
-            END
-            IF CHARINDEX('_{DirectorySeparator}',@CurrentDirectoryStructure) > 0
-            BEGIN
-              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'_{DirectorySeparator}','{DirectorySeparator}')
+              SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'of.','.')
               SET @Updated = 1
             END
 
-            IF CHARINDEX('{DirectorySeparator}-',@CurrentDirectoryStructure) > 0
+            IF LEFT(@CurrentDatabaseFileName,1) = '_'
             BEGIN
-              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}-','{DirectorySeparator}')
+              SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
               SET @Updated = 1
             END
-            IF CHARINDEX('-{DirectorySeparator}',@CurrentDirectoryStructure) > 0
+            IF RIGHT(@CurrentDatabaseFileName,1) = '_'
             BEGIN
-              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'-{DirectorySeparator}','{DirectorySeparator}')
-              SET @Updated = 1
-            END
-
-            IF CHARINDEX('_$',@CurrentDirectoryStructure) > 0
-            BEGIN
-              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'_$','_')
-              SET @Updated = 1
-            END
-            IF CHARINDEX('$_',@CurrentDirectoryStructure) > 0
-            BEGIN
-              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'$_','_')
+              SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
               SET @Updated = 1
             END
 
-            IF CHARINDEX('-$',@CurrentDirectoryStructure) > 0
+            IF LEFT(@CurrentDatabaseFileName,1) = '-'
             BEGIN
-              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'-$','-')
+              SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
               SET @Updated = 1
             END
-            IF CHARINDEX('$-',@CurrentDirectoryStructure) > 0
+            IF RIGHT(@CurrentDatabaseFileName,1) = '-'
             BEGIN
-              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'$-','-')
-              SET @Updated = 1
-            END
-
-            IF LEFT(@CurrentDirectoryStructure,1) = '_'
-            BEGIN
-              SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-              SET @Updated = 1
-            END
-            IF RIGHT(@CurrentDirectoryStructure,1) = '_'
-            BEGIN
-              SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
               SET @Updated = 1
             END
 
-            IF LEFT(@CurrentDirectoryStructure,1) = '-'
+            IF LEFT(@CurrentDatabaseFileName,1) = '$'
             BEGIN
-              SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
               SET @Updated = 1
             END
-            IF RIGHT(@CurrentDirectoryStructure,1) = '-'
+            IF RIGHT(@CurrentDatabaseFileName,1) = '$'
             BEGIN
-              SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-              SET @Updated = 1
-            END
-
-            IF LEFT(@CurrentDirectoryStructure,1) = '$'
-            BEGIN
-              SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-              SET @Updated = 1
-            END
-            IF RIGHT(@CurrentDirectoryStructure,1) = '$'
-            BEGIN
-              SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-              SET @Updated = 1
-            END
-
-            IF LEFT(@CurrentDirectoryStructure,20) = '{DirectorySeparator}'
-            BEGIN
-              SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 20)
-              SET @Updated = 1
-            END
-            IF RIGHT(@CurrentDirectoryStructure,20) = '{DirectorySeparator}'
-            BEGIN
-              SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 20)
+              SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
               SET @Updated = 1
             END
           END
 
           SET @Updated = NULL
 
-          -- Directory structure - replace tokens with real values
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}',@DirectorySeparator)
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServerName}',CASE WHEN SERVERPROPERTY('EngineEdition') = 8 THEN LEFT(CAST(SERVERPROPERTY('ServerName') AS nvarchar(max)),CHARINDEX('.',CAST(SERVERPROPERTY('ServerName') AS nvarchar(max))) - 1) ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar(max)) END)
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}',ISNULL(CAST(SERVERPROPERTY('InstanceName') AS nvarchar(max)),''))
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServiceName}',ISNULL(@@SERVICENAME,''))
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}',ISNULL(@Cluster,''))
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}',ISNULL(@CurrentAvailabilityGroup,''))
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DatabaseName}',@CurrentDatabaseNameFS)
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}',ISNULL(@CurrentFileGroupName,''))
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupType}',@CurrentBackupType)
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Partial}','PARTIAL')
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{CopyOnly}','COPY_ONLY')
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Description}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@Description,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupSetName}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@BackupSetName,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Year}',CAST(DATEPART(YEAR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar))
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Month}',RIGHT('0' + CAST(DATEPART(MONTH,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Day}',RIGHT('0' + CAST(DATEPART(DAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Week}',RIGHT('0' + CAST(DATEPART(WEEK,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Weekday}',DATENAME(WEEKDAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END))
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Hour}',RIGHT('0' + CAST(DATEPART(HOUR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Minute}',RIGHT('0' + CAST(DATEPART(MINUTE,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Second}',RIGHT('0' + CAST(DATEPART(SECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Millisecond}',RIGHT('00' + CAST(DATEPART(MILLISECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),3))
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Microsecond}',RIGHT('00000' + CAST(DATEPART(MICROSECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),6))
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{MajorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMajorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4)))
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{MinorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMinorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3)))
-        END
-
-        IF @DirectoryStructureCase IS NOT NULL
-        BEGIN
-          SET @CurrentDirectoryStructure = CASE WHEN @DirectoryStructureCase = 'LOWER' THEN LOWER(@CurrentDirectoryStructure)
-                                                WHEN @DirectoryStructureCase = 'UPPER' THEN UPPER(@CurrentDirectoryStructure) END
-        END
-
-        INSERT INTO @CurrentDirectories (ID, DirectoryPath, Mirror, DirectoryNumber, CreateCompleted, CleanupCompleted)
-        SELECT ROW_NUMBER() OVER (ORDER BY ID),
-               DirectoryPath + CASE WHEN DirectoryPath = 'NUL' THEN '' WHEN @CurrentDirectoryStructure IS NOT NULL THEN @DirectorySeparator + @CurrentDirectoryStructure ELSE '' END,
-               Mirror,
-               ROW_NUMBER() OVER (PARTITION BY Mirror ORDER BY ID ASC),
-               0,
-               0
-        FROM @Directories
-        ORDER BY ID ASC
-
-        INSERT INTO @CurrentURLs (ID, DirectoryPath, Mirror, DirectoryNumber)
-        SELECT ROW_NUMBER() OVER (ORDER BY ID),
-               DirectoryPath + CASE WHEN @CurrentDirectoryStructure IS NOT NULL THEN @DirectorySeparator + @CurrentDirectoryStructure ELSE '' END,
-               Mirror,
-               ROW_NUMBER() OVER (PARTITION BY Mirror ORDER BY ID ASC)
-        FROM @URLs
-        ORDER BY ID ASC
-
-        SELECT @CurrentDatabaseFileName = CASE
-        WHEN @CurrentAvailabilityGroup IS NOT NULL THEN @AvailabilityGroupFileName
-        ELSE @FileName
-        END
-
-        -- File name - remove tokens that are not needed
-        IF @CurrentFileGroupName IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}','')
-        IF @ReadWriteFileGroups = 'N' SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Partial}','')
-        IF @CopyOnly = 'N' SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{CopyOnly}','')
-        IF @Cluster IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ClusterName}','')
-        IF @CurrentAvailabilityGroup IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{AvailabilityGroupName}','')
-        IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{InstanceName}','')
-        IF @@SERVICENAME IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServiceName}','')
-        IF @Description IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Description}','')
-        IF @BackupSetName IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupSetName}','')
-        IF @CurrentNumberOfFiles = 1 SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileNumber}','')
-        IF @CurrentNumberOfFiles = 1 SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{NumberOfFiles}','')
-
-        WHILE (@Updated = 1 OR @Updated IS NULL)
-        BEGIN
-          SET @Updated = 0
-
-          IF CHARINDEX('__',@CurrentDatabaseFileName) > 0
-          BEGIN
-            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'__','_')
-            SET @Updated = 1
+          SELECT @CurrentFileExtension = CASE
+          WHEN @CurrentBackupType = 'FULL' THEN @FileExtensionFull
+          WHEN @CurrentBackupType = 'DIFF' THEN @FileExtensionDiff
+          WHEN @CurrentBackupType = 'LOG' THEN @FileExtensionLog
           END
 
-          IF CHARINDEX('--',@CurrentDatabaseFileName) > 0
+          -- File name - replace tokens with real values
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServerName}',CASE WHEN SERVERPROPERTY('EngineEdition') = 8 THEN LEFT(CAST(SERVERPROPERTY('ServerName') AS nvarchar(max)),CHARINDEX('.',CAST(SERVERPROPERTY('ServerName') AS nvarchar(max))) - 1) ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar(max)) END)
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{InstanceName}',ISNULL(CAST(SERVERPROPERTY('InstanceName') AS nvarchar(max)),''))
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServiceName}',ISNULL(@@SERVICENAME,''))
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ClusterName}',ISNULL(@Cluster,''))
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{AvailabilityGroupName}',ISNULL(@CurrentAvailabilityGroup,''))
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}',ISNULL(@CurrentFileGroupName,''))
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupType}',@CurrentBackupType)
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Partial}','PARTIAL')
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{CopyOnly}','COPY_ONLY')
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Description}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@Description,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupSetName}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@BackupSetName,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Year}',CAST(DATEPART(YEAR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar))
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Month}',RIGHT('0' + CAST(DATEPART(MONTH,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Day}',RIGHT('0' + CAST(DATEPART(DAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Week}',RIGHT('0' + CAST(DATEPART(WEEK,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Weekday}',DATENAME(WEEKDAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END))
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Hour}',RIGHT('0' + CAST(DATEPART(HOUR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Minute}',RIGHT('0' + CAST(DATEPART(MINUTE,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Second}',RIGHT('0' + CAST(DATEPART(SECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Millisecond}',RIGHT('00' + CAST(DATEPART(MILLISECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),3))
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Microsecond}',RIGHT('00000' + CAST(DATEPART(MICROSECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),6))
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{NumberOfFiles}',@CurrentNumberOfFiles)
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileExtension}',@CurrentFileExtension)
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{MajorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMajorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4)))
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{MinorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMinorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3)))
+
+          SELECT @CurrentMaxFilePathLength = CASE
+          WHEN EXISTS (SELECT * FROM @CurrentDirectories) THEN (SELECT MAX(LEN(DirectoryPath + @DirectorySeparator)) FROM @CurrentDirectories)
+          WHEN EXISTS (SELECT * FROM @CurrentURLs) THEN (SELECT MAX(LEN(DirectoryPath + @DirectorySeparator)) FROM @CurrentURLs)
+          END
+          + LEN(REPLACE(REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',@CurrentDatabaseNameFS), '{FileNumber}', CASE WHEN @CurrentNumberOfFiles >= 1 AND @CurrentNumberOfFiles <= 9 THEN '1' WHEN @CurrentNumberOfFiles >= 10 THEN '01' END))
+
+          -- The maximum length of a backup device is 259 characters
+          IF @CurrentMaxFilePathLength > 259
           BEGIN
-            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'--','-')
-            SET @Updated = 1
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',LEFT(@CurrentDatabaseNameFS,CASE WHEN (LEN(@CurrentDatabaseNameFS) + 259 - @CurrentMaxFilePathLength - 3) < 20 THEN 20 ELSE (LEN(@CurrentDatabaseNameFS) + 259 - @CurrentMaxFilePathLength - 3) END) + '...')
+          END
+          ELSE
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',@CurrentDatabaseNameFS)
           END
 
-          IF CHARINDEX('_$',@CurrentDatabaseFileName) > 0
+          IF @FileNameCase IS NOT NULL
           BEGIN
-            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'_$','_')
-            SET @Updated = 1
-          END
-          IF CHARINDEX('$_',@CurrentDatabaseFileName) > 0
-          BEGIN
-            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'$_','_')
-            SET @Updated = 1
+            SET @CurrentDatabaseFileName = CASE WHEN @FileNameCase = 'LOWER' THEN LOWER(@CurrentDatabaseFileName)
+                                                WHEN @FileNameCase = 'UPPER' THEN UPPER(@CurrentDatabaseFileName) END
           END
 
-          IF CHARINDEX('-$',@CurrentDatabaseFileName) > 0
+          IF EXISTS (SELECT * FROM @CurrentDirectories WHERE Mirror = 0)
           BEGIN
-            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'-$','-')
-            SET @Updated = 1
-          END
-          IF CHARINDEX('$-',@CurrentDatabaseFileName) > 0
-          BEGIN
-            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'$-','-')
-            SET @Updated = 1
-          END
+            SET @CurrentFileNumber = 0
 
-          IF CHARINDEX('_.',@CurrentDatabaseFileName) > 0
-          BEGIN
-            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'_.','.')
-            SET @Updated = 1
-          END
-
-          IF CHARINDEX('-.',@CurrentDatabaseFileName) > 0
-          BEGIN
-            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'-.','.')
-            SET @Updated = 1
-          END
-
-          IF CHARINDEX('of.',@CurrentDatabaseFileName) > 0
-          BEGIN
-            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'of.','.')
-            SET @Updated = 1
-          END
-
-          IF LEFT(@CurrentDatabaseFileName,1) = '_'
-          BEGIN
-            SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
-            SET @Updated = 1
-          END
-          IF RIGHT(@CurrentDatabaseFileName,1) = '_'
-          BEGIN
-            SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
-            SET @Updated = 1
-          END
-
-          IF LEFT(@CurrentDatabaseFileName,1) = '-'
-          BEGIN
-            SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
-            SET @Updated = 1
-          END
-          IF RIGHT(@CurrentDatabaseFileName,1) = '-'
-          BEGIN
-            SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
-            SET @Updated = 1
-          END
-
-          IF LEFT(@CurrentDatabaseFileName,1) = '$'
-          BEGIN
-            SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
-            SET @Updated = 1
-          END
-          IF RIGHT(@CurrentDatabaseFileName,1) = '$'
-          BEGIN
-            SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
-            SET @Updated = 1
-          END
-        END
-
-        SET @Updated = NULL
-
-        SELECT @CurrentFileExtension = CASE
-        WHEN @CurrentBackupType = 'FULL' THEN @FileExtensionFull
-        WHEN @CurrentBackupType = 'DIFF' THEN @FileExtensionDiff
-        WHEN @CurrentBackupType = 'LOG' THEN @FileExtensionLog
-        END
-
-        -- File name - replace tokens with real values
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServerName}',CASE WHEN SERVERPROPERTY('EngineEdition') = 8 THEN LEFT(CAST(SERVERPROPERTY('ServerName') AS nvarchar(max)),CHARINDEX('.',CAST(SERVERPROPERTY('ServerName') AS nvarchar(max))) - 1) ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar(max)) END)
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{InstanceName}',ISNULL(CAST(SERVERPROPERTY('InstanceName') AS nvarchar(max)),''))
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServiceName}',ISNULL(@@SERVICENAME,''))
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ClusterName}',ISNULL(@Cluster,''))
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{AvailabilityGroupName}',ISNULL(@CurrentAvailabilityGroup,''))
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}',ISNULL(@CurrentFileGroupName,''))
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupType}',@CurrentBackupType)
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Partial}','PARTIAL')
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{CopyOnly}','COPY_ONLY')
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Description}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@Description,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupSetName}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@BackupSetName,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Year}',CAST(DATEPART(YEAR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar))
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Month}',RIGHT('0' + CAST(DATEPART(MONTH,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Day}',RIGHT('0' + CAST(DATEPART(DAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Week}',RIGHT('0' + CAST(DATEPART(WEEK,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Weekday}',DATENAME(WEEKDAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END))
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Hour}',RIGHT('0' + CAST(DATEPART(HOUR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Minute}',RIGHT('0' + CAST(DATEPART(MINUTE,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Second}',RIGHT('0' + CAST(DATEPART(SECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Millisecond}',RIGHT('00' + CAST(DATEPART(MILLISECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),3))
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Microsecond}',RIGHT('00000' + CAST(DATEPART(MICROSECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),6))
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{NumberOfFiles}',@CurrentNumberOfFiles)
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileExtension}',@CurrentFileExtension)
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{MajorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMajorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4)))
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{MinorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMinorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3)))
-
-        SELECT @CurrentMaxFilePathLength = CASE
-        WHEN EXISTS (SELECT * FROM @CurrentDirectories) THEN (SELECT MAX(LEN(DirectoryPath + @DirectorySeparator)) FROM @CurrentDirectories)
-        WHEN EXISTS (SELECT * FROM @CurrentURLs) THEN (SELECT MAX(LEN(DirectoryPath + @DirectorySeparator)) FROM @CurrentURLs)
-        END
-        + LEN(REPLACE(REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',@CurrentDatabaseNameFS), '{FileNumber}', CASE WHEN @CurrentNumberOfFiles >= 1 AND @CurrentNumberOfFiles <= 9 THEN '1' WHEN @CurrentNumberOfFiles >= 10 THEN '01' END))
-
-        -- The maximum length of a backup device is 259 characters
-        IF @CurrentMaxFilePathLength > 259
-        BEGIN
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',LEFT(@CurrentDatabaseNameFS,CASE WHEN (LEN(@CurrentDatabaseNameFS) + 259 - @CurrentMaxFilePathLength - 3) < 20 THEN 20 ELSE (LEN(@CurrentDatabaseNameFS) + 259 - @CurrentMaxFilePathLength - 3) END) + '...')
-        END
-        ELSE
-        BEGIN
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',@CurrentDatabaseNameFS)
-        END
-
-        IF @FileNameCase IS NOT NULL
-        BEGIN
-          SET @CurrentDatabaseFileName = CASE WHEN @FileNameCase = 'LOWER' THEN LOWER(@CurrentDatabaseFileName)
-                                              WHEN @FileNameCase = 'UPPER' THEN UPPER(@CurrentDatabaseFileName) END
-        END
-
-        IF EXISTS (SELECT * FROM @CurrentDirectories WHERE Mirror = 0)
-        BEGIN
-          SET @CurrentFileNumber = 0
-
-          WHILE @CurrentFileNumber < @CurrentNumberOfFiles
-          BEGIN
-            SET @CurrentFileNumber = @CurrentFileNumber + 1
-
-            SELECT @CurrentDirectoryPath = DirectoryPath
-            FROM @CurrentDirectories
-            WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 0) + 1
-            AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 0)
-            AND Mirror = 0
-
-            SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles >= 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) END)
-
-            IF @CurrentDirectoryPath = 'NUL'
+            WHILE @CurrentFileNumber < @CurrentNumberOfFiles
             BEGIN
-              SET @CurrentFilePath = 'NUL'
+              SET @CurrentFileNumber = @CurrentFileNumber + 1
+
+              SELECT @CurrentDirectoryPath = DirectoryPath
+              FROM @CurrentDirectories
+              WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 0) + 1
+              AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 0)
+              AND Mirror = 0
+
+              SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles >= 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) END)
+
+              IF @CurrentDirectoryPath = 'NUL'
+              BEGIN
+                SET @CurrentFilePath = 'NUL'
+              END
+              ELSE
+              BEGIN
+                SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
+              END
+
+              INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
+              SELECT 'DISK', @CurrentFilePath, 0
+
+              SET @CurrentDirectoryPath = NULL
+              SET @CurrentFileName = NULL
+              SET @CurrentFilePath = NULL
             END
-            ELSE
+
+            INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
+            SELECT 0, 0
+          END
+
+          IF EXISTS (SELECT * FROM @CurrentDirectories WHERE Mirror = 1)
+          BEGIN
+            SET @CurrentFileNumber = 0
+
+            WHILE @CurrentFileNumber < @CurrentNumberOfFiles
             BEGIN
+              SET @CurrentFileNumber = @CurrentFileNumber + 1
+
+              SELECT @CurrentDirectoryPath = DirectoryPath
+              FROM @CurrentDirectories
+              WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 1) + 1
+              AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 1)
+              AND Mirror = 1
+
+              SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
+
               SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
+
+              INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
+              SELECT 'DISK', @CurrentFilePath, 1
+
+              SET @CurrentDirectoryPath = NULL
+              SET @CurrentFileName = NULL
+              SET @CurrentFilePath = NULL
             END
 
-            INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
-            SELECT 'DISK', @CurrentFilePath, 0
-
-            SET @CurrentDirectoryPath = NULL
-            SET @CurrentFileName = NULL
-            SET @CurrentFilePath = NULL
+            INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
+            SELECT 1, 0
           END
 
-          INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
-          SELECT 0, 0
-        END
-
-        IF EXISTS (SELECT * FROM @CurrentDirectories WHERE Mirror = 1)
-        BEGIN
-          SET @CurrentFileNumber = 0
-
-          WHILE @CurrentFileNumber < @CurrentNumberOfFiles
+          IF EXISTS (SELECT * FROM @CurrentURLs WHERE Mirror = 0)
           BEGIN
-            SET @CurrentFileNumber = @CurrentFileNumber + 1
+            SET @CurrentFileNumber = 0
 
-            SELECT @CurrentDirectoryPath = DirectoryPath
-            FROM @CurrentDirectories
-            WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 1) + 1
-            AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 1)
-            AND Mirror = 1
-
-            SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
-
-            SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
-
-            INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
-            SELECT 'DISK', @CurrentFilePath, 1
-
-            SET @CurrentDirectoryPath = NULL
-            SET @CurrentFileName = NULL
-            SET @CurrentFilePath = NULL
-          END
-
-          INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
-          SELECT 1, 0
-        END
-
-        IF EXISTS (SELECT * FROM @CurrentURLs WHERE Mirror = 0)
-        BEGIN
-          SET @CurrentFileNumber = 0
-
-          WHILE @CurrentFileNumber < @CurrentNumberOfFiles
-          BEGIN
-            SET @CurrentFileNumber = @CurrentFileNumber + 1
-
-            SELECT @CurrentDirectoryPath = DirectoryPath
-            FROM @CurrentURLs
-            WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0) + 1
-            AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0)
-            AND Mirror = 0
-
-            SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
-
-            SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
-
-            INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
-            SELECT 'URL', @CurrentFilePath, 0
-
-            SET @CurrentDirectoryPath = NULL
-            SET @CurrentFileName = NULL
-            SET @CurrentFilePath = NULL
-          END
-
-          INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
-          SELECT 0, 0
-        END
-
-        IF EXISTS (SELECT * FROM @CurrentURLs WHERE Mirror = 1)
-        BEGIN
-          SET @CurrentFileNumber = 0
-
-          WHILE @CurrentFileNumber < @CurrentNumberOfFiles
-          BEGIN
-            SET @CurrentFileNumber = @CurrentFileNumber + 1
-
-            SELECT @CurrentDirectoryPath = DirectoryPath
-            FROM @CurrentURLs
-            WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0) + 1
-            AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0)
-            AND Mirror = 1
-
-            SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
-
-            SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
-
-            INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
-            SELECT 'URL', @CurrentFilePath, 1
-
-            SET @CurrentDirectoryPath = NULL
-            SET @CurrentFileName = NULL
-            SET @CurrentFilePath = NULL
-          END
-
-          INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
-          SELECT 1, 0
-        END
-
-        -- Create directory
-        IF @HostPlatform = 'Windows'
-        AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
-        AND NOT EXISTS(SELECT * FROM @CurrentDirectories WHERE DirectoryPath = 'NUL' OR DirectoryPath IN(SELECT DirectoryPath FROM @Directories))
-        BEGIN
-          WHILE (1 = 1)
-          BEGIN
-            SELECT TOP 1 @CurrentDirectoryID = ID,
-                         @CurrentDirectoryPath = DirectoryPath
-            FROM @CurrentDirectories
-            WHERE CreateCompleted = 0
-            ORDER BY ID ASC
-
-            IF @@ROWCOUNT = 0
+            WHILE @CurrentFileNumber < @CurrentNumberOfFiles
             BEGIN
-              BREAK
+              SET @CurrentFileNumber = @CurrentFileNumber + 1
+
+              SELECT @CurrentDirectoryPath = DirectoryPath
+              FROM @CurrentURLs
+              WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0) + 1
+              AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0)
+              AND Mirror = 0
+
+              SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
+
+              SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
+
+              INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
+              SELECT 'URL', @CurrentFilePath, 0
+
+              SET @CurrentDirectoryPath = NULL
+              SET @CurrentFileName = NULL
+              SET @CurrentFilePath = NULL
             END
 
-            IF @DirectoryCheck = 'Y'
+            INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
+            SELECT 0, 0
+          END
+
+          IF EXISTS (SELECT * FROM @CurrentURLs WHERE Mirror = 1)
+          BEGIN
+            SET @CurrentFileNumber = 0
+
+            WHILE @CurrentFileNumber < @CurrentNumberOfFiles
             BEGIN
-              INSERT INTO @DirectoryInfo (FileExists, FileIsADirectory, ParentDirectoryExists)
-              EXECUTE [master].dbo.xp_fileexist @CurrentDirectoryPath
+              SET @CurrentFileNumber = @CurrentFileNumber + 1
+
+              SELECT @CurrentDirectoryPath = DirectoryPath
+              FROM @CurrentURLs
+              WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0) + 1
+              AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0)
+              AND Mirror = 1
+
+              SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
+
+              SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
+
+              INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
+              SELECT 'URL', @CurrentFilePath, 1
+
+              SET @CurrentDirectoryPath = NULL
+              SET @CurrentFileName = NULL
+              SET @CurrentFilePath = NULL
             END
 
-            IF NOT EXISTS (SELECT * FROM @DirectoryInfo WHERE FileExists = 0 AND FileIsADirectory = 1 AND ParentDirectoryExists = 1)
+            INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
+            SELECT 1, 0
+          END
+
+          -- Create directory
+          IF @HostPlatform = 'Windows'
+          AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
+          AND NOT EXISTS(SELECT * FROM @CurrentDirectories WHERE DirectoryPath = 'NUL' OR DirectoryPath IN(SELECT DirectoryPath FROM @Directories))
+          BEGIN
+            WHILE (1 = 1)
             BEGIN
-              SET @CurrentDatabaseContext = 'master'
+              SELECT TOP 1 @CurrentDirectoryID = ID,
+                           @CurrentDirectoryPath = DirectoryPath
+              FROM @CurrentDirectories
+              WHERE CreateCompleted = 0
+              ORDER BY ID ASC
 
-              SET @CurrentCommandType = 'xp_create_subdir'
+              IF @@ROWCOUNT = 0
+              BEGIN
+                BREAK
+              END
 
-              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_create_subdir N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''' IF @ReturnCode <> 0 RAISERROR(''Error creating directory.'', 16, 1)'
+              IF @DirectoryCheck = 'Y'
+              BEGIN
+                INSERT INTO @DirectoryInfo (FileExists, FileIsADirectory, ParentDirectoryExists)
+                EXECUTE [master].dbo.xp_fileexist @CurrentDirectoryPath
+              END
+
+              IF NOT EXISTS (SELECT * FROM @DirectoryInfo WHERE FileExists = 0 AND FileIsADirectory = 1 AND ParentDirectoryExists = 1)
+              BEGIN
+                SET @CurrentDatabaseContext = 'master'
+
+                SET @CurrentCommandType = 'xp_create_subdir'
+
+                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_create_subdir N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''' IF @ReturnCode <> 0 RAISERROR(''Error creating directory.'', 16, 1)'
+
+                EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
+                SET @Error = @@ERROR
+                IF @Error <> 0 SET @CurrentCommandOutput = @Error
+                IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
+
+                UPDATE @CurrentDirectories
+                SET CreateCompleted = 1,
+                    CreateOutput = @CurrentCommandOutput
+                WHERE ID = @CurrentDirectoryID
+              END
+              ELSE
+              BEGIN
+                UPDATE @CurrentDirectories
+                SET CreateCompleted = 1,
+                    CreateOutput = 0
+                WHERE ID = @CurrentDirectoryID
+              END
+
+              SET @CurrentDirectoryID = NULL
+              SET @CurrentDirectoryPath = NULL
+
+              SET @CurrentDatabaseContext = NULL
+              SET @CurrentCommand = NULL
+              SET @CurrentCommandOutput = NULL
+              SET @CurrentCommandType = NULL
+
+              DELETE FROM @DirectoryInfo
+            END
+          END
+
+          IF @CleanupMode = 'BEFORE_BACKUP'
+          BEGIN
+            INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
+            SELECT DATEADD(hh,-(@CleanupTime),SYSDATETIME()), 0
+
+            IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 0 OR Mirror IS NULL) AND CleanupDate IS NULL)
+            BEGIN
+              UPDATE @CurrentDirectories
+              SET CleanupDate = (SELECT MIN(CleanupDate)
+                                 FROM @CurrentCleanupDates
+                                 WHERE (Mirror = 0 OR Mirror IS NULL)),
+                  CleanupMode = 'BEFORE_BACKUP'
+              WHERE Mirror = 0
+            END
+          END
+
+          IF @MirrorCleanupMode = 'BEFORE_BACKUP'
+          BEGIN
+            INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
+            SELECT DATEADD(hh,-(@MirrorCleanupTime),SYSDATETIME()), 1
+
+            IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 1 OR Mirror IS NULL) AND CleanupDate IS NULL)
+            BEGIN
+              UPDATE @CurrentDirectories
+              SET CleanupDate = (SELECT MIN(CleanupDate)
+                                 FROM @CurrentCleanupDates
+                                 WHERE (Mirror = 1 OR Mirror IS NULL)),
+                  CleanupMode = 'BEFORE_BACKUP'
+              WHERE Mirror = 1
+            END
+          END
+
+          -- Delete old backup files, before backup
+          IF (NOT EXISTS (SELECT * FROM @CurrentDirectories WHERE CreateOutput <> 0 OR CreateOutput IS NULL) OR @HostPlatform = 'Linux')
+          AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
+          AND @CurrentBackupType = @BackupType
+          BEGIN
+            WHILE (1 = 1)
+            BEGIN
+              SELECT TOP 1 @CurrentDirectoryID = ID,
+                           @CurrentDirectoryPath = DirectoryPath,
+                           @CurrentCleanupDate = CleanupDate
+              FROM @CurrentDirectories
+              WHERE CleanupDate IS NOT NULL
+              AND CleanupMode = 'BEFORE_BACKUP'
+              AND CleanupCompleted = 0
+              ORDER BY ID ASC
+
+              IF @@ROWCOUNT = 0
+              BEGIN
+                BREAK
+              END
+
+              IF @BackupSoftware IS NULL
+              BEGIN
+                SET @CurrentDatabaseContext = 'master'
+
+                SET @CurrentCommandType = 'xp_delete_file'
+
+                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_delete_file 0, N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + @CurrentFileExtension + ''', ''' + CONVERT(nvarchar(19),@CurrentCleanupDate,126) + ''' IF @ReturnCode <> 0 RAISERROR(''Error deleting files.'', 16, 1)'
+              END
+
+              IF @BackupSoftware = 'LITESPEED'
+              BEGIN
+                SET @CurrentDatabaseContext = 'master'
+
+                SET @CurrentCommandType = 'xp_slssqlmaint'
+
+                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_slssqlmaint N''-MAINTDEL -DELFOLDER "' + REPLACE(@CurrentDirectoryPath,'''','''''') + '" -DELEXTENSION "' + @CurrentFileExtension + '" -DELUNIT "' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + '" -DELUNITTYPE "minutes" -DELUSEAGE'' IF @ReturnCode <> 0 RAISERROR(''Error deleting LiteSpeed backup files.'', 16, 1)'
+              END
+
+              IF @BackupSoftware = 'SQLBACKUP'
+              BEGIN
+                SET @CurrentDatabaseContext = 'master'
+
+                SET @CurrentCommandType = 'sqbutility'
+
+                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqbutility 1032, N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''', N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + CASE WHEN @CurrentBackupType = 'FULL' THEN 'D' WHEN @CurrentBackupType = 'DIFF' THEN 'I' WHEN @CurrentBackupType = 'LOG' THEN 'L' END + ''', ''' + CAST(DATEDIFF(hh,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'h'', ' + ISNULL('''' + REPLACE(@EncryptionKey,'''','''''') + '''','NULL') + ' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLBackup backup files.'', 16, 1)'
+              END
+
+              IF @BackupSoftware = 'SQLSAFE'
+              BEGIN
+                SET @CurrentDatabaseContext = 'master'
+
+                SET @CurrentCommandType = 'xp_ss_delete'
+
+                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_delete @filename = N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + '\*.' + @CurrentFileExtension + ''', @age = ''' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'Minutes'' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLsafe backup files.'', 16, 1)'
+              END
 
               EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
               SET @Error = @@ERROR
@@ -4208,481 +4337,164 @@ BEGIN
               IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
 
               UPDATE @CurrentDirectories
-              SET CreateCompleted = 1,
-                  CreateOutput = @CurrentCommandOutput
+              SET CleanupCompleted = 1,
+                  CleanupOutput = @CurrentCommandOutput
               WHERE ID = @CurrentDirectoryID
+
+              SET @CurrentDirectoryID = NULL
+              SET @CurrentDirectoryPath = NULL
+              SET @CurrentCleanupDate = NULL
+
+              SET @CurrentDatabaseContext = NULL
+              SET @CurrentCommand = NULL
+              SET @CurrentCommandOutput = NULL
+              SET @CurrentCommandType = NULL
             END
-            ELSE
-            BEGIN
-              UPDATE @CurrentDirectories
-              SET CreateCompleted = 1,
-                  CreateOutput = 0
-              WHERE ID = @CurrentDirectoryID
-            END
-
-            SET @CurrentDirectoryID = NULL
-            SET @CurrentDirectoryPath = NULL
-
-            SET @CurrentDatabaseContext = NULL
-            SET @CurrentCommand = NULL
-            SET @CurrentCommandOutput = NULL
-            SET @CurrentCommandType = NULL
-
-            DELETE FROM @DirectoryInfo
           END
-        END
 
-        IF @CleanupMode = 'BEFORE_BACKUP'
-        BEGIN
-          INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
-          SELECT DATEADD(hh,-(@CleanupTime),SYSDATETIME()), 0
-
-          IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 0 OR Mirror IS NULL) AND CleanupDate IS NULL)
+          -- Perform a backup
+          IF NOT EXISTS (SELECT * FROM @CurrentDirectories WHERE DirectoryPath <> 'NUL' AND DirectoryPath NOT IN(SELECT DirectoryPath FROM @Directories) AND (CreateOutput <> 0 OR CreateOutput IS NULL))
+          OR @HostPlatform = 'Linux'
           BEGIN
-            UPDATE @CurrentDirectories
-            SET CleanupDate = (SELECT MIN(CleanupDate)
-                               FROM @CurrentCleanupDates
-                               WHERE (Mirror = 0 OR Mirror IS NULL)),
-                CleanupMode = 'BEFORE_BACKUP'
-            WHERE Mirror = 0
-          END
-        END
-
-        IF @MirrorCleanupMode = 'BEFORE_BACKUP'
-        BEGIN
-          INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
-          SELECT DATEADD(hh,-(@MirrorCleanupTime),SYSDATETIME()), 1
-
-          IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 1 OR Mirror IS NULL) AND CleanupDate IS NULL)
-          BEGIN
-            UPDATE @CurrentDirectories
-            SET CleanupDate = (SELECT MIN(CleanupDate)
-                               FROM @CurrentCleanupDates
-                               WHERE (Mirror = 1 OR Mirror IS NULL)),
-                CleanupMode = 'BEFORE_BACKUP'
-            WHERE Mirror = 1
-          END
-        END
-
-        -- Delete old backup files, before backup
-        IF (NOT EXISTS (SELECT * FROM @CurrentDirectories WHERE CreateOutput <> 0 OR CreateOutput IS NULL) OR @HostPlatform = 'Linux')
-        AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
-        AND @CurrentBackupType = @BackupType
-        BEGIN
-          WHILE (1 = 1)
-          BEGIN
-            SELECT TOP 1 @CurrentDirectoryID = ID,
-                         @CurrentDirectoryPath = DirectoryPath,
-                         @CurrentCleanupDate = CleanupDate
-            FROM @CurrentDirectories
-            WHERE CleanupDate IS NOT NULL
-            AND CleanupMode = 'BEFORE_BACKUP'
-            AND CleanupCompleted = 0
-            ORDER BY ID ASC
-
-            IF @@ROWCOUNT = 0
-            BEGIN
-              BREAK
-            END
-
             IF @BackupSoftware IS NULL
             BEGIN
               SET @CurrentDatabaseContext = 'master'
 
-              SET @CurrentCommandType = 'xp_delete_file'
+              SELECT @CurrentCommandType = CASE
+              WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP_DATABASE'
+              WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP_LOG'
+              END
 
-              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_delete_file 0, N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + @CurrentFileExtension + ''', ''' + CONVERT(nvarchar(19),@CurrentCleanupDate,126) + ''' IF @ReturnCode <> 0 RAISERROR(''Error deleting files.'', 16, 1)'
-            END
+              SELECT @CurrentCommand = CASE
+              WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP DATABASE ' + QUOTENAME(@CurrentDatabaseName)
+              WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP LOG ' + QUOTENAME(@CurrentDatabaseName)
+              END
 
-            IF @BackupSoftware = 'LITESPEED'
-            BEGIN
-              SET @CurrentDatabaseContext = 'master'
+              IF @FileGroups IS NOT NULL SET @CurrentCommand += ' FILEGROUP = ''' + @CurrentFileGroupName + ''''
 
-              SET @CurrentCommandType = 'xp_slssqlmaint'
+              IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' READ_WRITE_FILEGROUPS'
 
-              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_slssqlmaint N''-MAINTDEL -DELFOLDER "' + REPLACE(@CurrentDirectoryPath,'''','''''') + '" -DELEXTENSION "' + @CurrentFileExtension + '" -DELUNIT "' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + '" -DELUNITTYPE "minutes" -DELUSEAGE'' IF @ReturnCode <> 0 RAISERROR(''Error deleting LiteSpeed backup files.'', 16, 1)'
-            END
-
-            IF @BackupSoftware = 'SQLBACKUP'
-            BEGIN
-              SET @CurrentDatabaseContext = 'master'
-
-              SET @CurrentCommandType = 'sqbutility'
-
-              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqbutility 1032, N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''', N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + CASE WHEN @CurrentBackupType = 'FULL' THEN 'D' WHEN @CurrentBackupType = 'DIFF' THEN 'I' WHEN @CurrentBackupType = 'LOG' THEN 'L' END + ''', ''' + CAST(DATEDIFF(hh,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'h'', ' + ISNULL('''' + REPLACE(@EncryptionKey,'''','''''') + '''','NULL') + ' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLBackup backup files.'', 16, 1)'
-            END
-
-            IF @BackupSoftware = 'SQLSAFE'
-            BEGIN
-              SET @CurrentDatabaseContext = 'master'
-
-              SET @CurrentCommandType = 'xp_ss_delete'
-
-              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_delete @filename = N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + '\*.' + @CurrentFileExtension + ''', @age = ''' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'Minutes'' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLsafe backup files.'', 16, 1)'
-            END
-
-            EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
-            SET @Error = @@ERROR
-            IF @Error <> 0 SET @CurrentCommandOutput = @Error
-            IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
-
-            UPDATE @CurrentDirectories
-            SET CleanupCompleted = 1,
-                CleanupOutput = @CurrentCommandOutput
-            WHERE ID = @CurrentDirectoryID
-
-            SET @CurrentDirectoryID = NULL
-            SET @CurrentDirectoryPath = NULL
-            SET @CurrentCleanupDate = NULL
-
-            SET @CurrentDatabaseContext = NULL
-            SET @CurrentCommand = NULL
-            SET @CurrentCommandOutput = NULL
-            SET @CurrentCommandType = NULL
-          END
-        END
-
-        -- Perform a backup
-        IF NOT EXISTS (SELECT * FROM @CurrentDirectories WHERE DirectoryPath <> 'NUL' AND DirectoryPath NOT IN(SELECT DirectoryPath FROM @Directories) AND (CreateOutput <> 0 OR CreateOutput IS NULL))
-        OR @HostPlatform = 'Linux'
-        BEGIN
-          IF @BackupSoftware IS NULL
-          BEGIN
-            SET @CurrentDatabaseContext = 'master'
-
-            SELECT @CurrentCommandType = CASE
-            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP_DATABASE'
-            WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP_LOG'
-            END
-
-            SELECT @CurrentCommand = CASE
-            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP DATABASE ' + QUOTENAME(@CurrentDatabaseName)
-            WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP LOG ' + QUOTENAME(@CurrentDatabaseName)
-            END
-
-            IF @FileGroups IS NOT NULL SET @CurrentCommand += ' FILEGROUP = ''' + @CurrentFileGroupName + ''''
-
-            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' READ_WRITE_FILEGROUPS'
-
-            SET @CurrentCommand += ' TO'
-
-            SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
-            FROM @CurrentFiles
-            WHERE Mirror = 0
-            ORDER BY FilePath ASC
-
-            IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
-            BEGIN
-              SET @CurrentCommand += ' MIRROR TO'
+              SET @CurrentCommand += ' TO'
 
               SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
               FROM @CurrentFiles
-              WHERE Mirror = 1
+              WHERE Mirror = 0
               ORDER BY FilePath ASC
-            END
 
-            SET @CurrentCommand += ' WITH '
-            IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
-            IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+              IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
+              BEGIN
+                SET @CurrentCommand += ' MIRROR TO'
 
-            IF @Version >= 10
-            BEGIN
-              SET @CurrentCommand += CASE WHEN @Compress = 'Y' AND (@CurrentIsEncrypted = 0 OR (@CurrentIsEncrypted = 1 AND ((@Version >= 13 AND @CurrentMaxTransferSize >= 65537) OR @Version >= 15.0404316 OR SERVERPROPERTY('EngineEdition') = 8))) THEN ', COMPRESSION' ELSE ', NO_COMPRESSION' END
-            END
-
-            IF @Compress = 'Y' AND @CompressionAlgorithm IS NOT NULL
-            BEGIN
-              SET @CurrentCommand += ' (ALGORITHM = ' + @CompressionAlgorithm + CASE WHEN @CompressionLevel IS NOT NULL THEN ', LEVEL = ' + @CompressionLevel ELSE '' END + ')'
-            END
-
-            IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
-
-            IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
-            BEGIN
-              SET @CurrentCommand += ', FORMAT'
-            END
-
-            IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
-            IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
-            IF @Init = 'Y' SET @CurrentCommand += ', INIT'
-            IF @Format = 'Y' SET @CurrentCommand += ', FORMAT'
-            IF @BlockSize IS NOT NULL SET @CurrentCommand += ', BLOCKSIZE = ' + CAST(@BlockSize AS nvarchar)
-            IF @BufferCount IS NOT NULL SET @CurrentCommand += ', BUFFERCOUNT = ' + CAST(@BufferCount AS nvarchar)
-            IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', MAXTRANSFERSIZE = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
-            IF @Description IS NOT NULL SET @CurrentCommand += ', DESCRIPTION = N''' + REPLACE(@Description,'''','''''') + ''''
-            IF @BackupSetName IS NOT NULL SET @CurrentCommand += ', NAME = N''' + REPLACE(@BackupSetName,'''','''''') + ''''
-            IF @Stats IS NOT NULL SET @CurrentCommand += ', STATS = ' + CAST(@Stats AS nvarchar)
-            IF @BackupOptions IS NOT NULL SET @CurrentCommand += ', BACKUP_OPTIONS = N''' + REPLACE(@BackupOptions,'''','''''') + ''''
-            IF @Encrypt = 'Y' SET @CurrentCommand += ', ENCRYPTION (ALGORITHM = ' + UPPER(@EncryptionAlgorithm) + ', '
-            IF @Encrypt = 'Y' AND @ServerCertificate IS NOT NULL SET @CurrentCommand += 'SERVER CERTIFICATE = ' + QUOTENAME(@ServerCertificate)
-            IF @Encrypt = 'Y' AND @ServerAsymmetricKey IS NOT NULL SET @CurrentCommand += 'SERVER ASYMMETRIC KEY = ' + QUOTENAME(@ServerAsymmetricKey)
-            IF @Encrypt = 'Y' SET @CurrentCommand += ')'
-            IF @URL IS NOT NULL AND @Credential IS NOT NULL SET @CurrentCommand += ', CREDENTIAL = N''' + REPLACE(@Credential,'''','''''') + ''''
-            IF @ExpireDate IS NOT NULL SET @CurrentCommand += ', EXPIREDATE = ''' + CONVERT(nvarchar, @ExpireDate, 21) + ''''
-            IF @RetainDays IS NOT NULL SET @CurrentCommand += ', RETAINDAYS = ' + CAST(@RetainDays AS nvarchar)
-          END
-
-          IF @BackupSoftware = 'LITESPEED'
-          BEGIN
-            SET @CurrentDatabaseContext = 'master'
-
-            SELECT @CurrentCommandType = CASE
-            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'xp_backup_database'
-            WHEN @CurrentBackupType = 'LOG' THEN 'xp_backup_log'
-            END
-
-            SELECT @CurrentCommand = CASE
-            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_backup_database @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
-            WHEN @CurrentBackupType = 'LOG' THEN 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_backup_log @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
-            END
-
-            SELECT @CurrentCommand += ', @filename = N''' + REPLACE(FilePath,'''','''''') + ''''
-            FROM @CurrentFiles
-            WHERE Mirror = 0
-            ORDER BY FilePath ASC
-
-            IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
-            BEGIN
-              SELECT @CurrentCommand += ', @mirror = N''' + REPLACE(FilePath,'''','''''') + ''''
-              FROM @CurrentFiles
-              WHERE Mirror = 1
-              ORDER BY FilePath ASC
-            END
-
-            SET @CurrentCommand += ', @with = '''
-            IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
-            IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
-            IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
-            IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
-            IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
-            IF @BlockSize IS NOT NULL SET @CurrentCommand += ', BLOCKSIZE = ' + CAST(@BlockSize AS nvarchar)
-            SET @CurrentCommand += ''''
-            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ', @read_write_filegroups = 1'
-            IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', @compressionlevel = ' + CAST(@CompressionLevelNumeric AS nvarchar)
-            IF @AdaptiveCompression IS NOT NULL SET @CurrentCommand += ', @adaptivecompression = ''' + CASE WHEN @AdaptiveCompression = 'SIZE' THEN 'Size' WHEN @AdaptiveCompression = 'SPEED' THEN 'Speed' END + ''''
-            IF @BufferCount IS NOT NULL SET @CurrentCommand += ', @buffercount = ' + CAST(@BufferCount AS nvarchar)
-            IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', @maxtransfersize = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
-            IF @Threads IS NOT NULL SET @CurrentCommand += ', @threads = ' + CAST(@Threads AS nvarchar)
-            IF @Init = 'Y' SET @CurrentCommand += ', @init = 1'
-            IF @Format = 'Y' SET @CurrentCommand += ', @format = 1'
-            IF @Throttle IS NOT NULL SET @CurrentCommand += ', @throttle = ' + CAST(@Throttle AS nvarchar)
-            IF @Description IS NOT NULL SET @CurrentCommand += ', @desc = N''' + REPLACE(@Description,'''','''''') + ''''
-            IF @ObjectLevelRecoveryMap = 'Y' SET @CurrentCommand += ', @olrmap = 1'
-            IF @ExpireDate IS NOT NULL SET @CurrentCommand += ', @expiration = ''' + CONVERT(nvarchar, @ExpireDate, 21) + ''''
-            IF @RetainDays IS NOT NULL SET @CurrentCommand += ', @retaindays = ' + CAST(@RetainDays AS nvarchar)
-
-            IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', @cryptlevel = ' + CASE
-            WHEN @EncryptionAlgorithm = 'RC2_40' THEN '0'
-            WHEN @EncryptionAlgorithm = 'RC2_56' THEN '1'
-            WHEN @EncryptionAlgorithm = 'RC2_112' THEN '2'
-            WHEN @EncryptionAlgorithm = 'RC2_128' THEN '3'
-            WHEN @EncryptionAlgorithm = 'TRIPLE_DES_3KEY' THEN '4'
-            WHEN @EncryptionAlgorithm = 'RC4_128' THEN '5'
-            WHEN @EncryptionAlgorithm = 'AES_128' THEN '6'
-            WHEN @EncryptionAlgorithm = 'AES_192' THEN '7'
-            WHEN @EncryptionAlgorithm = 'AES_256' THEN '8'
-            END
-
-            IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptionkey = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
-            SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing LiteSpeed backup.'', 16, 1)'
-          END
-
-          IF @BackupSoftware = 'SQLBACKUP'
-          BEGIN
-            SET @CurrentDatabaseContext = 'master'
-
-            SET @CurrentCommandType = 'sqlbackup'
-
-            SELECT @CurrentCommand = CASE
-            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP DATABASE ' + QUOTENAME(@CurrentDatabaseName)
-            WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP LOG ' + QUOTENAME(@CurrentDatabaseName)
-            END
-
-            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' READ_WRITE_FILEGROUPS'
-
-            SET @CurrentCommand += ' TO'
-
-            SELECT @CurrentCommand += ' DISK = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
-            FROM @CurrentFiles
-            WHERE Mirror = 0
-            ORDER BY FilePath ASC
-
-            SET @CurrentCommand += ' WITH '
-
-            IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
-            BEGIN
-              SET @CurrentCommand += ' MIRRORFILE' + ' = N''' + REPLACE((SELECT FilePath FROM @CurrentFiles WHERE Mirror = 1),'''','''''') + ''', '
-            END
-
-            IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
-            IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
-            IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
-            IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
-            IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
-            IF @Init = 'Y' SET @CurrentCommand += ', INIT'
-            IF @Format = 'Y' SET @CurrentCommand += ', FORMAT'
-            IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', COMPRESSION = ' + CAST(@CompressionLevelNumeric AS nvarchar)
-            IF @Threads IS NOT NULL SET @CurrentCommand += ', THREADCOUNT = ' + CAST(@Threads AS nvarchar)
-            IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', MAXTRANSFERSIZE = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
-            IF @Description IS NOT NULL SET @CurrentCommand += ', DESCRIPTION = N''' + REPLACE(@Description,'''','''''') + ''''
-
-            IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', KEYSIZE = ' + CASE
-            WHEN @EncryptionAlgorithm = 'AES_128' THEN '128'
-            WHEN @EncryptionAlgorithm = 'AES_256' THEN '256'
-            END
-
-            IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', PASSWORD = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqlbackup N''-SQL "' + REPLACE(@CurrentCommand,'''','''''') + '"''' + ' IF @ReturnCode <> 0 RAISERROR(''Error performing SQLBackup backup.'', 16, 1)'
-          END
-
-          IF @BackupSoftware = 'SQLSAFE'
-          BEGIN
-            SET @CurrentDatabaseContext = 'master'
-
-            SET @CurrentCommandType = 'xp_ss_backup'
-
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_backup @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
-
-            SELECT @CurrentCommand += ', ' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) = 1 THEN '@filename' ELSE '@backupfile' END + ' = N''' + REPLACE(FilePath,'''','''''') + ''''
-            FROM @CurrentFiles
-            WHERE Mirror = 0
-            ORDER BY FilePath ASC
-
-            SELECT @CurrentCommand += ', @mirrorfile = N''' + REPLACE(FilePath,'''','''''') + ''''
-            FROM @CurrentFiles
-            WHERE Mirror = 1
-            ORDER BY FilePath ASC
-
-            SET @CurrentCommand += ', @backuptype = ' + CASE WHEN @CurrentBackupType = 'FULL' THEN '''Full''' WHEN @CurrentBackupType = 'DIFF' THEN '''Differential''' WHEN @CurrentBackupType = 'LOG' THEN '''Log''' END
-            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ', @readwritefilegroups = 1'
-            SET @CurrentCommand += ', @checksum = ' + CASE WHEN @Checksum = 'Y' THEN '1' WHEN @Checksum = 'N' THEN '0' END
-            SET @CurrentCommand += ', @copyonly = ' + CASE WHEN @CopyOnly = 'Y' THEN '1' WHEN @CopyOnly = 'N' THEN '0' END
-            IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', @compressionlevel = ' + CAST(@CompressionLevelNumeric AS nvarchar)
-            IF @Threads IS NOT NULL SET @CurrentCommand += ', @threads = ' + CAST(@Threads AS nvarchar)
-            IF @Init = 'Y' SET @CurrentCommand += ', @overwrite = 1'
-            IF @Description IS NOT NULL SET @CurrentCommand += ', @desc = N''' + REPLACE(@Description,'''','''''') + ''''
-
-            IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', @encryptiontype = N''' + CASE
-            WHEN @EncryptionAlgorithm = 'AES_128' THEN 'AES128'
-            WHEN @EncryptionAlgorithm = 'AES_256' THEN 'AES256'
-            END + ''''
-
-            IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptedbackuppassword = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
-            SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing SQLsafe backup.'', 16, 1)'
-          END
-
-          IF @BackupSoftware = 'DATA_DOMAIN_BOOST'
-          BEGIN
-            SET @CurrentDatabaseContext = 'master'
-
-            SET @CurrentCommandType = 'emc_run_backup'
-
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.emc_run_backup '''
-
-            SET @CurrentCommand += ' -c ' + CASE WHEN @Cluster IS NOT NULL AND @CurrentAvailabilityGroup IS NOT NULL THEN @Cluster ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar) END
-
-            SET @CurrentCommand += ' -l ' + CASE
-            WHEN @CurrentBackupType = 'FULL' THEN 'full'
-            WHEN @CurrentBackupType = 'DIFF' THEN 'diff'
-            WHEN @CurrentBackupType = 'LOG' THEN 'incr'
-            END
-
-            IF @NoRecovery = 'Y' SET @CurrentCommand += ' -H'
-
-            IF @CleanupTime IS NOT NULL SET @CurrentCommand += ' -y +' + CAST(@CleanupTime/24 + CASE WHEN @CleanupTime%24 > 0 THEN 1 ELSE 0 END AS nvarchar) + 'd'
-
-            IF @Checksum = 'Y' SET @CurrentCommand += ' -k'
-
-            SET @CurrentCommand += ' -S ' + CAST(@CurrentNumberOfFiles AS nvarchar)
-
-            IF @Description IS NOT NULL SET @CurrentCommand += ' -b "' + REPLACE(@Description,'''','''''') + '"'
-
-            IF @BufferCount IS NOT NULL SET @CurrentCommand += ' -O "BUFFERCOUNT=' + CAST(@BufferCount AS nvarchar) + '"'
-
-            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' -O "READ_WRITE_FILEGROUPS"'
-
-            IF @DataDomainBoostHost IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_HOST=' + REPLACE(@DataDomainBoostHost,'''','''''') + '"'
-            IF @DataDomainBoostUser IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_USER=' + REPLACE(@DataDomainBoostUser,'''','''''') + '"'
-            IF @DataDomainBoostDevicePath IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DEVICE_PATH=' + REPLACE(@DataDomainBoostDevicePath,'''','''''') + '"'
-            IF @DataDomainBoostLockboxPath IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_LOCKBOX_PATH=' + REPLACE(@DataDomainBoostLockboxPath,'''','''''') + '"'
-            SET @CurrentCommand += ' -a "NSR_SKIP_NON_BACKUPABLE_STATE_DB=TRUE"'
-            SET @CurrentCommand += ' -a "BACKUP_PROMOTION=NONE"'
-            IF @CopyOnly = 'Y' SET @CurrentCommand += ' -a "NSR_COPY_ONLY=TRUE"'
-            IF @BackupSetName IS NOT NULL SET @CurrentCommand += ' -N "' + REPLACE(@BackupSetName,'''','''''') + '"'
-
-            IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentCommand += ' "MSSQL'
-            IF SERVERPROPERTY('InstanceName') IS NOT NULL SET @CurrentCommand += ' "MSSQL$' + CAST(SERVERPROPERTY('InstanceName') AS nvarchar)
-            SET @CurrentCommand += ':' + REPLACE(REPLACE(@CurrentDatabaseName,'''',''''''),'.','\.') + '"'
-
-            SET @CurrentCommand += ''''
-
-            SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing Data Domain Boost backup.'', 16, 1)'
-          END
-
-          EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
-          SET @Error = @@ERROR
-          IF @Error <> 0 SET @CurrentCommandOutput = @Error
-          IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
-          SET @CurrentBackupOutput = @CurrentCommandOutput
-        END
-
-        -- Verify the backup
-        IF @CurrentBackupOutput = 0 AND @Verify = 'Y'
-        BEGIN
-          WHILE (1 = 1)
-          BEGIN
-            SELECT TOP 1 @CurrentBackupSetID = ID,
-                         @CurrentIsMirror = Mirror
-            FROM @CurrentBackupSet
-            WHERE VerifyCompleted = 0
-            ORDER BY ID ASC
-
-            IF @@ROWCOUNT = 0
-            BEGIN
-              BREAK
-            END
-
-            IF @BackupSoftware IS NULL
-            BEGIN
-              SET @CurrentDatabaseContext = 'master'
-
-              SET @CurrentCommandType = 'RESTORE_VERIFYONLY'
-
-              SET @CurrentCommand = 'RESTORE VERIFYONLY FROM'
-
-              SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
-              FROM @CurrentFiles
-              WHERE Mirror = @CurrentIsMirror
-              ORDER BY FilePath ASC
+                SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
+                FROM @CurrentFiles
+                WHERE Mirror = 1
+                ORDER BY FilePath ASC
+              END
 
               SET @CurrentCommand += ' WITH '
               IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
               IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+
+              IF @Version >= 10
+              BEGIN
+                SET @CurrentCommand += CASE WHEN @Compress = 'Y' AND (@CurrentIsEncrypted = 0 OR (@CurrentIsEncrypted = 1 AND ((@Version >= 13 AND @CurrentMaxTransferSize >= 65537) OR @Version >= 15.0404316 OR SERVERPROPERTY('EngineEdition') = 8))) THEN ', COMPRESSION' ELSE ', NO_COMPRESSION' END
+              END
+
+              IF @Compress = 'Y' AND @CompressionAlgorithm IS NOT NULL
+              BEGIN
+                SET @CurrentCommand += ' (ALGORITHM = ' + @CompressionAlgorithm + CASE WHEN @CompressionLevel IS NOT NULL THEN ', LEVEL = ' + @CompressionLevel ELSE '' END + ')'
+              END
+
+              IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
+
+              IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
+              BEGIN
+                SET @CurrentCommand += ', FORMAT'
+              END
+
+              IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
+              IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
+              IF @Init = 'Y' SET @CurrentCommand += ', INIT'
+              IF @Format = 'Y' SET @CurrentCommand += ', FORMAT'
+              IF @BlockSize IS NOT NULL SET @CurrentCommand += ', BLOCKSIZE = ' + CAST(@BlockSize AS nvarchar)
+              IF @BufferCount IS NOT NULL SET @CurrentCommand += ', BUFFERCOUNT = ' + CAST(@BufferCount AS nvarchar)
+              IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', MAXTRANSFERSIZE = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
+              IF @Description IS NOT NULL SET @CurrentCommand += ', DESCRIPTION = N''' + REPLACE(@Description,'''','''''') + ''''
+              IF @BackupSetName IS NOT NULL SET @CurrentCommand += ', NAME = N''' + REPLACE(@BackupSetName,'''','''''') + ''''
               IF @Stats IS NOT NULL SET @CurrentCommand += ', STATS = ' + CAST(@Stats AS nvarchar)
-              IF @BackupOptions IS NOT NULL SET @CurrentCommand += ', RESTORE_OPTIONS = N''' + REPLACE(@BackupOptions,'''','''''') + ''''
+              IF @BackupOptions IS NOT NULL SET @CurrentCommand += ', BACKUP_OPTIONS = N''' + REPLACE(@BackupOptions,'''','''''') + ''''
+              IF @Encrypt = 'Y' SET @CurrentCommand += ', ENCRYPTION (ALGORITHM = ' + UPPER(@EncryptionAlgorithm) + ', '
+              IF @Encrypt = 'Y' AND @ServerCertificate IS NOT NULL SET @CurrentCommand += 'SERVER CERTIFICATE = ' + QUOTENAME(@ServerCertificate)
+              IF @Encrypt = 'Y' AND @ServerAsymmetricKey IS NOT NULL SET @CurrentCommand += 'SERVER ASYMMETRIC KEY = ' + QUOTENAME(@ServerAsymmetricKey)
+              IF @Encrypt = 'Y' SET @CurrentCommand += ')'
               IF @URL IS NOT NULL AND @Credential IS NOT NULL SET @CurrentCommand += ', CREDENTIAL = N''' + REPLACE(@Credential,'''','''''') + ''''
+              IF @ExpireDate IS NOT NULL SET @CurrentCommand += ', EXPIREDATE = ''' + CONVERT(nvarchar, @ExpireDate, 21) + ''''
+              IF @RetainDays IS NOT NULL SET @CurrentCommand += ', RETAINDAYS = ' + CAST(@RetainDays AS nvarchar)
             END
 
             IF @BackupSoftware = 'LITESPEED'
             BEGIN
               SET @CurrentDatabaseContext = 'master'
 
-              SET @CurrentCommandType = 'xp_restore_verifyonly'
+              SELECT @CurrentCommandType = CASE
+              WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'xp_backup_database'
+              WHEN @CurrentBackupType = 'LOG' THEN 'xp_backup_log'
+              END
 
-              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_restore_verifyonly'
+              SELECT @CurrentCommand = CASE
+              WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_backup_database @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
+              WHEN @CurrentBackupType = 'LOG' THEN 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_backup_log @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
+              END
 
-              SELECT @CurrentCommand += ' @filename = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
+              SELECT @CurrentCommand += ', @filename = N''' + REPLACE(FilePath,'''','''''') + ''''
               FROM @CurrentFiles
-              WHERE Mirror = @CurrentIsMirror
+              WHERE Mirror = 0
               ORDER BY FilePath ASC
+
+              IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
+              BEGIN
+                SELECT @CurrentCommand += ', @mirror = N''' + REPLACE(FilePath,'''','''''') + ''''
+                FROM @CurrentFiles
+                WHERE Mirror = 1
+                ORDER BY FilePath ASC
+              END
 
               SET @CurrentCommand += ', @with = '''
               IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
               IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+              IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
+              IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
+              IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
+              IF @BlockSize IS NOT NULL SET @CurrentCommand += ', BLOCKSIZE = ' + CAST(@BlockSize AS nvarchar)
               SET @CurrentCommand += ''''
-              IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptionkey = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+              IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ', @read_write_filegroups = 1'
+              IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', @compressionlevel = ' + CAST(@CompressionLevelNumeric AS nvarchar)
+              IF @AdaptiveCompression IS NOT NULL SET @CurrentCommand += ', @adaptivecompression = ''' + CASE WHEN @AdaptiveCompression = 'SIZE' THEN 'Size' WHEN @AdaptiveCompression = 'SPEED' THEN 'Speed' END + ''''
+              IF @BufferCount IS NOT NULL SET @CurrentCommand += ', @buffercount = ' + CAST(@BufferCount AS nvarchar)
+              IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', @maxtransfersize = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
+              IF @Threads IS NOT NULL SET @CurrentCommand += ', @threads = ' + CAST(@Threads AS nvarchar)
+              IF @Init = 'Y' SET @CurrentCommand += ', @init = 1'
+              IF @Format = 'Y' SET @CurrentCommand += ', @format = 1'
+              IF @Throttle IS NOT NULL SET @CurrentCommand += ', @throttle = ' + CAST(@Throttle AS nvarchar)
+              IF @Description IS NOT NULL SET @CurrentCommand += ', @desc = N''' + REPLACE(@Description,'''','''''') + ''''
+              IF @ObjectLevelRecoveryMap = 'Y' SET @CurrentCommand += ', @olrmap = 1'
+              IF @ExpireDate IS NOT NULL SET @CurrentCommand += ', @expiration = ''' + CONVERT(nvarchar, @ExpireDate, 21) + ''''
+              IF @RetainDays IS NOT NULL SET @CurrentCommand += ', @retaindays = ' + CAST(@RetainDays AS nvarchar)
 
-              SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error verifying LiteSpeed backup.'', 16, 1)'
+              IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', @cryptlevel = ' + CASE
+              WHEN @EncryptionAlgorithm = 'RC2_40' THEN '0'
+              WHEN @EncryptionAlgorithm = 'RC2_56' THEN '1'
+              WHEN @EncryptionAlgorithm = 'RC2_112' THEN '2'
+              WHEN @EncryptionAlgorithm = 'RC2_128' THEN '3'
+              WHEN @EncryptionAlgorithm = 'TRIPLE_DES_3KEY' THEN '4'
+              WHEN @EncryptionAlgorithm = 'RC4_128' THEN '5'
+              WHEN @EncryptionAlgorithm = 'AES_128' THEN '6'
+              WHEN @EncryptionAlgorithm = 'AES_192' THEN '7'
+              WHEN @EncryptionAlgorithm = 'AES_256' THEN '8'
+              END
+
+              IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptionkey = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+              SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing LiteSpeed backup.'', 16, 1)'
             END
 
             IF @BackupSoftware = 'SQLBACKUP'
@@ -4691,167 +4503,367 @@ BEGIN
 
               SET @CurrentCommandType = 'sqlbackup'
 
-              SET @CurrentCommand = 'RESTORE VERIFYONLY FROM'
+              SELECT @CurrentCommand = CASE
+              WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP DATABASE ' + QUOTENAME(@CurrentDatabaseName)
+              WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP LOG ' + QUOTENAME(@CurrentDatabaseName)
+              END
+
+              IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' READ_WRITE_FILEGROUPS'
+
+              SET @CurrentCommand += ' TO'
 
               SELECT @CurrentCommand += ' DISK = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
               FROM @CurrentFiles
-              WHERE Mirror = @CurrentIsMirror
+              WHERE Mirror = 0
               ORDER BY FilePath ASC
 
               SET @CurrentCommand += ' WITH '
+
+              IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
+              BEGIN
+                SET @CurrentCommand += ' MIRRORFILE' + ' = N''' + REPLACE((SELECT FilePath FROM @CurrentFiles WHERE Mirror = 1),'''','''''') + ''', '
+              END
+
               IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
               IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
-              IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', PASSWORD = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+              IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
+              IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
+              IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
+              IF @Init = 'Y' SET @CurrentCommand += ', INIT'
+              IF @Format = 'Y' SET @CurrentCommand += ', FORMAT'
+              IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', COMPRESSION = ' + CAST(@CompressionLevelNumeric AS nvarchar)
+              IF @Threads IS NOT NULL SET @CurrentCommand += ', THREADCOUNT = ' + CAST(@Threads AS nvarchar)
+              IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', MAXTRANSFERSIZE = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
+              IF @Description IS NOT NULL SET @CurrentCommand += ', DESCRIPTION = N''' + REPLACE(@Description,'''','''''') + ''''
 
-              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqlbackup N''-SQL "' + REPLACE(@CurrentCommand,'''','''''') + '"''' + ' IF @ReturnCode <> 0 RAISERROR(''Error verifying SQLBackup backup.'', 16, 1)'
+              IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', KEYSIZE = ' + CASE
+              WHEN @EncryptionAlgorithm = 'AES_128' THEN '128'
+              WHEN @EncryptionAlgorithm = 'AES_256' THEN '256'
+              END
+
+              IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', PASSWORD = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqlbackup N''-SQL "' + REPLACE(@CurrentCommand,'''','''''') + '"''' + ' IF @ReturnCode <> 0 RAISERROR(''Error performing SQLBackup backup.'', 16, 1)'
             END
 
             IF @BackupSoftware = 'SQLSAFE'
             BEGIN
               SET @CurrentDatabaseContext = 'master'
 
-              SET @CurrentCommandType = 'xp_ss_verify'
+              SET @CurrentCommandType = 'xp_ss_backup'
 
-              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_verify @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_backup @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
 
               SELECT @CurrentCommand += ', ' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) = 1 THEN '@filename' ELSE '@backupfile' END + ' = N''' + REPLACE(FilePath,'''','''''') + ''''
               FROM @CurrentFiles
-              WHERE Mirror = @CurrentIsMirror
+              WHERE Mirror = 0
               ORDER BY FilePath ASC
 
-              SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error verifying SQLsafe backup.'', 16, 1)'
+              SELECT @CurrentCommand += ', @mirrorfile = N''' + REPLACE(FilePath,'''','''''') + ''''
+              FROM @CurrentFiles
+              WHERE Mirror = 1
+              ORDER BY FilePath ASC
+
+              SET @CurrentCommand += ', @backuptype = ' + CASE WHEN @CurrentBackupType = 'FULL' THEN '''Full''' WHEN @CurrentBackupType = 'DIFF' THEN '''Differential''' WHEN @CurrentBackupType = 'LOG' THEN '''Log''' END
+              IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ', @readwritefilegroups = 1'
+              SET @CurrentCommand += ', @checksum = ' + CASE WHEN @Checksum = 'Y' THEN '1' WHEN @Checksum = 'N' THEN '0' END
+              SET @CurrentCommand += ', @copyonly = ' + CASE WHEN @CopyOnly = 'Y' THEN '1' WHEN @CopyOnly = 'N' THEN '0' END
+              IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', @compressionlevel = ' + CAST(@CompressionLevelNumeric AS nvarchar)
+              IF @Threads IS NOT NULL SET @CurrentCommand += ', @threads = ' + CAST(@Threads AS nvarchar)
+              IF @Init = 'Y' SET @CurrentCommand += ', @overwrite = 1'
+              IF @Description IS NOT NULL SET @CurrentCommand += ', @desc = N''' + REPLACE(@Description,'''','''''') + ''''
+
+              IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', @encryptiontype = N''' + CASE
+              WHEN @EncryptionAlgorithm = 'AES_128' THEN 'AES128'
+              WHEN @EncryptionAlgorithm = 'AES_256' THEN 'AES256'
+              END + ''''
+
+              IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptedbackuppassword = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+              SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing SQLsafe backup.'', 16, 1)'
+            END
+
+            IF @BackupSoftware = 'DATA_DOMAIN_BOOST'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'emc_run_backup'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.emc_run_backup '''
+
+              SET @CurrentCommand += ' -c ' + CASE WHEN @Cluster IS NOT NULL AND @CurrentAvailabilityGroup IS NOT NULL THEN @Cluster ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar) END
+
+              SET @CurrentCommand += ' -l ' + CASE
+              WHEN @CurrentBackupType = 'FULL' THEN 'full'
+              WHEN @CurrentBackupType = 'DIFF' THEN 'diff'
+              WHEN @CurrentBackupType = 'LOG' THEN 'incr'
+              END
+
+              IF @NoRecovery = 'Y' SET @CurrentCommand += ' -H'
+
+              IF @CleanupTime IS NOT NULL SET @CurrentCommand += ' -y +' + CAST(@CleanupTime/24 + CASE WHEN @CleanupTime%24 > 0 THEN 1 ELSE 0 END AS nvarchar) + 'd'
+
+              IF @Checksum = 'Y' SET @CurrentCommand += ' -k'
+
+              SET @CurrentCommand += ' -S ' + CAST(@CurrentNumberOfFiles AS nvarchar)
+
+              IF @Description IS NOT NULL SET @CurrentCommand += ' -b "' + REPLACE(@Description,'''','''''') + '"'
+
+              IF @BufferCount IS NOT NULL SET @CurrentCommand += ' -O "BUFFERCOUNT=' + CAST(@BufferCount AS nvarchar) + '"'
+
+              IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' -O "READ_WRITE_FILEGROUPS"'
+
+              IF @DataDomainBoostHost IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_HOST=' + REPLACE(@DataDomainBoostHost,'''','''''') + '"'
+              IF @DataDomainBoostUser IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_USER=' + REPLACE(@DataDomainBoostUser,'''','''''') + '"'
+              IF @DataDomainBoostDevicePath IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DEVICE_PATH=' + REPLACE(@DataDomainBoostDevicePath,'''','''''') + '"'
+              IF @DataDomainBoostLockboxPath IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_LOCKBOX_PATH=' + REPLACE(@DataDomainBoostLockboxPath,'''','''''') + '"'
+              SET @CurrentCommand += ' -a "NSR_SKIP_NON_BACKUPABLE_STATE_DB=TRUE"'
+              SET @CurrentCommand += ' -a "BACKUP_PROMOTION=NONE"'
+              IF @CopyOnly = 'Y' SET @CurrentCommand += ' -a "NSR_COPY_ONLY=TRUE"'
+              IF @BackupSetName IS NOT NULL SET @CurrentCommand += ' -N "' + REPLACE(@BackupSetName,'''','''''') + '"'
+
+              IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentCommand += ' "MSSQL'
+              IF SERVERPROPERTY('InstanceName') IS NOT NULL SET @CurrentCommand += ' "MSSQL$' + CAST(SERVERPROPERTY('InstanceName') AS nvarchar)
+              SET @CurrentCommand += ':' + REPLACE(REPLACE(@CurrentDatabaseName,'''',''''''),'.','\.') + '"'
+
+              SET @CurrentCommand += ''''
+
+              SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing Data Domain Boost backup.'', 16, 1)'
             END
 
             EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
             SET @Error = @@ERROR
             IF @Error <> 0 SET @CurrentCommandOutput = @Error
             IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
-
-            UPDATE @CurrentBackupSet
-            SET VerifyCompleted = 1,
-                VerifyOutput = @CurrentCommandOutput
-            WHERE ID = @CurrentBackupSetID
-
-            SET @CurrentBackupSetID = NULL
-            SET @CurrentIsMirror = NULL
-
-            SET @CurrentDatabaseContext = NULL
-            SET @CurrentCommand = NULL
-            SET @CurrentCommandOutput = NULL
-            SET @CurrentCommandType = NULL
+            SET @CurrentBackupOutput = @CurrentCommandOutput
           END
-        END
 
-        IF @CleanupMode = 'AFTER_BACKUP'
-        BEGIN
-          INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
-          SELECT DATEADD(hh,-(@CleanupTime),SYSDATETIME()), 0
-
-          IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 0 OR Mirror IS NULL) AND CleanupDate IS NULL)
+          -- Verify the backup
+          IF @CurrentBackupOutput = 0 AND @Verify = 'Y'
           BEGIN
-            UPDATE @CurrentDirectories
-            SET CleanupDate = (SELECT MIN(CleanupDate)
-                               FROM @CurrentCleanupDates
-                               WHERE (Mirror = 0 OR Mirror IS NULL)),
-                CleanupMode = 'AFTER_BACKUP'
-            WHERE Mirror = 0
+            WHILE (1 = 1)
+            BEGIN
+              SELECT TOP 1 @CurrentBackupSetID = ID,
+                           @CurrentIsMirror = Mirror
+              FROM @CurrentBackupSet
+              WHERE VerifyCompleted = 0
+              ORDER BY ID ASC
+
+              IF @@ROWCOUNT = 0
+              BEGIN
+                BREAK
+              END
+
+              IF @BackupSoftware IS NULL
+              BEGIN
+                SET @CurrentDatabaseContext = 'master'
+
+                SET @CurrentCommandType = 'RESTORE_VERIFYONLY'
+
+                SET @CurrentCommand = 'RESTORE VERIFYONLY FROM'
+
+                SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
+                FROM @CurrentFiles
+                WHERE Mirror = @CurrentIsMirror
+                ORDER BY FilePath ASC
+
+                SET @CurrentCommand += ' WITH '
+                IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
+                IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+                IF @Stats IS NOT NULL SET @CurrentCommand += ', STATS = ' + CAST(@Stats AS nvarchar)
+                IF @BackupOptions IS NOT NULL SET @CurrentCommand += ', RESTORE_OPTIONS = N''' + REPLACE(@BackupOptions,'''','''''') + ''''
+                IF @URL IS NOT NULL AND @Credential IS NOT NULL SET @CurrentCommand += ', CREDENTIAL = N''' + REPLACE(@Credential,'''','''''') + ''''
+              END
+
+              IF @BackupSoftware = 'LITESPEED'
+              BEGIN
+                SET @CurrentDatabaseContext = 'master'
+
+                SET @CurrentCommandType = 'xp_restore_verifyonly'
+
+                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_restore_verifyonly'
+
+                SELECT @CurrentCommand += ' @filename = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
+                FROM @CurrentFiles
+                WHERE Mirror = @CurrentIsMirror
+                ORDER BY FilePath ASC
+
+                SET @CurrentCommand += ', @with = '''
+                IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
+                IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+                SET @CurrentCommand += ''''
+                IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptionkey = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+
+                SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error verifying LiteSpeed backup.'', 16, 1)'
+              END
+
+              IF @BackupSoftware = 'SQLBACKUP'
+              BEGIN
+                SET @CurrentDatabaseContext = 'master'
+
+                SET @CurrentCommandType = 'sqlbackup'
+
+                SET @CurrentCommand = 'RESTORE VERIFYONLY FROM'
+
+                SELECT @CurrentCommand += ' DISK = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
+                FROM @CurrentFiles
+                WHERE Mirror = @CurrentIsMirror
+                ORDER BY FilePath ASC
+
+                SET @CurrentCommand += ' WITH '
+                IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
+                IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+                IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', PASSWORD = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+
+                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqlbackup N''-SQL "' + REPLACE(@CurrentCommand,'''','''''') + '"''' + ' IF @ReturnCode <> 0 RAISERROR(''Error verifying SQLBackup backup.'', 16, 1)'
+              END
+
+              IF @BackupSoftware = 'SQLSAFE'
+              BEGIN
+                SET @CurrentDatabaseContext = 'master'
+
+                SET @CurrentCommandType = 'xp_ss_verify'
+
+                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_verify @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
+
+                SELECT @CurrentCommand += ', ' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) = 1 THEN '@filename' ELSE '@backupfile' END + ' = N''' + REPLACE(FilePath,'''','''''') + ''''
+                FROM @CurrentFiles
+                WHERE Mirror = @CurrentIsMirror
+                ORDER BY FilePath ASC
+
+                SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error verifying SQLsafe backup.'', 16, 1)'
+              END
+
+              EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
+              SET @Error = @@ERROR
+              IF @Error <> 0 SET @CurrentCommandOutput = @Error
+              IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
+
+              UPDATE @CurrentBackupSet
+              SET VerifyCompleted = 1,
+                  VerifyOutput = @CurrentCommandOutput
+              WHERE ID = @CurrentBackupSetID
+
+              SET @CurrentBackupSetID = NULL
+              SET @CurrentIsMirror = NULL
+
+              SET @CurrentDatabaseContext = NULL
+              SET @CurrentCommand = NULL
+              SET @CurrentCommandOutput = NULL
+              SET @CurrentCommandType = NULL
+            END
           END
-        END
 
-        IF @MirrorCleanupMode = 'AFTER_BACKUP'
-        BEGIN
-          INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
-          SELECT DATEADD(hh,-(@MirrorCleanupTime),SYSDATETIME()), 1
-
-          IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 1 OR Mirror IS NULL) AND CleanupDate IS NULL)
+          IF @CleanupMode = 'AFTER_BACKUP'
           BEGIN
-            UPDATE @CurrentDirectories
-            SET CleanupDate = (SELECT MIN(CleanupDate)
-                               FROM @CurrentCleanupDates
-                               WHERE (Mirror = 1 OR Mirror IS NULL)),
-                CleanupMode = 'AFTER_BACKUP'
-            WHERE Mirror = 1
-          END
-        END
+            INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
+            SELECT DATEADD(hh,-(@CleanupTime),SYSDATETIME()), 0
 
-        -- Delete old backup files, after backup
-        IF ((@CurrentBackupOutput = 0 AND @Verify = 'N')
-        OR (@CurrentBackupOutput = 0 AND @Verify = 'Y' AND NOT EXISTS (SELECT * FROM @CurrentBackupSet WHERE VerifyOutput <> 0 OR VerifyOutput IS NULL)))
-        AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
-        AND @CurrentBackupType = @BackupType
-        BEGIN
-          WHILE (1 = 1)
+            IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 0 OR Mirror IS NULL) AND CleanupDate IS NULL)
+            BEGIN
+              UPDATE @CurrentDirectories
+              SET CleanupDate = (SELECT MIN(CleanupDate)
+                                 FROM @CurrentCleanupDates
+                                 WHERE (Mirror = 0 OR Mirror IS NULL)),
+                  CleanupMode = 'AFTER_BACKUP'
+              WHERE Mirror = 0
+            END
+          END
+
+          IF @MirrorCleanupMode = 'AFTER_BACKUP'
           BEGIN
-            SELECT TOP 1 @CurrentDirectoryID = ID,
-                         @CurrentDirectoryPath = DirectoryPath,
-                         @CurrentCleanupDate = CleanupDate
-            FROM @CurrentDirectories
-            WHERE CleanupDate IS NOT NULL
-            AND CleanupMode = 'AFTER_BACKUP'
-            AND CleanupCompleted = 0
-            ORDER BY ID ASC
+            INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
+            SELECT DATEADD(hh,-(@MirrorCleanupTime),SYSDATETIME()), 1
 
-            IF @@ROWCOUNT = 0
+            IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 1 OR Mirror IS NULL) AND CleanupDate IS NULL)
             BEGIN
-              BREAK
+              UPDATE @CurrentDirectories
+              SET CleanupDate = (SELECT MIN(CleanupDate)
+                                 FROM @CurrentCleanupDates
+                                 WHERE (Mirror = 1 OR Mirror IS NULL)),
+                  CleanupMode = 'AFTER_BACKUP'
+              WHERE Mirror = 1
             END
-
-            IF @BackupSoftware IS NULL
-            BEGIN
-              SET @CurrentDatabaseContext = 'master'
-
-              SET @CurrentCommandType = 'xp_delete_file'
-
-              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_delete_file 0, N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + @CurrentFileExtension + ''', ''' + CONVERT(nvarchar(19),@CurrentCleanupDate,126) + ''' IF @ReturnCode <> 0 RAISERROR(''Error deleting files.'', 16, 1)'
-            END
-
-            IF @BackupSoftware = 'LITESPEED'
-            BEGIN
-              SET @CurrentDatabaseContext = 'master'
-
-              SET @CurrentCommandType = 'xp_slssqlmaint'
-
-              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_slssqlmaint N''-MAINTDEL -DELFOLDER "' + REPLACE(@CurrentDirectoryPath,'''','''''') + '" -DELEXTENSION "' + @CurrentFileExtension + '" -DELUNIT "' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + '" -DELUNITTYPE "minutes" -DELUSEAGE'' IF @ReturnCode <> 0 RAISERROR(''Error deleting LiteSpeed backup files.'', 16, 1)'
-            END
-
-            IF @BackupSoftware = 'SQLBACKUP'
-            BEGIN
-              SET @CurrentDatabaseContext = 'master'
-
-              SET @CurrentCommandType = 'sqbutility'
-
-              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqbutility 1032, N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''', N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + CASE WHEN @CurrentBackupType = 'FULL' THEN 'D' WHEN @CurrentBackupType = 'DIFF' THEN 'I' WHEN @CurrentBackupType = 'LOG' THEN 'L' END + ''', ''' + CAST(DATEDIFF(hh,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'h'', ' + ISNULL('''' + REPLACE(@EncryptionKey,'''','''''') + '''','NULL') + ' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLBackup backup files.'', 16, 1)'
-            END
-
-            IF @BackupSoftware = 'SQLSAFE'
-            BEGIN
-              SET @CurrentDatabaseContext = 'master'
-
-              SET @CurrentCommandType = 'xp_ss_delete'
-
-              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_delete @filename = N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + '\*.' + @CurrentFileExtension + ''', @age = ''' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'Minutes'' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLsafe backup files.'', 16, 1)'
-            END
-
-            EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
-            SET @Error = @@ERROR
-            IF @Error <> 0 SET @CurrentCommandOutput = @Error
-            IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
-
-            UPDATE @CurrentDirectories
-            SET CleanupCompleted = 1,
-                CleanupOutput = @CurrentCommandOutput
-            WHERE ID = @CurrentDirectoryID
-
-            SET @CurrentDirectoryID = NULL
-            SET @CurrentDirectoryPath = NULL
-            SET @CurrentCleanupDate = NULL
-
-            SET @CurrentDatabaseContext = NULL
-            SET @CurrentCommand = NULL
-            SET @CurrentCommandOutput = NULL
-            SET @CurrentCommandType = NULL
           END
-        END
+
+          -- Delete old backup files, after backup
+          IF ((@CurrentBackupOutput = 0 AND @Verify = 'N')
+          OR (@CurrentBackupOutput = 0 AND @Verify = 'Y' AND NOT EXISTS (SELECT * FROM @CurrentBackupSet WHERE VerifyOutput <> 0 OR VerifyOutput IS NULL)))
+          AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
+          AND @CurrentBackupType = @BackupType
+          BEGIN
+            WHILE (1 = 1)
+            BEGIN
+              SELECT TOP 1 @CurrentDirectoryID = ID,
+                           @CurrentDirectoryPath = DirectoryPath,
+                           @CurrentCleanupDate = CleanupDate
+              FROM @CurrentDirectories
+              WHERE CleanupDate IS NOT NULL
+              AND CleanupMode = 'AFTER_BACKUP'
+              AND CleanupCompleted = 0
+              ORDER BY ID ASC
+
+              IF @@ROWCOUNT = 0
+              BEGIN
+                BREAK
+              END
+
+              IF @BackupSoftware IS NULL
+              BEGIN
+                SET @CurrentDatabaseContext = 'master'
+
+                SET @CurrentCommandType = 'xp_delete_file'
+
+                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_delete_file 0, N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + @CurrentFileExtension + ''', ''' + CONVERT(nvarchar(19),@CurrentCleanupDate,126) + ''' IF @ReturnCode <> 0 RAISERROR(''Error deleting files.'', 16, 1)'
+              END
+
+              IF @BackupSoftware = 'LITESPEED'
+              BEGIN
+                SET @CurrentDatabaseContext = 'master'
+
+                SET @CurrentCommandType = 'xp_slssqlmaint'
+
+                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_slssqlmaint N''-MAINTDEL -DELFOLDER "' + REPLACE(@CurrentDirectoryPath,'''','''''') + '" -DELEXTENSION "' + @CurrentFileExtension + '" -DELUNIT "' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + '" -DELUNITTYPE "minutes" -DELUSEAGE'' IF @ReturnCode <> 0 RAISERROR(''Error deleting LiteSpeed backup files.'', 16, 1)'
+              END
+
+              IF @BackupSoftware = 'SQLBACKUP'
+              BEGIN
+                SET @CurrentDatabaseContext = 'master'
+
+                SET @CurrentCommandType = 'sqbutility'
+
+                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqbutility 1032, N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''', N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + CASE WHEN @CurrentBackupType = 'FULL' THEN 'D' WHEN @CurrentBackupType = 'DIFF' THEN 'I' WHEN @CurrentBackupType = 'LOG' THEN 'L' END + ''', ''' + CAST(DATEDIFF(hh,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'h'', ' + ISNULL('''' + REPLACE(@EncryptionKey,'''','''''') + '''','NULL') + ' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLBackup backup files.'', 16, 1)'
+              END
+
+              IF @BackupSoftware = 'SQLSAFE'
+              BEGIN
+                SET @CurrentDatabaseContext = 'master'
+
+                SET @CurrentCommandType = 'xp_ss_delete'
+
+                SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_delete @filename = N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + '\*.' + @CurrentFileExtension + ''', @age = ''' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'Minutes'' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLsafe backup files.'', 16, 1)'
+              END
+
+              EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
+              SET @Error = @@ERROR
+              IF @Error <> 0 SET @CurrentCommandOutput = @Error
+              IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
+
+              UPDATE @CurrentDirectories
+              SET CleanupCompleted = 1,
+                  CleanupOutput = @CurrentCommandOutput
+              WHERE ID = @CurrentDirectoryID
+
+              SET @CurrentDirectoryID = NULL
+              SET @CurrentDirectoryPath = NULL
+              SET @CurrentCleanupDate = NULL
+
+              SET @CurrentDatabaseContext = NULL
+              SET @CurrentCommand = NULL
+              SET @CurrentCommandOutput = NULL
+              SET @CurrentCommandType = NULL
+            END
+          END
+
+        END -- End of file group check
 
         UPDATE @tmpFileGroups
         SET Completed = 1
@@ -5012,7 +5024,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-08 20:41:55                                                               //--
+  --// Version: 2025-06-08 22:57:39                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON
@@ -6911,7 +6923,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-08 20:41:55                                                               //--
+  --// Version: 2025-06-08 22:57:39                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON

--- a/MaintenanceSolution.sql
+++ b/MaintenanceSolution.sql
@@ -10,7 +10,7 @@ License: https://ola.hallengren.com/license.html
 
 GitHub: https://github.com/olahallengren/sql-server-maintenance-solution
 
-Version: 2025-06-08 12:16:23
+Version: 2025-06-08 20:41:55
 
 You can contact me by e-mail at ola@hallengren.com.
 
@@ -137,7 +137,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-08 12:16:23                                                               //--
+  --// Version: 2025-06-08 20:41:55                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON
@@ -485,7 +485,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-08 12:16:23                                                               //--
+  --// Version: 2025-06-08 20:41:55                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON
@@ -1591,6 +1591,12 @@ BEGIN
     SELECT 'The value for the parameter @BackupType is not supported.', 16, 1
   END
 
+  IF @BackupType = 'LOG' AND @FileGroups IS NOT NULL
+  BEGIN
+    INSERT INTO @Errors ([Message], Severity, [State])
+    SELECT 'The value for the parameter @BackupType is not supported. Transaction log backup on file groups is not supported.', 16, 2
+  END
+
   ----------------------------------------------------------------------------------------------------
 
   IF SERVERPROPERTY('EngineEdition') = 8 AND NOT (@BackupType = 'FULL' AND @CopyOnly = 'Y')
@@ -1661,6 +1667,12 @@ BEGIN
   BEGIN
     INSERT INTO @Errors ([Message], Severity, [State])
     SELECT 'The value for the parameter @CleanupTime is not supported. Cleanup is not supported if the token {CopyOnly} is not part of the directory.', 16, 7
+  END
+
+  IF @CleanupTime IS NOT NULL AND @FileGroups IS NOT NULL AND ((@DirectoryStructure NOT LIKE '%{FileGroupName}%' OR @DirectoryStructure IS NULL) OR (SERVERPROPERTY('IsHadrEnabled') = 1 AND (@AvailabilityGroupDirectoryStructure NOT LIKE '%{FileGroupName}%' OR @AvailabilityGroupDirectoryStructure IS NULL)))
+  BEGIN
+    INSERT INTO @Errors ([Message], Severity, [State])
+    SELECT 'The value for the parameter @CleanupTime is not supported. Cleanup is not supported if the token {FileGroupName} is not part of the directory.', 16, 8
   END
 
   ----------------------------------------------------------------------------------------------------
@@ -1763,6 +1775,12 @@ BEGIN
   BEGIN
     INSERT INTO @Errors ([Message], Severity, [State])
     SELECT 'The value for the parameter @ChangeBackupType is not supported.', 16, 1
+  END
+
+  IF @ChangeBackupType = 'Y' AND @FileGroups IS NOT NULL
+  BEGIN
+    INSERT INTO @Errors ([Message], Severity, [State])
+    SELECT 'The value for the parameter @ChangeBackupType is not supported. Changing the backup type is not supported with file group backup.', 16, 2
   END
 
   ----------------------------------------------------------------------------------------------------
@@ -1983,6 +2001,12 @@ BEGIN
     SELECT 'The value for the parameter @MinBackupSizeForMultipleFiles is not supported. The column sys.dm_db_log_stats.log_since_last_log_backup_mb is not available in this version of SQL Server.', 16, 4
   END
 
+  IF @MinBackupSizeForMultipleFiles IS NOT NULL AND @FileGroups IS NOT NULL
+  BEGIN
+    INSERT INTO @Errors ([Message], Severity, [State])
+    SELECT 'The value for the parameter @MinBackupSizeForMultipleFiles is not supported. This option is not supported with file group backup.', 16, 5
+  END
+
   ----------------------------------------------------------------------------------------------------
 
   IF @MaxFileSize <= 0
@@ -2007,6 +2031,12 @@ BEGIN
   BEGIN
     INSERT INTO @Errors ([Message], Severity, [State])
     SELECT 'The value for the parameter @MaxFileSize is not supported. The column sys.dm_db_log_stats.log_since_last_log_backup_mb is not available in this version of SQL Server.', 16, 4
+  END
+
+  IF @MaxFileSize IS NOT NULL AND @FileGroups IS NOT NULL
+  BEGIN
+    INSERT INTO @Errors ([Message], Severity, [State])
+    SELECT 'The value for the parameter @MaxFileSize is not supported. This option is not supported with file group backup.', 16, 5
   END
 
   ----------------------------------------------------------------------------------------------------
@@ -2254,6 +2284,12 @@ BEGIN
     SELECT 'The value for the parameter @ReadWriteFileGroups is not supported.', 16, 2
   END
 
+  IF @ReadWriteFileGroups = 'Y' AND @FileGroups IS NOT NULL
+  BEGIN
+    INSERT INTO @Errors ([Message], Severity, [State])
+    SELECT 'The value for the parameter @ReadWriteFileGroups is not supported. This option is not supported with file group backup.', 16, 3
+  END
+
   ----------------------------------------------------------------------------------------------------
 
   IF @OverrideBackupPreference NOT IN('Y','N') OR @OverrideBackupPreference IS NULL
@@ -2448,6 +2484,12 @@ BEGIN
   BEGIN
     INSERT INTO @Errors ([Message], Severity, [State])
     SELECT 'The parameter @MinDatabaseSizeForDifferentialBackup can only be used for differential backups.', 16, 2
+  END
+
+  IF @MinDatabaseSizeForDifferentialBackup IS NOT NULL AND @FileGroups IS NOT NULL
+  BEGIN
+    INSERT INTO @Errors ([Message], Severity, [State])
+    SELECT 'The value for the parameter @MinDatabaseSizeForDifferentialBackup is not supported. This option is not supported with file group backup.', 16, 3
   END
 
   ----------------------------------------------------------------------------------------------------
@@ -2832,6 +2874,26 @@ BEGIN
   BEGIN
     INSERT INTO @Errors ([Message], Severity, [State])
     SELECT 'The value for the parameter @RetainDays is not supported.', 16, 1
+  END
+
+  ----------------------------------------------------------------------------------------------------
+
+  IF EXISTS(SELECT * FROM @SelectedFileGroups WHERE DatabaseName IS NULL OR FileGroupName IS NULL)
+  BEGIN
+    INSERT INTO @Errors ([Message], Severity, [State])
+    SELECT 'The value for the parameter @FileGroups is not supported.', 16, 1
+  END
+
+  IF @FileGroups IS NOT NULL AND NOT EXISTS(SELECT * FROM @SelectedFileGroups)
+  BEGIN
+    INSERT INTO @Errors ([Message], Severity, [State])
+    SELECT 'The value for the parameter @FileGroups is not supported.', 16, 2
+  END
+
+  IF @FileGroups IS NOT NULL AND @BackupSoftware IS NOT NULL
+  BEGIN
+    INSERT INTO @Errors ([Message], Severity, [State])
+    SELECT 'The value for the parameter @FileGroups is not supported. File group backup is only supported with native SQL Server backup.', 16, 2
   END
 
   ----------------------------------------------------------------------------------------------------
@@ -3288,7 +3350,6 @@ BEGIN
         RAISERROR(@ErrorMessage,16,1) WITH NOWAIT
         SET @Error = @@ERROR
       END
-
     END
 
     SET @CurrentDatabase_sp_executesql = QUOTENAME(@CurrentDatabaseName) + '.sys.sp_executesql'
@@ -3544,602 +3605,721 @@ BEGIN
     AND NOT (@CurrentBackupType = 'DIFF' AND @MinDatabaseSizeForDifferentialBackup IS NOT NULL AND (COALESCE(CAST(@CurrentAllocatedExtentPageCount AS bigint) * 8192, CAST(@CurrentDatabaseSize AS bigint) * 8192) < CAST(@MinDatabaseSizeForDifferentialBackup AS bigint) * 1024 * 1024))
     BEGIN
 
-    WHILE (1 = 1)
-    BEGIN
-
-      IF @FileGroups IS NOT NULL
+      WHILE (1 = 1)
       BEGIN
-        SELECT TOP 1 @CurrentFGID = ID,
-                     @CurrentFileGroupID = FileGroupID,
-                     @CurrentFileGroupName = FileGroupName
-        FROM @tmpFileGroups
-        WHERE Selected = 1
-        AND Completed = 0
-        ORDER BY [Order] ASC
 
-        IF @@ROWCOUNT = 0
+        IF @FileGroups IS NOT NULL
         BEGIN
-          BREAK
-        END
-
-        -- Does the filegroup exist?
-        SET @CurrentCommand = ''
-        SET @CurrentCommand = @CurrentCommand + 'IF EXISTS(SELECT * FROM ' + QUOTENAME(@CurrentDatabaseName) + '.sys.filegroups filegroups WHERE [type] <> ''FX'' AND filegroups.data_space_id = @ParamFileGroupID AND filegroups.[name] = @ParamFileGroupName) BEGIN SET @ParamFileGroupExists = 1 END'
-
-        EXECUTE sp_executesql @statement = @CurrentCommand, @params = N'@ParamFileGroupID int, @ParamFileGroupName sysname, @ParamFileGroupExists bit OUTPUT', @ParamFileGroupID = @CurrentFileGroupID, @ParamFileGroupName = @CurrentFileGroupName, @ParamFileGroupExists = @CurrentFileGroupExists OUTPUT
-        SET @Error = @@ERROR
-        IF @Error = 0 AND @CurrentFileGroupExists IS NULL SET @CurrentFileGroupExists = 0
-        IF @Error = 1222
-        BEGIN
-          SET @ErrorMessage = 'The file group ' + QUOTENAME(@CurrentFileGroupName) + ' in the database ' + QUOTENAME(@CurrentDatabaseName) + ' is locked. It could not be checked if the filegroup exists.' + CHAR(13) + CHAR(10) + ' '
-          SET @ErrorMessage = REPLACE(@ErrorMessage,'%','%%')
-          RAISERROR(@ErrorMessage,16,1) WITH NOWAIT
-        END
-        IF @Error <> 0
-        BEGIN
-          SET @ReturnCode = @Error
-        END
-      END
-
-      IF @CurrentBackupType = 'LOG' AND (@CleanupTime IS NOT NULL OR @MirrorCleanupTime IS NOT NULL)
-      BEGIN
-        SELECT @CurrentLatestBackup = MAX(backup_start_date)
-        FROM msdb.dbo.backupset
-        WHERE ([type] IN('D','I')
-        OR ([type] = 'L' AND last_lsn < @CurrentDifferentialBaseLSN))
-        AND is_damaged = 0
-        AND [database_name] = @CurrentDatabaseName
-      END
-
-      SET @CurrentDate = SYSDATETIME()
-      SET @CurrentDateUTC = SYSUTCDATETIME()
-
-      INSERT INTO @CurrentCleanupDates (CleanupDate)
-      SELECT @CurrentDate
-
-      IF @CurrentBackupType = 'LOG'
-      BEGIN
-        INSERT INTO @CurrentCleanupDates (CleanupDate)
-        SELECT @CurrentLatestBackup
-      END
-
-      SELECT @CurrentDirectoryStructure = CASE
-      WHEN @CurrentAvailabilityGroup IS NOT NULL THEN @AvailabilityGroupDirectoryStructure
-      ELSE @DirectoryStructure
-      END
-
-      IF @CurrentDirectoryStructure IS NOT NULL
-      BEGIN
-      -- Directory structure - remove tokens that are not needed
-        IF @CurrentFileGroupName IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}','')
-        IF @ReadWriteFileGroups = 'N' SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Partial}','')
-        IF @CopyOnly = 'N' SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{CopyOnly}','')
-        IF @Cluster IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}','')
-        IF @CurrentAvailabilityGroup IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}','')
-        IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}','')
-        IF @@SERVICENAME IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServiceName}','')
-        IF @Description IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Description}','')
-        IF @BackupSetName IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupSetName}','')
-
-        IF @Directory IS NULL AND @MirrorDirectory IS NULL AND @URL IS NULL AND @DefaultDirectory LIKE '%' + '.' + @@SERVICENAME + @DirectorySeparator + 'MSSQL' + @DirectorySeparator + 'Backup'
-        BEGIN
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServerName}','')
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}','')
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}','')
-          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}','')
-        END
-
-        WHILE (@Updated = 1 OR @Updated IS NULL)
-        BEGIN
-          SET @Updated = 0
-
-          IF CHARINDEX('\',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'\','{DirectorySeparator}')
-            SET @Updated = 1
-          END
-
-          IF CHARINDEX('/',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'/','{DirectorySeparator}')
-            SET @Updated = 1
-          END
-
-          IF CHARINDEX('__',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'__','_')
-            SET @Updated = 1
-          END
-
-          IF CHARINDEX('--',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'--','-')
-            SET @Updated = 1
-          END
-
-          IF CHARINDEX('{DirectorySeparator}{DirectorySeparator}',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}{DirectorySeparator}','{DirectorySeparator}')
-            SET @Updated = 1
-          END
-
-          IF CHARINDEX('{DirectorySeparator}$',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}$','{DirectorySeparator}')
-            SET @Updated = 1
-          END
-          IF CHARINDEX('${DirectorySeparator}',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'${DirectorySeparator}','{DirectorySeparator}')
-            SET @Updated = 1
-          END
-
-          IF CHARINDEX('{DirectorySeparator}_',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}_','{DirectorySeparator}')
-            SET @Updated = 1
-          END
-          IF CHARINDEX('_{DirectorySeparator}',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'_{DirectorySeparator}','{DirectorySeparator}')
-            SET @Updated = 1
-          END
-
-          IF CHARINDEX('{DirectorySeparator}-',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}-','{DirectorySeparator}')
-            SET @Updated = 1
-          END
-          IF CHARINDEX('-{DirectorySeparator}',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'-{DirectorySeparator}','{DirectorySeparator}')
-            SET @Updated = 1
-          END
-
-          IF CHARINDEX('_$',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'_$','_')
-            SET @Updated = 1
-          END
-          IF CHARINDEX('$_',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'$_','_')
-            SET @Updated = 1
-          END
-
-          IF CHARINDEX('-$',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'-$','-')
-            SET @Updated = 1
-          END
-          IF CHARINDEX('$-',@CurrentDirectoryStructure) > 0
-          BEGIN
-            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'$-','-')
-            SET @Updated = 1
-          END
-
-          IF LEFT(@CurrentDirectoryStructure,1) = '_'
-          BEGIN
-            SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-            SET @Updated = 1
-          END
-          IF RIGHT(@CurrentDirectoryStructure,1) = '_'
-          BEGIN
-            SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-            SET @Updated = 1
-          END
-
-          IF LEFT(@CurrentDirectoryStructure,1) = '-'
-          BEGIN
-            SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-            SET @Updated = 1
-          END
-          IF RIGHT(@CurrentDirectoryStructure,1) = '-'
-          BEGIN
-            SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-            SET @Updated = 1
-          END
-
-          IF LEFT(@CurrentDirectoryStructure,1) = '$'
-          BEGIN
-            SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-            SET @Updated = 1
-          END
-          IF RIGHT(@CurrentDirectoryStructure,1) = '$'
-          BEGIN
-            SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
-            SET @Updated = 1
-          END
-
-          IF LEFT(@CurrentDirectoryStructure,20) = '{DirectorySeparator}'
-          BEGIN
-            SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 20)
-            SET @Updated = 1
-          END
-          IF RIGHT(@CurrentDirectoryStructure,20) = '{DirectorySeparator}'
-          BEGIN
-            SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 20)
-            SET @Updated = 1
-          END
-        END
-
-        SET @Updated = NULL
-
-        -- Directory structure - replace tokens with real values
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}',@DirectorySeparator)
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServerName}',CASE WHEN SERVERPROPERTY('EngineEdition') = 8 THEN LEFT(CAST(SERVERPROPERTY('ServerName') AS nvarchar(max)),CHARINDEX('.',CAST(SERVERPROPERTY('ServerName') AS nvarchar(max))) - 1) ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar(max)) END)
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}',ISNULL(CAST(SERVERPROPERTY('InstanceName') AS nvarchar(max)),''))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServiceName}',ISNULL(@@SERVICENAME,''))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}',ISNULL(@Cluster,''))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}',ISNULL(@CurrentAvailabilityGroup,''))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DatabaseName}',@CurrentDatabaseNameFS)
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}',ISNULL(@CurrentFileGroupName,''))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupType}',@CurrentBackupType)
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Partial}','PARTIAL')
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{CopyOnly}','COPY_ONLY')
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Description}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@Description,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupSetName}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@BackupSetName,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Year}',CAST(DATEPART(YEAR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Month}',RIGHT('0' + CAST(DATEPART(MONTH,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Day}',RIGHT('0' + CAST(DATEPART(DAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Week}',RIGHT('0' + CAST(DATEPART(WEEK,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Weekday}',DATENAME(WEEKDAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Hour}',RIGHT('0' + CAST(DATEPART(HOUR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Minute}',RIGHT('0' + CAST(DATEPART(MINUTE,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Second}',RIGHT('0' + CAST(DATEPART(SECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Millisecond}',RIGHT('00' + CAST(DATEPART(MILLISECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),3))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Microsecond}',RIGHT('00000' + CAST(DATEPART(MICROSECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),6))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{MajorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMajorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4)))
-        SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{MinorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMinorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3)))
-      END
-
-      IF @DirectoryStructureCase IS NOT NULL
-      BEGIN
-        SET @CurrentDirectoryStructure = CASE WHEN @DirectoryStructureCase = 'LOWER' THEN LOWER(@CurrentDirectoryStructure)
-                                              WHEN @DirectoryStructureCase = 'UPPER' THEN UPPER(@CurrentDirectoryStructure) END
-      END
-
-      INSERT INTO @CurrentDirectories (ID, DirectoryPath, Mirror, DirectoryNumber, CreateCompleted, CleanupCompleted)
-      SELECT ROW_NUMBER() OVER (ORDER BY ID),
-             DirectoryPath + CASE WHEN DirectoryPath = 'NUL' THEN '' WHEN @CurrentDirectoryStructure IS NOT NULL THEN @DirectorySeparator + @CurrentDirectoryStructure ELSE '' END,
-             Mirror,
-             ROW_NUMBER() OVER (PARTITION BY Mirror ORDER BY ID ASC),
-             0,
-             0
-      FROM @Directories
-      ORDER BY ID ASC
-
-      INSERT INTO @CurrentURLs (ID, DirectoryPath, Mirror, DirectoryNumber)
-      SELECT ROW_NUMBER() OVER (ORDER BY ID),
-             DirectoryPath + CASE WHEN @CurrentDirectoryStructure IS NOT NULL THEN @DirectorySeparator + @CurrentDirectoryStructure ELSE '' END,
-             Mirror,
-             ROW_NUMBER() OVER (PARTITION BY Mirror ORDER BY ID ASC)
-      FROM @URLs
-      ORDER BY ID ASC
-
-      SELECT @CurrentDatabaseFileName = CASE
-      WHEN @CurrentAvailabilityGroup IS NOT NULL THEN @AvailabilityGroupFileName
-      ELSE @FileName
-      END
-
-      -- File name - remove tokens that are not needed
-      IF @CurrentFileGroupName IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}','')
-      IF @ReadWriteFileGroups = 'N' SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Partial}','')
-      IF @CopyOnly = 'N' SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{CopyOnly}','')
-      IF @Cluster IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ClusterName}','')
-      IF @CurrentAvailabilityGroup IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{AvailabilityGroupName}','')
-      IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{InstanceName}','')
-      IF @@SERVICENAME IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServiceName}','')
-      IF @Description IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Description}','')
-      IF @BackupSetName IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupSetName}','')
-      IF @CurrentNumberOfFiles = 1 SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileNumber}','')
-      IF @CurrentNumberOfFiles = 1 SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{NumberOfFiles}','')
-
-      WHILE (@Updated = 1 OR @Updated IS NULL)
-      BEGIN
-        SET @Updated = 0
-
-        IF CHARINDEX('__',@CurrentDatabaseFileName) > 0
-        BEGIN
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'__','_')
-          SET @Updated = 1
-        END
-
-        IF CHARINDEX('--',@CurrentDatabaseFileName) > 0
-        BEGIN
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'--','-')
-          SET @Updated = 1
-        END
-
-        IF CHARINDEX('_$',@CurrentDatabaseFileName) > 0
-        BEGIN
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'_$','_')
-          SET @Updated = 1
-        END
-        IF CHARINDEX('$_',@CurrentDatabaseFileName) > 0
-        BEGIN
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'$_','_')
-          SET @Updated = 1
-        END
-
-        IF CHARINDEX('-$',@CurrentDatabaseFileName) > 0
-        BEGIN
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'-$','-')
-          SET @Updated = 1
-        END
-        IF CHARINDEX('$-',@CurrentDatabaseFileName) > 0
-        BEGIN
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'$-','-')
-          SET @Updated = 1
-        END
-
-        IF CHARINDEX('_.',@CurrentDatabaseFileName) > 0
-        BEGIN
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'_.','.')
-          SET @Updated = 1
-        END
-
-        IF CHARINDEX('-.',@CurrentDatabaseFileName) > 0
-        BEGIN
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'-.','.')
-          SET @Updated = 1
-        END
-
-        IF CHARINDEX('of.',@CurrentDatabaseFileName) > 0
-        BEGIN
-          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'of.','.')
-          SET @Updated = 1
-        END
-
-        IF LEFT(@CurrentDatabaseFileName,1) = '_'
-        BEGIN
-          SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
-          SET @Updated = 1
-        END
-        IF RIGHT(@CurrentDatabaseFileName,1) = '_'
-        BEGIN
-          SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
-          SET @Updated = 1
-        END
-
-        IF LEFT(@CurrentDatabaseFileName,1) = '-'
-        BEGIN
-          SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
-          SET @Updated = 1
-        END
-        IF RIGHT(@CurrentDatabaseFileName,1) = '-'
-        BEGIN
-          SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
-          SET @Updated = 1
-        END
-
-        IF LEFT(@CurrentDatabaseFileName,1) = '$'
-        BEGIN
-          SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
-          SET @Updated = 1
-        END
-        IF RIGHT(@CurrentDatabaseFileName,1) = '$'
-        BEGIN
-          SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
-          SET @Updated = 1
-        END
-      END
-
-      SET @Updated = NULL
-
-      SELECT @CurrentFileExtension = CASE
-      WHEN @CurrentBackupType = 'FULL' THEN @FileExtensionFull
-      WHEN @CurrentBackupType = 'DIFF' THEN @FileExtensionDiff
-      WHEN @CurrentBackupType = 'LOG' THEN @FileExtensionLog
-      END
-
-      -- File name - replace tokens with real values
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServerName}',CASE WHEN SERVERPROPERTY('EngineEdition') = 8 THEN LEFT(CAST(SERVERPROPERTY('ServerName') AS nvarchar(max)),CHARINDEX('.',CAST(SERVERPROPERTY('ServerName') AS nvarchar(max))) - 1) ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar(max)) END)
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{InstanceName}',ISNULL(CAST(SERVERPROPERTY('InstanceName') AS nvarchar(max)),''))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServiceName}',ISNULL(@@SERVICENAME,''))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ClusterName}',ISNULL(@Cluster,''))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{AvailabilityGroupName}',ISNULL(@CurrentAvailabilityGroup,''))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}',ISNULL(@CurrentFileGroupName,''))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupType}',@CurrentBackupType)
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Partial}','PARTIAL')
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{CopyOnly}','COPY_ONLY')
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Description}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@Description,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupSetName}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@BackupSetName,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Year}',CAST(DATEPART(YEAR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Month}',RIGHT('0' + CAST(DATEPART(MONTH,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Day}',RIGHT('0' + CAST(DATEPART(DAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Week}',RIGHT('0' + CAST(DATEPART(WEEK,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Weekday}',DATENAME(WEEKDAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Hour}',RIGHT('0' + CAST(DATEPART(HOUR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Minute}',RIGHT('0' + CAST(DATEPART(MINUTE,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Second}',RIGHT('0' + CAST(DATEPART(SECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Millisecond}',RIGHT('00' + CAST(DATEPART(MILLISECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),3))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Microsecond}',RIGHT('00000' + CAST(DATEPART(MICROSECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),6))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{NumberOfFiles}',@CurrentNumberOfFiles)
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileExtension}',@CurrentFileExtension)
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{MajorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMajorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4)))
-      SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{MinorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMinorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3)))
-
-      SELECT @CurrentMaxFilePathLength = CASE
-      WHEN EXISTS (SELECT * FROM @CurrentDirectories) THEN (SELECT MAX(LEN(DirectoryPath + @DirectorySeparator)) FROM @CurrentDirectories)
-      WHEN EXISTS (SELECT * FROM @CurrentURLs) THEN (SELECT MAX(LEN(DirectoryPath + @DirectorySeparator)) FROM @CurrentURLs)
-      END
-      + LEN(REPLACE(REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',@CurrentDatabaseNameFS), '{FileNumber}', CASE WHEN @CurrentNumberOfFiles >= 1 AND @CurrentNumberOfFiles <= 9 THEN '1' WHEN @CurrentNumberOfFiles >= 10 THEN '01' END))
-
-      -- The maximum length of a backup device is 259 characters
-      IF @CurrentMaxFilePathLength > 259
-      BEGIN
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',LEFT(@CurrentDatabaseNameFS,CASE WHEN (LEN(@CurrentDatabaseNameFS) + 259 - @CurrentMaxFilePathLength - 3) < 20 THEN 20 ELSE (LEN(@CurrentDatabaseNameFS) + 259 - @CurrentMaxFilePathLength - 3) END) + '...')
-      END
-      ELSE
-      BEGIN
-        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',@CurrentDatabaseNameFS)
-      END
-
-      IF @FileNameCase IS NOT NULL
-      BEGIN
-        SET @CurrentDatabaseFileName = CASE WHEN @FileNameCase = 'LOWER' THEN LOWER(@CurrentDatabaseFileName)
-                                            WHEN @FileNameCase = 'UPPER' THEN UPPER(@CurrentDatabaseFileName) END
-      END
-
-      IF EXISTS (SELECT * FROM @CurrentDirectories WHERE Mirror = 0)
-      BEGIN
-        SET @CurrentFileNumber = 0
-
-        WHILE @CurrentFileNumber < @CurrentNumberOfFiles
-        BEGIN
-          SET @CurrentFileNumber = @CurrentFileNumber + 1
-
-          SELECT @CurrentDirectoryPath = DirectoryPath
-          FROM @CurrentDirectories
-          WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 0) + 1
-          AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 0)
-          AND Mirror = 0
-
-          SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles >= 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) END)
-
-          IF @CurrentDirectoryPath = 'NUL'
-          BEGIN
-            SET @CurrentFilePath = 'NUL'
-          END
-          ELSE
-          BEGIN
-            SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
-          END
-
-          INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
-          SELECT 'DISK', @CurrentFilePath, 0
-
-          SET @CurrentDirectoryPath = NULL
-          SET @CurrentFileName = NULL
-          SET @CurrentFilePath = NULL
-        END
-
-        INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
-        SELECT 0, 0
-      END
-
-      IF EXISTS (SELECT * FROM @CurrentDirectories WHERE Mirror = 1)
-      BEGIN
-        SET @CurrentFileNumber = 0
-
-        WHILE @CurrentFileNumber < @CurrentNumberOfFiles
-        BEGIN
-          SET @CurrentFileNumber = @CurrentFileNumber + 1
-
-          SELECT @CurrentDirectoryPath = DirectoryPath
-          FROM @CurrentDirectories
-          WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 1) + 1
-          AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 1)
-          AND Mirror = 1
-
-          SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
-
-          SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
-
-          INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
-          SELECT 'DISK', @CurrentFilePath, 1
-
-          SET @CurrentDirectoryPath = NULL
-          SET @CurrentFileName = NULL
-          SET @CurrentFilePath = NULL
-        END
-
-        INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
-        SELECT 1, 0
-      END
-
-      IF EXISTS (SELECT * FROM @CurrentURLs WHERE Mirror = 0)
-      BEGIN
-        SET @CurrentFileNumber = 0
-
-        WHILE @CurrentFileNumber < @CurrentNumberOfFiles
-        BEGIN
-          SET @CurrentFileNumber = @CurrentFileNumber + 1
-
-          SELECT @CurrentDirectoryPath = DirectoryPath
-          FROM @CurrentURLs
-          WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0) + 1
-          AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0)
-          AND Mirror = 0
-
-          SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
-
-          SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
-
-          INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
-          SELECT 'URL', @CurrentFilePath, 0
-
-          SET @CurrentDirectoryPath = NULL
-          SET @CurrentFileName = NULL
-          SET @CurrentFilePath = NULL
-        END
-
-        INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
-        SELECT 0, 0
-      END
-
-      IF EXISTS (SELECT * FROM @CurrentURLs WHERE Mirror = 1)
-      BEGIN
-        SET @CurrentFileNumber = 0
-
-        WHILE @CurrentFileNumber < @CurrentNumberOfFiles
-        BEGIN
-          SET @CurrentFileNumber = @CurrentFileNumber + 1
-
-          SELECT @CurrentDirectoryPath = DirectoryPath
-          FROM @CurrentURLs
-          WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0) + 1
-          AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0)
-          AND Mirror = 1
-
-          SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
-
-          SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
-
-          INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
-          SELECT 'URL', @CurrentFilePath, 1
-
-          SET @CurrentDirectoryPath = NULL
-          SET @CurrentFileName = NULL
-          SET @CurrentFilePath = NULL
-        END
-
-        INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
-        SELECT 1, 0
-      END
-
-      -- Create directory
-      IF @HostPlatform = 'Windows'
-      AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
-      AND NOT EXISTS(SELECT * FROM @CurrentDirectories WHERE DirectoryPath = 'NUL' OR DirectoryPath IN(SELECT DirectoryPath FROM @Directories))
-      BEGIN
-        WHILE (1 = 1)
-        BEGIN
-          SELECT TOP 1 @CurrentDirectoryID = ID,
-                       @CurrentDirectoryPath = DirectoryPath
-          FROM @CurrentDirectories
-          WHERE CreateCompleted = 0
-          ORDER BY ID ASC
+          SELECT TOP 1 @CurrentFGID = ID,
+                       @CurrentFileGroupID = FileGroupID,
+                       @CurrentFileGroupName = FileGroupName
+          FROM @tmpFileGroups
+          WHERE Selected = 1
+          AND Completed = 0
+          ORDER BY [Order] ASC
 
           IF @@ROWCOUNT = 0
           BEGIN
             BREAK
           END
 
-          IF @DirectoryCheck = 'Y'
+          -- Does the filegroup exist?
+          SET @CurrentCommand = ''
+          SET @CurrentCommand = @CurrentCommand + 'IF EXISTS(SELECT * FROM ' + QUOTENAME(@CurrentDatabaseName) + '.sys.filegroups filegroups WHERE [type] <> ''FX'' AND filegroups.data_space_id = @ParamFileGroupID AND filegroups.[name] = @ParamFileGroupName) BEGIN SET @ParamFileGroupExists = 1 END'
+
+          EXECUTE sp_executesql @statement = @CurrentCommand, @params = N'@ParamFileGroupID int, @ParamFileGroupName sysname, @ParamFileGroupExists bit OUTPUT', @ParamFileGroupID = @CurrentFileGroupID, @ParamFileGroupName = @CurrentFileGroupName, @ParamFileGroupExists = @CurrentFileGroupExists OUTPUT
+          SET @Error = @@ERROR
+          IF @Error = 0 AND @CurrentFileGroupExists IS NULL SET @CurrentFileGroupExists = 0
+          IF @Error = 1222
           BEGIN
-            INSERT INTO @DirectoryInfo (FileExists, FileIsADirectory, ParentDirectoryExists)
-            EXECUTE [master].dbo.xp_fileexist @CurrentDirectoryPath
+            SET @ErrorMessage = 'The file group ' + QUOTENAME(@CurrentFileGroupName) + ' in the database ' + QUOTENAME(@CurrentDatabaseName) + ' is locked. It could not be checked if the filegroup exists.' + CHAR(13) + CHAR(10) + ' '
+            SET @ErrorMessage = REPLACE(@ErrorMessage,'%','%%')
+            RAISERROR(@ErrorMessage,16,1) WITH NOWAIT
+          END
+          IF @Error <> 0
+          BEGIN
+            SET @ReturnCode = @Error
+          END
+        END
+
+        IF @CurrentBackupType = 'LOG' AND (@CleanupTime IS NOT NULL OR @MirrorCleanupTime IS NOT NULL)
+        BEGIN
+          SELECT @CurrentLatestBackup = MAX(backup_start_date)
+          FROM msdb.dbo.backupset
+          WHERE ([type] IN('D','I')
+          OR ([type] = 'L' AND last_lsn < @CurrentDifferentialBaseLSN))
+          AND is_damaged = 0
+          AND [database_name] = @CurrentDatabaseName
+        END
+
+        SET @CurrentDate = SYSDATETIME()
+        SET @CurrentDateUTC = SYSUTCDATETIME()
+
+        INSERT INTO @CurrentCleanupDates (CleanupDate)
+        SELECT @CurrentDate
+
+        IF @CurrentBackupType = 'LOG'
+        BEGIN
+          INSERT INTO @CurrentCleanupDates (CleanupDate)
+          SELECT @CurrentLatestBackup
+        END
+
+        SELECT @CurrentDirectoryStructure = CASE
+        WHEN @CurrentAvailabilityGroup IS NOT NULL THEN @AvailabilityGroupDirectoryStructure
+        ELSE @DirectoryStructure
+        END
+
+        IF @CurrentDirectoryStructure IS NOT NULL
+        BEGIN
+        -- Directory structure - remove tokens that are not needed
+          IF @CurrentFileGroupName IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}','')
+          IF @ReadWriteFileGroups = 'N' SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Partial}','')
+          IF @CopyOnly = 'N' SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{CopyOnly}','')
+          IF @Cluster IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}','')
+          IF @CurrentAvailabilityGroup IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}','')
+          IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}','')
+          IF @@SERVICENAME IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServiceName}','')
+          IF @Description IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Description}','')
+          IF @BackupSetName IS NULL SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupSetName}','')
+
+          IF @Directory IS NULL AND @MirrorDirectory IS NULL AND @URL IS NULL AND @DefaultDirectory LIKE '%' + '.' + @@SERVICENAME + @DirectorySeparator + 'MSSQL' + @DirectorySeparator + 'Backup'
+          BEGIN
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServerName}','')
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}','')
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}','')
+            SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}','')
           END
 
-          IF NOT EXISTS (SELECT * FROM @DirectoryInfo WHERE FileExists = 0 AND FileIsADirectory = 1 AND ParentDirectoryExists = 1)
+          WHILE (@Updated = 1 OR @Updated IS NULL)
           BEGIN
-            SET @CurrentDatabaseContext = 'master'
+            SET @Updated = 0
 
-            SET @CurrentCommandType = 'xp_create_subdir'
+            IF CHARINDEX('\',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'\','{DirectorySeparator}')
+              SET @Updated = 1
+            END
 
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_create_subdir N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''' IF @ReturnCode <> 0 RAISERROR(''Error creating directory.'', 16, 1)'
+            IF CHARINDEX('/',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'/','{DirectorySeparator}')
+              SET @Updated = 1
+            END
+
+            IF CHARINDEX('__',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'__','_')
+              SET @Updated = 1
+            END
+
+            IF CHARINDEX('--',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'--','-')
+              SET @Updated = 1
+            END
+
+            IF CHARINDEX('{DirectorySeparator}{DirectorySeparator}',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}{DirectorySeparator}','{DirectorySeparator}')
+              SET @Updated = 1
+            END
+
+            IF CHARINDEX('{DirectorySeparator}$',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}$','{DirectorySeparator}')
+              SET @Updated = 1
+            END
+            IF CHARINDEX('${DirectorySeparator}',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'${DirectorySeparator}','{DirectorySeparator}')
+              SET @Updated = 1
+            END
+
+            IF CHARINDEX('{DirectorySeparator}_',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}_','{DirectorySeparator}')
+              SET @Updated = 1
+            END
+            IF CHARINDEX('_{DirectorySeparator}',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'_{DirectorySeparator}','{DirectorySeparator}')
+              SET @Updated = 1
+            END
+
+            IF CHARINDEX('{DirectorySeparator}-',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}-','{DirectorySeparator}')
+              SET @Updated = 1
+            END
+            IF CHARINDEX('-{DirectorySeparator}',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'-{DirectorySeparator}','{DirectorySeparator}')
+              SET @Updated = 1
+            END
+
+            IF CHARINDEX('_$',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'_$','_')
+              SET @Updated = 1
+            END
+            IF CHARINDEX('$_',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'$_','_')
+              SET @Updated = 1
+            END
+
+            IF CHARINDEX('-$',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'-$','-')
+              SET @Updated = 1
+            END
+            IF CHARINDEX('$-',@CurrentDirectoryStructure) > 0
+            BEGIN
+              SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'$-','-')
+              SET @Updated = 1
+            END
+
+            IF LEFT(@CurrentDirectoryStructure,1) = '_'
+            BEGIN
+              SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+            IF RIGHT(@CurrentDirectoryStructure,1) = '_'
+            BEGIN
+              SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+
+            IF LEFT(@CurrentDirectoryStructure,1) = '-'
+            BEGIN
+              SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+            IF RIGHT(@CurrentDirectoryStructure,1) = '-'
+            BEGIN
+              SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+
+            IF LEFT(@CurrentDirectoryStructure,1) = '$'
+            BEGIN
+              SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+            IF RIGHT(@CurrentDirectoryStructure,1) = '$'
+            BEGIN
+              SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 1)
+              SET @Updated = 1
+            END
+
+            IF LEFT(@CurrentDirectoryStructure,20) = '{DirectorySeparator}'
+            BEGIN
+              SET @CurrentDirectoryStructure = RIGHT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 20)
+              SET @Updated = 1
+            END
+            IF RIGHT(@CurrentDirectoryStructure,20) = '{DirectorySeparator}'
+            BEGIN
+              SET @CurrentDirectoryStructure = LEFT(@CurrentDirectoryStructure,LEN(@CurrentDirectoryStructure) - 20)
+              SET @Updated = 1
+            END
+          END
+
+          SET @Updated = NULL
+
+          -- Directory structure - replace tokens with real values
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DirectorySeparator}',@DirectorySeparator)
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServerName}',CASE WHEN SERVERPROPERTY('EngineEdition') = 8 THEN LEFT(CAST(SERVERPROPERTY('ServerName') AS nvarchar(max)),CHARINDEX('.',CAST(SERVERPROPERTY('ServerName') AS nvarchar(max))) - 1) ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar(max)) END)
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{InstanceName}',ISNULL(CAST(SERVERPROPERTY('InstanceName') AS nvarchar(max)),''))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ServiceName}',ISNULL(@@SERVICENAME,''))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{ClusterName}',ISNULL(@Cluster,''))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{AvailabilityGroupName}',ISNULL(@CurrentAvailabilityGroup,''))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{DatabaseName}',@CurrentDatabaseNameFS)
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{FileGroupName}',ISNULL(@CurrentFileGroupName,''))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupType}',@CurrentBackupType)
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Partial}','PARTIAL')
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{CopyOnly}','COPY_ONLY')
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Description}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@Description,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{BackupSetName}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@BackupSetName,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Year}',CAST(DATEPART(YEAR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Month}',RIGHT('0' + CAST(DATEPART(MONTH,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Day}',RIGHT('0' + CAST(DATEPART(DAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Week}',RIGHT('0' + CAST(DATEPART(WEEK,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Weekday}',DATENAME(WEEKDAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Hour}',RIGHT('0' + CAST(DATEPART(HOUR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Minute}',RIGHT('0' + CAST(DATEPART(MINUTE,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Second}',RIGHT('0' + CAST(DATEPART(SECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Millisecond}',RIGHT('00' + CAST(DATEPART(MILLISECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),3))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{Microsecond}',RIGHT('00000' + CAST(DATEPART(MICROSECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),6))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{MajorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMajorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4)))
+          SET @CurrentDirectoryStructure = REPLACE(@CurrentDirectoryStructure,'{MinorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMinorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3)))
+        END
+
+        IF @DirectoryStructureCase IS NOT NULL
+        BEGIN
+          SET @CurrentDirectoryStructure = CASE WHEN @DirectoryStructureCase = 'LOWER' THEN LOWER(@CurrentDirectoryStructure)
+                                                WHEN @DirectoryStructureCase = 'UPPER' THEN UPPER(@CurrentDirectoryStructure) END
+        END
+
+        INSERT INTO @CurrentDirectories (ID, DirectoryPath, Mirror, DirectoryNumber, CreateCompleted, CleanupCompleted)
+        SELECT ROW_NUMBER() OVER (ORDER BY ID),
+               DirectoryPath + CASE WHEN DirectoryPath = 'NUL' THEN '' WHEN @CurrentDirectoryStructure IS NOT NULL THEN @DirectorySeparator + @CurrentDirectoryStructure ELSE '' END,
+               Mirror,
+               ROW_NUMBER() OVER (PARTITION BY Mirror ORDER BY ID ASC),
+               0,
+               0
+        FROM @Directories
+        ORDER BY ID ASC
+
+        INSERT INTO @CurrentURLs (ID, DirectoryPath, Mirror, DirectoryNumber)
+        SELECT ROW_NUMBER() OVER (ORDER BY ID),
+               DirectoryPath + CASE WHEN @CurrentDirectoryStructure IS NOT NULL THEN @DirectorySeparator + @CurrentDirectoryStructure ELSE '' END,
+               Mirror,
+               ROW_NUMBER() OVER (PARTITION BY Mirror ORDER BY ID ASC)
+        FROM @URLs
+        ORDER BY ID ASC
+
+        SELECT @CurrentDatabaseFileName = CASE
+        WHEN @CurrentAvailabilityGroup IS NOT NULL THEN @AvailabilityGroupFileName
+        ELSE @FileName
+        END
+
+        -- File name - remove tokens that are not needed
+        IF @CurrentFileGroupName IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}','')
+        IF @ReadWriteFileGroups = 'N' SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Partial}','')
+        IF @CopyOnly = 'N' SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{CopyOnly}','')
+        IF @Cluster IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ClusterName}','')
+        IF @CurrentAvailabilityGroup IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{AvailabilityGroupName}','')
+        IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{InstanceName}','')
+        IF @@SERVICENAME IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServiceName}','')
+        IF @Description IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Description}','')
+        IF @BackupSetName IS NULL SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupSetName}','')
+        IF @CurrentNumberOfFiles = 1 SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileNumber}','')
+        IF @CurrentNumberOfFiles = 1 SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{NumberOfFiles}','')
+
+        WHILE (@Updated = 1 OR @Updated IS NULL)
+        BEGIN
+          SET @Updated = 0
+
+          IF CHARINDEX('__',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'__','_')
+            SET @Updated = 1
+          END
+
+          IF CHARINDEX('--',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'--','-')
+            SET @Updated = 1
+          END
+
+          IF CHARINDEX('_$',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'_$','_')
+            SET @Updated = 1
+          END
+          IF CHARINDEX('$_',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'$_','_')
+            SET @Updated = 1
+          END
+
+          IF CHARINDEX('-$',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'-$','-')
+            SET @Updated = 1
+          END
+          IF CHARINDEX('$-',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'$-','-')
+            SET @Updated = 1
+          END
+
+          IF CHARINDEX('_.',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'_.','.')
+            SET @Updated = 1
+          END
+
+          IF CHARINDEX('-.',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'-.','.')
+            SET @Updated = 1
+          END
+
+          IF CHARINDEX('of.',@CurrentDatabaseFileName) > 0
+          BEGIN
+            SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'of.','.')
+            SET @Updated = 1
+          END
+
+          IF LEFT(@CurrentDatabaseFileName,1) = '_'
+          BEGIN
+            SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+          IF RIGHT(@CurrentDatabaseFileName,1) = '_'
+          BEGIN
+            SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+
+          IF LEFT(@CurrentDatabaseFileName,1) = '-'
+          BEGIN
+            SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+          IF RIGHT(@CurrentDatabaseFileName,1) = '-'
+          BEGIN
+            SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+
+          IF LEFT(@CurrentDatabaseFileName,1) = '$'
+          BEGIN
+            SET @CurrentDatabaseFileName = RIGHT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+          IF RIGHT(@CurrentDatabaseFileName,1) = '$'
+          BEGIN
+            SET @CurrentDatabaseFileName = LEFT(@CurrentDatabaseFileName,LEN(@CurrentDatabaseFileName) - 1)
+            SET @Updated = 1
+          END
+        END
+
+        SET @Updated = NULL
+
+        SELECT @CurrentFileExtension = CASE
+        WHEN @CurrentBackupType = 'FULL' THEN @FileExtensionFull
+        WHEN @CurrentBackupType = 'DIFF' THEN @FileExtensionDiff
+        WHEN @CurrentBackupType = 'LOG' THEN @FileExtensionLog
+        END
+
+        -- File name - replace tokens with real values
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServerName}',CASE WHEN SERVERPROPERTY('EngineEdition') = 8 THEN LEFT(CAST(SERVERPROPERTY('ServerName') AS nvarchar(max)),CHARINDEX('.',CAST(SERVERPROPERTY('ServerName') AS nvarchar(max))) - 1) ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar(max)) END)
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{InstanceName}',ISNULL(CAST(SERVERPROPERTY('InstanceName') AS nvarchar(max)),''))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ServiceName}',ISNULL(@@SERVICENAME,''))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{ClusterName}',ISNULL(@Cluster,''))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{AvailabilityGroupName}',ISNULL(@CurrentAvailabilityGroup,''))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileGroupName}',ISNULL(@CurrentFileGroupName,''))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupType}',@CurrentBackupType)
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Partial}','PARTIAL')
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{CopyOnly}','COPY_ONLY')
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Description}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@Description,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{BackupSetName}',LTRIM(RTRIM(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ISNULL(@BackupSetName,''),'\',''),'/',''),':',''),'*',''),'?',''),'"',''),'<',''),'>',''),'|',''))))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Year}',CAST(DATEPART(YEAR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Month}',RIGHT('0' + CAST(DATEPART(MONTH,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Day}',RIGHT('0' + CAST(DATEPART(DAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Week}',RIGHT('0' + CAST(DATEPART(WEEK,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Weekday}',DATENAME(WEEKDAY,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Hour}',RIGHT('0' + CAST(DATEPART(HOUR,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Minute}',RIGHT('0' + CAST(DATEPART(MINUTE,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Second}',RIGHT('0' + CAST(DATEPART(SECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),2))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Millisecond}',RIGHT('00' + CAST(DATEPART(MILLISECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),3))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{Microsecond}',RIGHT('00000' + CAST(DATEPART(MICROSECOND,CASE WHEN @TokenTimezone = 'UTC' THEN @CurrentDateUTC ELSE @CurrentDate END) AS nvarchar),6))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{NumberOfFiles}',@CurrentNumberOfFiles)
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{FileExtension}',@CurrentFileExtension)
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{MajorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMajorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),4)))
+        SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{MinorVersion}',ISNULL(CAST(SERVERPROPERTY('ProductMinorVersion') AS nvarchar),PARSENAME(CAST(SERVERPROPERTY('ProductVersion') AS nvarchar),3)))
+
+        SELECT @CurrentMaxFilePathLength = CASE
+        WHEN EXISTS (SELECT * FROM @CurrentDirectories) THEN (SELECT MAX(LEN(DirectoryPath + @DirectorySeparator)) FROM @CurrentDirectories)
+        WHEN EXISTS (SELECT * FROM @CurrentURLs) THEN (SELECT MAX(LEN(DirectoryPath + @DirectorySeparator)) FROM @CurrentURLs)
+        END
+        + LEN(REPLACE(REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',@CurrentDatabaseNameFS), '{FileNumber}', CASE WHEN @CurrentNumberOfFiles >= 1 AND @CurrentNumberOfFiles <= 9 THEN '1' WHEN @CurrentNumberOfFiles >= 10 THEN '01' END))
+
+        -- The maximum length of a backup device is 259 characters
+        IF @CurrentMaxFilePathLength > 259
+        BEGIN
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',LEFT(@CurrentDatabaseNameFS,CASE WHEN (LEN(@CurrentDatabaseNameFS) + 259 - @CurrentMaxFilePathLength - 3) < 20 THEN 20 ELSE (LEN(@CurrentDatabaseNameFS) + 259 - @CurrentMaxFilePathLength - 3) END) + '...')
+        END
+        ELSE
+        BEGIN
+          SET @CurrentDatabaseFileName = REPLACE(@CurrentDatabaseFileName,'{DatabaseName}',@CurrentDatabaseNameFS)
+        END
+
+        IF @FileNameCase IS NOT NULL
+        BEGIN
+          SET @CurrentDatabaseFileName = CASE WHEN @FileNameCase = 'LOWER' THEN LOWER(@CurrentDatabaseFileName)
+                                              WHEN @FileNameCase = 'UPPER' THEN UPPER(@CurrentDatabaseFileName) END
+        END
+
+        IF EXISTS (SELECT * FROM @CurrentDirectories WHERE Mirror = 0)
+        BEGIN
+          SET @CurrentFileNumber = 0
+
+          WHILE @CurrentFileNumber < @CurrentNumberOfFiles
+          BEGIN
+            SET @CurrentFileNumber = @CurrentFileNumber + 1
+
+            SELECT @CurrentDirectoryPath = DirectoryPath
+            FROM @CurrentDirectories
+            WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 0) + 1
+            AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 0)
+            AND Mirror = 0
+
+            SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles >= 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) END)
+
+            IF @CurrentDirectoryPath = 'NUL'
+            BEGIN
+              SET @CurrentFilePath = 'NUL'
+            END
+            ELSE
+            BEGIN
+              SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
+            END
+
+            INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
+            SELECT 'DISK', @CurrentFilePath, 0
+
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentFileName = NULL
+            SET @CurrentFilePath = NULL
+          END
+
+          INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
+          SELECT 0, 0
+        END
+
+        IF EXISTS (SELECT * FROM @CurrentDirectories WHERE Mirror = 1)
+        BEGIN
+          SET @CurrentFileNumber = 0
+
+          WHILE @CurrentFileNumber < @CurrentNumberOfFiles
+          BEGIN
+            SET @CurrentFileNumber = @CurrentFileNumber + 1
+
+            SELECT @CurrentDirectoryPath = DirectoryPath
+            FROM @CurrentDirectories
+            WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 1) + 1
+            AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentDirectories WHERE Mirror = 1)
+            AND Mirror = 1
+
+            SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
+
+            SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
+
+            INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
+            SELECT 'DISK', @CurrentFilePath, 1
+
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentFileName = NULL
+            SET @CurrentFilePath = NULL
+          END
+
+          INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
+          SELECT 1, 0
+        END
+
+        IF EXISTS (SELECT * FROM @CurrentURLs WHERE Mirror = 0)
+        BEGIN
+          SET @CurrentFileNumber = 0
+
+          WHILE @CurrentFileNumber < @CurrentNumberOfFiles
+          BEGIN
+            SET @CurrentFileNumber = @CurrentFileNumber + 1
+
+            SELECT @CurrentDirectoryPath = DirectoryPath
+            FROM @CurrentURLs
+            WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0) + 1
+            AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0)
+            AND Mirror = 0
+
+            SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
+
+            SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
+
+            INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
+            SELECT 'URL', @CurrentFilePath, 0
+
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentFileName = NULL
+            SET @CurrentFilePath = NULL
+          END
+
+          INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
+          SELECT 0, 0
+        END
+
+        IF EXISTS (SELECT * FROM @CurrentURLs WHERE Mirror = 1)
+        BEGIN
+          SET @CurrentFileNumber = 0
+
+          WHILE @CurrentFileNumber < @CurrentNumberOfFiles
+          BEGIN
+            SET @CurrentFileNumber = @CurrentFileNumber + 1
+
+            SELECT @CurrentDirectoryPath = DirectoryPath
+            FROM @CurrentURLs
+            WHERE @CurrentFileNumber >= (DirectoryNumber - 1) * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0) + 1
+            AND @CurrentFileNumber <= DirectoryNumber * (SELECT @CurrentNumberOfFiles / COUNT(*) FROM @CurrentURLs WHERE Mirror = 0)
+            AND Mirror = 1
+
+            SET @CurrentFileName = REPLACE(@CurrentDatabaseFileName, '{FileNumber}', CASE WHEN @CurrentNumberOfFiles > 1 AND @CurrentNumberOfFiles <= 9 THEN CAST(@CurrentFileNumber AS nvarchar) WHEN @CurrentNumberOfFiles >= 10 THEN RIGHT('0' + CAST(@CurrentFileNumber AS nvarchar),2) ELSE '' END)
+
+            SET @CurrentFilePath = @CurrentDirectoryPath + @DirectorySeparator + @CurrentFileName
+
+            INSERT INTO @CurrentFiles ([Type], FilePath, Mirror)
+            SELECT 'URL', @CurrentFilePath, 1
+
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentFileName = NULL
+            SET @CurrentFilePath = NULL
+          END
+
+          INSERT INTO @CurrentBackupSet (Mirror, VerifyCompleted)
+          SELECT 1, 0
+        END
+
+        -- Create directory
+        IF @HostPlatform = 'Windows'
+        AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
+        AND NOT EXISTS(SELECT * FROM @CurrentDirectories WHERE DirectoryPath = 'NUL' OR DirectoryPath IN(SELECT DirectoryPath FROM @Directories))
+        BEGIN
+          WHILE (1 = 1)
+          BEGIN
+            SELECT TOP 1 @CurrentDirectoryID = ID,
+                         @CurrentDirectoryPath = DirectoryPath
+            FROM @CurrentDirectories
+            WHERE CreateCompleted = 0
+            ORDER BY ID ASC
+
+            IF @@ROWCOUNT = 0
+            BEGIN
+              BREAK
+            END
+
+            IF @DirectoryCheck = 'Y'
+            BEGIN
+              INSERT INTO @DirectoryInfo (FileExists, FileIsADirectory, ParentDirectoryExists)
+              EXECUTE [master].dbo.xp_fileexist @CurrentDirectoryPath
+            END
+
+            IF NOT EXISTS (SELECT * FROM @DirectoryInfo WHERE FileExists = 0 AND FileIsADirectory = 1 AND ParentDirectoryExists = 1)
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_create_subdir'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_create_subdir N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''' IF @ReturnCode <> 0 RAISERROR(''Error creating directory.'', 16, 1)'
+
+              EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
+              SET @Error = @@ERROR
+              IF @Error <> 0 SET @CurrentCommandOutput = @Error
+              IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
+
+              UPDATE @CurrentDirectories
+              SET CreateCompleted = 1,
+                  CreateOutput = @CurrentCommandOutput
+              WHERE ID = @CurrentDirectoryID
+            END
+            ELSE
+            BEGIN
+              UPDATE @CurrentDirectories
+              SET CreateCompleted = 1,
+                  CreateOutput = 0
+              WHERE ID = @CurrentDirectoryID
+            END
+
+            SET @CurrentDirectoryID = NULL
+            SET @CurrentDirectoryPath = NULL
+
+            SET @CurrentDatabaseContext = NULL
+            SET @CurrentCommand = NULL
+            SET @CurrentCommandOutput = NULL
+            SET @CurrentCommandType = NULL
+
+            DELETE FROM @DirectoryInfo
+          END
+        END
+
+        IF @CleanupMode = 'BEFORE_BACKUP'
+        BEGIN
+          INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
+          SELECT DATEADD(hh,-(@CleanupTime),SYSDATETIME()), 0
+
+          IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 0 OR Mirror IS NULL) AND CleanupDate IS NULL)
+          BEGIN
+            UPDATE @CurrentDirectories
+            SET CleanupDate = (SELECT MIN(CleanupDate)
+                               FROM @CurrentCleanupDates
+                               WHERE (Mirror = 0 OR Mirror IS NULL)),
+                CleanupMode = 'BEFORE_BACKUP'
+            WHERE Mirror = 0
+          END
+        END
+
+        IF @MirrorCleanupMode = 'BEFORE_BACKUP'
+        BEGIN
+          INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
+          SELECT DATEADD(hh,-(@MirrorCleanupTime),SYSDATETIME()), 1
+
+          IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 1 OR Mirror IS NULL) AND CleanupDate IS NULL)
+          BEGIN
+            UPDATE @CurrentDirectories
+            SET CleanupDate = (SELECT MIN(CleanupDate)
+                               FROM @CurrentCleanupDates
+                               WHERE (Mirror = 1 OR Mirror IS NULL)),
+                CleanupMode = 'BEFORE_BACKUP'
+            WHERE Mirror = 1
+          END
+        END
+
+        -- Delete old backup files, before backup
+        IF (NOT EXISTS (SELECT * FROM @CurrentDirectories WHERE CreateOutput <> 0 OR CreateOutput IS NULL) OR @HostPlatform = 'Linux')
+        AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
+        AND @CurrentBackupType = @BackupType
+        BEGIN
+          WHILE (1 = 1)
+          BEGIN
+            SELECT TOP 1 @CurrentDirectoryID = ID,
+                         @CurrentDirectoryPath = DirectoryPath,
+                         @CurrentCleanupDate = CleanupDate
+            FROM @CurrentDirectories
+            WHERE CleanupDate IS NOT NULL
+            AND CleanupMode = 'BEFORE_BACKUP'
+            AND CleanupCompleted = 0
+            ORDER BY ID ASC
+
+            IF @@ROWCOUNT = 0
+            BEGIN
+              BREAK
+            END
+
+            IF @BackupSoftware IS NULL
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_delete_file'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_delete_file 0, N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + @CurrentFileExtension + ''', ''' + CONVERT(nvarchar(19),@CurrentCleanupDate,126) + ''' IF @ReturnCode <> 0 RAISERROR(''Error deleting files.'', 16, 1)'
+            END
+
+            IF @BackupSoftware = 'LITESPEED'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_slssqlmaint'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_slssqlmaint N''-MAINTDEL -DELFOLDER "' + REPLACE(@CurrentDirectoryPath,'''','''''') + '" -DELEXTENSION "' + @CurrentFileExtension + '" -DELUNIT "' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + '" -DELUNITTYPE "minutes" -DELUSEAGE'' IF @ReturnCode <> 0 RAISERROR(''Error deleting LiteSpeed backup files.'', 16, 1)'
+            END
+
+            IF @BackupSoftware = 'SQLBACKUP'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'sqbutility'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqbutility 1032, N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''', N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + CASE WHEN @CurrentBackupType = 'FULL' THEN 'D' WHEN @CurrentBackupType = 'DIFF' THEN 'I' WHEN @CurrentBackupType = 'LOG' THEN 'L' END + ''', ''' + CAST(DATEDIFF(hh,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'h'', ' + ISNULL('''' + REPLACE(@EncryptionKey,'''','''''') + '''','NULL') + ' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLBackup backup files.'', 16, 1)'
+            END
+
+            IF @BackupSoftware = 'SQLSAFE'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_ss_delete'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_delete @filename = N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + '\*.' + @CurrentFileExtension + ''', @age = ''' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'Minutes'' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLsafe backup files.'', 16, 1)'
+            END
 
             EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
             SET @Error = @@ERROR
@@ -4147,481 +4327,164 @@ BEGIN
             IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
 
             UPDATE @CurrentDirectories
-            SET CreateCompleted = 1,
-                CreateOutput = @CurrentCommandOutput
+            SET CleanupCompleted = 1,
+                CleanupOutput = @CurrentCommandOutput
             WHERE ID = @CurrentDirectoryID
+
+            SET @CurrentDirectoryID = NULL
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentCleanupDate = NULL
+
+            SET @CurrentDatabaseContext = NULL
+            SET @CurrentCommand = NULL
+            SET @CurrentCommandOutput = NULL
+            SET @CurrentCommandType = NULL
           END
-          ELSE
-          BEGIN
-            UPDATE @CurrentDirectories
-            SET CreateCompleted = 1,
-                CreateOutput = 0
-            WHERE ID = @CurrentDirectoryID
-          END
-
-          SET @CurrentDirectoryID = NULL
-          SET @CurrentDirectoryPath = NULL
-
-          SET @CurrentDatabaseContext = NULL
-          SET @CurrentCommand = NULL
-          SET @CurrentCommandOutput = NULL
-          SET @CurrentCommandType = NULL
-
-          DELETE FROM @DirectoryInfo
         END
-      END
 
-      IF @CleanupMode = 'BEFORE_BACKUP'
-      BEGIN
-        INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
-        SELECT DATEADD(hh,-(@CleanupTime),SYSDATETIME()), 0
-
-        IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 0 OR Mirror IS NULL) AND CleanupDate IS NULL)
+        -- Perform a backup
+        IF NOT EXISTS (SELECT * FROM @CurrentDirectories WHERE DirectoryPath <> 'NUL' AND DirectoryPath NOT IN(SELECT DirectoryPath FROM @Directories) AND (CreateOutput <> 0 OR CreateOutput IS NULL))
+        OR @HostPlatform = 'Linux'
         BEGIN
-          UPDATE @CurrentDirectories
-          SET CleanupDate = (SELECT MIN(CleanupDate)
-                             FROM @CurrentCleanupDates
-                             WHERE (Mirror = 0 OR Mirror IS NULL)),
-              CleanupMode = 'BEFORE_BACKUP'
-          WHERE Mirror = 0
-        END
-      END
-
-      IF @MirrorCleanupMode = 'BEFORE_BACKUP'
-      BEGIN
-        INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
-        SELECT DATEADD(hh,-(@MirrorCleanupTime),SYSDATETIME()), 1
-
-        IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 1 OR Mirror IS NULL) AND CleanupDate IS NULL)
-        BEGIN
-          UPDATE @CurrentDirectories
-          SET CleanupDate = (SELECT MIN(CleanupDate)
-                             FROM @CurrentCleanupDates
-                             WHERE (Mirror = 1 OR Mirror IS NULL)),
-              CleanupMode = 'BEFORE_BACKUP'
-          WHERE Mirror = 1
-        END
-      END
-
-      -- Delete old backup files, before backup
-      IF (NOT EXISTS (SELECT * FROM @CurrentDirectories WHERE CreateOutput <> 0 OR CreateOutput IS NULL) OR @HostPlatform = 'Linux')
-      AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
-      AND @CurrentBackupType = @BackupType
-      BEGIN
-        WHILE (1 = 1)
-        BEGIN
-          SELECT TOP 1 @CurrentDirectoryID = ID,
-                       @CurrentDirectoryPath = DirectoryPath,
-                       @CurrentCleanupDate = CleanupDate
-          FROM @CurrentDirectories
-          WHERE CleanupDate IS NOT NULL
-          AND CleanupMode = 'BEFORE_BACKUP'
-          AND CleanupCompleted = 0
-          ORDER BY ID ASC
-
-          IF @@ROWCOUNT = 0
-          BEGIN
-            BREAK
-          END
-
           IF @BackupSoftware IS NULL
           BEGIN
             SET @CurrentDatabaseContext = 'master'
 
-            SET @CurrentCommandType = 'xp_delete_file'
+            SELECT @CurrentCommandType = CASE
+            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP_DATABASE'
+            WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP_LOG'
+            END
 
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_delete_file 0, N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + @CurrentFileExtension + ''', ''' + CONVERT(nvarchar(19),@CurrentCleanupDate,126) + ''' IF @ReturnCode <> 0 RAISERROR(''Error deleting files.'', 16, 1)'
-          END
+            SELECT @CurrentCommand = CASE
+            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP DATABASE ' + QUOTENAME(@CurrentDatabaseName)
+            WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP LOG ' + QUOTENAME(@CurrentDatabaseName)
+            END
 
-          IF @BackupSoftware = 'LITESPEED'
-          BEGIN
-            SET @CurrentDatabaseContext = 'master'
+            IF @FileGroups IS NOT NULL SET @CurrentCommand += ' FILEGROUP = ''' + @CurrentFileGroupName + ''''
 
-            SET @CurrentCommandType = 'xp_slssqlmaint'
+            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' READ_WRITE_FILEGROUPS'
 
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_slssqlmaint N''-MAINTDEL -DELFOLDER "' + REPLACE(@CurrentDirectoryPath,'''','''''') + '" -DELEXTENSION "' + @CurrentFileExtension + '" -DELUNIT "' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + '" -DELUNITTYPE "minutes" -DELUSEAGE'' IF @ReturnCode <> 0 RAISERROR(''Error deleting LiteSpeed backup files.'', 16, 1)'
-          END
-
-          IF @BackupSoftware = 'SQLBACKUP'
-          BEGIN
-            SET @CurrentDatabaseContext = 'master'
-
-            SET @CurrentCommandType = 'sqbutility'
-
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqbutility 1032, N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''', N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + CASE WHEN @CurrentBackupType = 'FULL' THEN 'D' WHEN @CurrentBackupType = 'DIFF' THEN 'I' WHEN @CurrentBackupType = 'LOG' THEN 'L' END + ''', ''' + CAST(DATEDIFF(hh,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'h'', ' + ISNULL('''' + REPLACE(@EncryptionKey,'''','''''') + '''','NULL') + ' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLBackup backup files.'', 16, 1)'
-          END
-
-          IF @BackupSoftware = 'SQLSAFE'
-          BEGIN
-            SET @CurrentDatabaseContext = 'master'
-
-            SET @CurrentCommandType = 'xp_ss_delete'
-
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_delete @filename = N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + '\*.' + @CurrentFileExtension + ''', @age = ''' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'Minutes'' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLsafe backup files.'', 16, 1)'
-          END
-
-          EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
-          SET @Error = @@ERROR
-          IF @Error <> 0 SET @CurrentCommandOutput = @Error
-          IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
-
-          UPDATE @CurrentDirectories
-          SET CleanupCompleted = 1,
-              CleanupOutput = @CurrentCommandOutput
-          WHERE ID = @CurrentDirectoryID
-
-          SET @CurrentDirectoryID = NULL
-          SET @CurrentDirectoryPath = NULL
-          SET @CurrentCleanupDate = NULL
-
-          SET @CurrentDatabaseContext = NULL
-          SET @CurrentCommand = NULL
-          SET @CurrentCommandOutput = NULL
-          SET @CurrentCommandType = NULL
-        END
-      END
-
-      -- Perform a backup
-      IF NOT EXISTS (SELECT * FROM @CurrentDirectories WHERE DirectoryPath <> 'NUL' AND DirectoryPath NOT IN(SELECT DirectoryPath FROM @Directories) AND (CreateOutput <> 0 OR CreateOutput IS NULL))
-      OR @HostPlatform = 'Linux'
-      BEGIN
-        IF @BackupSoftware IS NULL
-        BEGIN
-          SET @CurrentDatabaseContext = 'master'
-
-          SELECT @CurrentCommandType = CASE
-          WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP_DATABASE'
-          WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP_LOG'
-          END
-
-          SELECT @CurrentCommand = CASE
-          WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP DATABASE ' + QUOTENAME(@CurrentDatabaseName)
-          WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP LOG ' + QUOTENAME(@CurrentDatabaseName)
-          END
-
-          IF @FileGroups IS NOT NULL SET @CurrentCommand += ' FILEGROUP = ''' + @CurrentFileGroupName + ''''
-
-          IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' READ_WRITE_FILEGROUPS'
-
-          SET @CurrentCommand += ' TO'
-
-          SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
-          FROM @CurrentFiles
-          WHERE Mirror = 0
-          ORDER BY FilePath ASC
-
-          IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
-          BEGIN
-            SET @CurrentCommand += ' MIRROR TO'
+            SET @CurrentCommand += ' TO'
 
             SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
             FROM @CurrentFiles
-            WHERE Mirror = 1
+            WHERE Mirror = 0
             ORDER BY FilePath ASC
-          END
 
-          SET @CurrentCommand += ' WITH '
-          IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
-          IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+            IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
+            BEGIN
+              SET @CurrentCommand += ' MIRROR TO'
 
-          IF @Version >= 10
-          BEGIN
-            SET @CurrentCommand += CASE WHEN @Compress = 'Y' AND (@CurrentIsEncrypted = 0 OR (@CurrentIsEncrypted = 1 AND ((@Version >= 13 AND @CurrentMaxTransferSize >= 65537) OR @Version >= 15.0404316 OR SERVERPROPERTY('EngineEdition') = 8))) THEN ', COMPRESSION' ELSE ', NO_COMPRESSION' END
-          END
-
-          IF @Compress = 'Y' AND @CompressionAlgorithm IS NOT NULL
-          BEGIN
-            SET @CurrentCommand += ' (ALGORITHM = ' + @CompressionAlgorithm + CASE WHEN @CompressionLevel IS NOT NULL THEN ', LEVEL = ' + @CompressionLevel ELSE '' END + ')'
-          END
-
-          IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
-
-          IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
-          BEGIN
-            SET @CurrentCommand += ', FORMAT'
-          END
-
-          IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
-          IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
-          IF @Init = 'Y' SET @CurrentCommand += ', INIT'
-          IF @Format = 'Y' SET @CurrentCommand += ', FORMAT'
-          IF @BlockSize IS NOT NULL SET @CurrentCommand += ', BLOCKSIZE = ' + CAST(@BlockSize AS nvarchar)
-          IF @BufferCount IS NOT NULL SET @CurrentCommand += ', BUFFERCOUNT = ' + CAST(@BufferCount AS nvarchar)
-          IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', MAXTRANSFERSIZE = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
-          IF @Description IS NOT NULL SET @CurrentCommand += ', DESCRIPTION = N''' + REPLACE(@Description,'''','''''') + ''''
-          IF @BackupSetName IS NOT NULL SET @CurrentCommand += ', NAME = N''' + REPLACE(@BackupSetName,'''','''''') + ''''
-          IF @Stats IS NOT NULL SET @CurrentCommand += ', STATS = ' + CAST(@Stats AS nvarchar)
-          IF @BackupOptions IS NOT NULL SET @CurrentCommand += ', BACKUP_OPTIONS = N''' + REPLACE(@BackupOptions,'''','''''') + ''''
-          IF @Encrypt = 'Y' SET @CurrentCommand += ', ENCRYPTION (ALGORITHM = ' + UPPER(@EncryptionAlgorithm) + ', '
-          IF @Encrypt = 'Y' AND @ServerCertificate IS NOT NULL SET @CurrentCommand += 'SERVER CERTIFICATE = ' + QUOTENAME(@ServerCertificate)
-          IF @Encrypt = 'Y' AND @ServerAsymmetricKey IS NOT NULL SET @CurrentCommand += 'SERVER ASYMMETRIC KEY = ' + QUOTENAME(@ServerAsymmetricKey)
-          IF @Encrypt = 'Y' SET @CurrentCommand += ')'
-          IF @URL IS NOT NULL AND @Credential IS NOT NULL SET @CurrentCommand += ', CREDENTIAL = N''' + REPLACE(@Credential,'''','''''') + ''''
-          IF @ExpireDate IS NOT NULL SET @CurrentCommand += ', EXPIREDATE = ''' + CONVERT(nvarchar, @ExpireDate, 21) + ''''
-          IF @RetainDays IS NOT NULL SET @CurrentCommand += ', RETAINDAYS = ' + CAST(@RetainDays AS nvarchar)
-        END
-
-        IF @BackupSoftware = 'LITESPEED'
-        BEGIN
-          SET @CurrentDatabaseContext = 'master'
-
-          SELECT @CurrentCommandType = CASE
-          WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'xp_backup_database'
-          WHEN @CurrentBackupType = 'LOG' THEN 'xp_backup_log'
-          END
-
-          SELECT @CurrentCommand = CASE
-          WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_backup_database @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
-          WHEN @CurrentBackupType = 'LOG' THEN 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_backup_log @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
-          END
-
-          SELECT @CurrentCommand += ', @filename = N''' + REPLACE(FilePath,'''','''''') + ''''
-          FROM @CurrentFiles
-          WHERE Mirror = 0
-          ORDER BY FilePath ASC
-
-          IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
-          BEGIN
-            SELECT @CurrentCommand += ', @mirror = N''' + REPLACE(FilePath,'''','''''') + ''''
-            FROM @CurrentFiles
-            WHERE Mirror = 1
-            ORDER BY FilePath ASC
-          END
-
-          SET @CurrentCommand += ', @with = '''
-          IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
-          IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
-          IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
-          IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
-          IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
-          IF @BlockSize IS NOT NULL SET @CurrentCommand += ', BLOCKSIZE = ' + CAST(@BlockSize AS nvarchar)
-          SET @CurrentCommand += ''''
-          IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ', @read_write_filegroups = 1'
-          IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', @compressionlevel = ' + CAST(@CompressionLevelNumeric AS nvarchar)
-          IF @AdaptiveCompression IS NOT NULL SET @CurrentCommand += ', @adaptivecompression = ''' + CASE WHEN @AdaptiveCompression = 'SIZE' THEN 'Size' WHEN @AdaptiveCompression = 'SPEED' THEN 'Speed' END + ''''
-          IF @BufferCount IS NOT NULL SET @CurrentCommand += ', @buffercount = ' + CAST(@BufferCount AS nvarchar)
-          IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', @maxtransfersize = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
-          IF @Threads IS NOT NULL SET @CurrentCommand += ', @threads = ' + CAST(@Threads AS nvarchar)
-          IF @Init = 'Y' SET @CurrentCommand += ', @init = 1'
-          IF @Format = 'Y' SET @CurrentCommand += ', @format = 1'
-          IF @Throttle IS NOT NULL SET @CurrentCommand += ', @throttle = ' + CAST(@Throttle AS nvarchar)
-          IF @Description IS NOT NULL SET @CurrentCommand += ', @desc = N''' + REPLACE(@Description,'''','''''') + ''''
-          IF @ObjectLevelRecoveryMap = 'Y' SET @CurrentCommand += ', @olrmap = 1'
-          IF @ExpireDate IS NOT NULL SET @CurrentCommand += ', @expiration = ''' + CONVERT(nvarchar, @ExpireDate, 21) + ''''
-          IF @RetainDays IS NOT NULL SET @CurrentCommand += ', @retaindays = ' + CAST(@RetainDays AS nvarchar)
-
-          IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', @cryptlevel = ' + CASE
-          WHEN @EncryptionAlgorithm = 'RC2_40' THEN '0'
-          WHEN @EncryptionAlgorithm = 'RC2_56' THEN '1'
-          WHEN @EncryptionAlgorithm = 'RC2_112' THEN '2'
-          WHEN @EncryptionAlgorithm = 'RC2_128' THEN '3'
-          WHEN @EncryptionAlgorithm = 'TRIPLE_DES_3KEY' THEN '4'
-          WHEN @EncryptionAlgorithm = 'RC4_128' THEN '5'
-          WHEN @EncryptionAlgorithm = 'AES_128' THEN '6'
-          WHEN @EncryptionAlgorithm = 'AES_192' THEN '7'
-          WHEN @EncryptionAlgorithm = 'AES_256' THEN '8'
-          END
-
-          IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptionkey = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
-          SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing LiteSpeed backup.'', 16, 1)'
-        END
-
-        IF @BackupSoftware = 'SQLBACKUP'
-        BEGIN
-          SET @CurrentDatabaseContext = 'master'
-
-          SET @CurrentCommandType = 'sqlbackup'
-
-          SELECT @CurrentCommand = CASE
-          WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP DATABASE ' + QUOTENAME(@CurrentDatabaseName)
-          WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP LOG ' + QUOTENAME(@CurrentDatabaseName)
-          END
-
-          IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' READ_WRITE_FILEGROUPS'
-
-          SET @CurrentCommand += ' TO'
-
-          SELECT @CurrentCommand += ' DISK = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
-          FROM @CurrentFiles
-          WHERE Mirror = 0
-          ORDER BY FilePath ASC
-
-          SET @CurrentCommand += ' WITH '
-
-          IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
-          BEGIN
-            SET @CurrentCommand += ' MIRRORFILE' + ' = N''' + REPLACE((SELECT FilePath FROM @CurrentFiles WHERE Mirror = 1),'''','''''') + ''', '
-          END
-
-          IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
-          IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
-          IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
-          IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
-          IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
-          IF @Init = 'Y' SET @CurrentCommand += ', INIT'
-          IF @Format = 'Y' SET @CurrentCommand += ', FORMAT'
-          IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', COMPRESSION = ' + CAST(@CompressionLevelNumeric AS nvarchar)
-          IF @Threads IS NOT NULL SET @CurrentCommand += ', THREADCOUNT = ' + CAST(@Threads AS nvarchar)
-          IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', MAXTRANSFERSIZE = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
-          IF @Description IS NOT NULL SET @CurrentCommand += ', DESCRIPTION = N''' + REPLACE(@Description,'''','''''') + ''''
-
-          IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', KEYSIZE = ' + CASE
-          WHEN @EncryptionAlgorithm = 'AES_128' THEN '128'
-          WHEN @EncryptionAlgorithm = 'AES_256' THEN '256'
-          END
-
-          IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', PASSWORD = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
-          SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqlbackup N''-SQL "' + REPLACE(@CurrentCommand,'''','''''') + '"''' + ' IF @ReturnCode <> 0 RAISERROR(''Error performing SQLBackup backup.'', 16, 1)'
-        END
-
-        IF @BackupSoftware = 'SQLSAFE'
-        BEGIN
-          SET @CurrentDatabaseContext = 'master'
-
-          SET @CurrentCommandType = 'xp_ss_backup'
-
-          SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_backup @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
-
-          SELECT @CurrentCommand += ', ' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) = 1 THEN '@filename' ELSE '@backupfile' END + ' = N''' + REPLACE(FilePath,'''','''''') + ''''
-          FROM @CurrentFiles
-          WHERE Mirror = 0
-          ORDER BY FilePath ASC
-
-          SELECT @CurrentCommand += ', @mirrorfile = N''' + REPLACE(FilePath,'''','''''') + ''''
-          FROM @CurrentFiles
-          WHERE Mirror = 1
-          ORDER BY FilePath ASC
-
-          SET @CurrentCommand += ', @backuptype = ' + CASE WHEN @CurrentBackupType = 'FULL' THEN '''Full''' WHEN @CurrentBackupType = 'DIFF' THEN '''Differential''' WHEN @CurrentBackupType = 'LOG' THEN '''Log''' END
-          IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ', @readwritefilegroups = 1'
-          SET @CurrentCommand += ', @checksum = ' + CASE WHEN @Checksum = 'Y' THEN '1' WHEN @Checksum = 'N' THEN '0' END
-          SET @CurrentCommand += ', @copyonly = ' + CASE WHEN @CopyOnly = 'Y' THEN '1' WHEN @CopyOnly = 'N' THEN '0' END
-          IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', @compressionlevel = ' + CAST(@CompressionLevelNumeric AS nvarchar)
-          IF @Threads IS NOT NULL SET @CurrentCommand += ', @threads = ' + CAST(@Threads AS nvarchar)
-          IF @Init = 'Y' SET @CurrentCommand += ', @overwrite = 1'
-          IF @Description IS NOT NULL SET @CurrentCommand += ', @desc = N''' + REPLACE(@Description,'''','''''') + ''''
-
-          IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', @encryptiontype = N''' + CASE
-          WHEN @EncryptionAlgorithm = 'AES_128' THEN 'AES128'
-          WHEN @EncryptionAlgorithm = 'AES_256' THEN 'AES256'
-          END + ''''
-
-          IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptedbackuppassword = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
-          SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing SQLsafe backup.'', 16, 1)'
-        END
-
-        IF @BackupSoftware = 'DATA_DOMAIN_BOOST'
-        BEGIN
-          SET @CurrentDatabaseContext = 'master'
-
-          SET @CurrentCommandType = 'emc_run_backup'
-
-          SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.emc_run_backup '''
-
-          SET @CurrentCommand += ' -c ' + CASE WHEN @Cluster IS NOT NULL AND @CurrentAvailabilityGroup IS NOT NULL THEN @Cluster ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar) END
-
-          SET @CurrentCommand += ' -l ' + CASE
-          WHEN @CurrentBackupType = 'FULL' THEN 'full'
-          WHEN @CurrentBackupType = 'DIFF' THEN 'diff'
-          WHEN @CurrentBackupType = 'LOG' THEN 'incr'
-          END
-
-          IF @NoRecovery = 'Y' SET @CurrentCommand += ' -H'
-
-          IF @CleanupTime IS NOT NULL SET @CurrentCommand += ' -y +' + CAST(@CleanupTime/24 + CASE WHEN @CleanupTime%24 > 0 THEN 1 ELSE 0 END AS nvarchar) + 'd'
-
-          IF @Checksum = 'Y' SET @CurrentCommand += ' -k'
-
-          SET @CurrentCommand += ' -S ' + CAST(@CurrentNumberOfFiles AS nvarchar)
-
-          IF @Description IS NOT NULL SET @CurrentCommand += ' -b "' + REPLACE(@Description,'''','''''') + '"'
-
-          IF @BufferCount IS NOT NULL SET @CurrentCommand += ' -O "BUFFERCOUNT=' + CAST(@BufferCount AS nvarchar) + '"'
-
-          IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' -O "READ_WRITE_FILEGROUPS"'
-
-          IF @DataDomainBoostHost IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_HOST=' + REPLACE(@DataDomainBoostHost,'''','''''') + '"'
-          IF @DataDomainBoostUser IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_USER=' + REPLACE(@DataDomainBoostUser,'''','''''') + '"'
-          IF @DataDomainBoostDevicePath IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DEVICE_PATH=' + REPLACE(@DataDomainBoostDevicePath,'''','''''') + '"'
-          IF @DataDomainBoostLockboxPath IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_LOCKBOX_PATH=' + REPLACE(@DataDomainBoostLockboxPath,'''','''''') + '"'
-          SET @CurrentCommand += ' -a "NSR_SKIP_NON_BACKUPABLE_STATE_DB=TRUE"'
-          SET @CurrentCommand += ' -a "BACKUP_PROMOTION=NONE"'
-          IF @CopyOnly = 'Y' SET @CurrentCommand += ' -a "NSR_COPY_ONLY=TRUE"'
-          IF @BackupSetName IS NOT NULL SET @CurrentCommand += ' -N "' + REPLACE(@BackupSetName,'''','''''') + '"'
-
-          IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentCommand += ' "MSSQL'
-          IF SERVERPROPERTY('InstanceName') IS NOT NULL SET @CurrentCommand += ' "MSSQL$' + CAST(SERVERPROPERTY('InstanceName') AS nvarchar)
-          SET @CurrentCommand += ':' + REPLACE(REPLACE(@CurrentDatabaseName,'''',''''''),'.','\.') + '"'
-
-          SET @CurrentCommand += ''''
-
-          SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing Data Domain Boost backup.'', 16, 1)'
-        END
-
-        EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
-        SET @Error = @@ERROR
-        IF @Error <> 0 SET @CurrentCommandOutput = @Error
-        IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
-        SET @CurrentBackupOutput = @CurrentCommandOutput
-      END
-
-      -- Verify the backup
-      IF @CurrentBackupOutput = 0 AND @Verify = 'Y'
-      BEGIN
-        WHILE (1 = 1)
-        BEGIN
-          SELECT TOP 1 @CurrentBackupSetID = ID,
-                       @CurrentIsMirror = Mirror
-          FROM @CurrentBackupSet
-          WHERE VerifyCompleted = 0
-          ORDER BY ID ASC
-
-          IF @@ROWCOUNT = 0
-          BEGIN
-            BREAK
-          END
-
-          IF @BackupSoftware IS NULL
-          BEGIN
-            SET @CurrentDatabaseContext = 'master'
-
-            SET @CurrentCommandType = 'RESTORE_VERIFYONLY'
-
-            SET @CurrentCommand = 'RESTORE VERIFYONLY FROM'
-
-            SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
-            FROM @CurrentFiles
-            WHERE Mirror = @CurrentIsMirror
-            ORDER BY FilePath ASC
+              SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
+              FROM @CurrentFiles
+              WHERE Mirror = 1
+              ORDER BY FilePath ASC
+            END
 
             SET @CurrentCommand += ' WITH '
             IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
             IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+
+            IF @Version >= 10
+            BEGIN
+              SET @CurrentCommand += CASE WHEN @Compress = 'Y' AND (@CurrentIsEncrypted = 0 OR (@CurrentIsEncrypted = 1 AND ((@Version >= 13 AND @CurrentMaxTransferSize >= 65537) OR @Version >= 15.0404316 OR SERVERPROPERTY('EngineEdition') = 8))) THEN ', COMPRESSION' ELSE ', NO_COMPRESSION' END
+            END
+
+            IF @Compress = 'Y' AND @CompressionAlgorithm IS NOT NULL
+            BEGIN
+              SET @CurrentCommand += ' (ALGORITHM = ' + @CompressionAlgorithm + CASE WHEN @CompressionLevel IS NOT NULL THEN ', LEVEL = ' + @CompressionLevel ELSE '' END + ')'
+            END
+
+            IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
+
+            IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
+            BEGIN
+              SET @CurrentCommand += ', FORMAT'
+            END
+
+            IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
+            IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
+            IF @Init = 'Y' SET @CurrentCommand += ', INIT'
+            IF @Format = 'Y' SET @CurrentCommand += ', FORMAT'
+            IF @BlockSize IS NOT NULL SET @CurrentCommand += ', BLOCKSIZE = ' + CAST(@BlockSize AS nvarchar)
+            IF @BufferCount IS NOT NULL SET @CurrentCommand += ', BUFFERCOUNT = ' + CAST(@BufferCount AS nvarchar)
+            IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', MAXTRANSFERSIZE = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
+            IF @Description IS NOT NULL SET @CurrentCommand += ', DESCRIPTION = N''' + REPLACE(@Description,'''','''''') + ''''
+            IF @BackupSetName IS NOT NULL SET @CurrentCommand += ', NAME = N''' + REPLACE(@BackupSetName,'''','''''') + ''''
             IF @Stats IS NOT NULL SET @CurrentCommand += ', STATS = ' + CAST(@Stats AS nvarchar)
-            IF @BackupOptions IS NOT NULL SET @CurrentCommand += ', RESTORE_OPTIONS = N''' + REPLACE(@BackupOptions,'''','''''') + ''''
+            IF @BackupOptions IS NOT NULL SET @CurrentCommand += ', BACKUP_OPTIONS = N''' + REPLACE(@BackupOptions,'''','''''') + ''''
+            IF @Encrypt = 'Y' SET @CurrentCommand += ', ENCRYPTION (ALGORITHM = ' + UPPER(@EncryptionAlgorithm) + ', '
+            IF @Encrypt = 'Y' AND @ServerCertificate IS NOT NULL SET @CurrentCommand += 'SERVER CERTIFICATE = ' + QUOTENAME(@ServerCertificate)
+            IF @Encrypt = 'Y' AND @ServerAsymmetricKey IS NOT NULL SET @CurrentCommand += 'SERVER ASYMMETRIC KEY = ' + QUOTENAME(@ServerAsymmetricKey)
+            IF @Encrypt = 'Y' SET @CurrentCommand += ')'
             IF @URL IS NOT NULL AND @Credential IS NOT NULL SET @CurrentCommand += ', CREDENTIAL = N''' + REPLACE(@Credential,'''','''''') + ''''
+            IF @ExpireDate IS NOT NULL SET @CurrentCommand += ', EXPIREDATE = ''' + CONVERT(nvarchar, @ExpireDate, 21) + ''''
+            IF @RetainDays IS NOT NULL SET @CurrentCommand += ', RETAINDAYS = ' + CAST(@RetainDays AS nvarchar)
           END
 
           IF @BackupSoftware = 'LITESPEED'
           BEGIN
             SET @CurrentDatabaseContext = 'master'
 
-            SET @CurrentCommandType = 'xp_restore_verifyonly'
+            SELECT @CurrentCommandType = CASE
+            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'xp_backup_database'
+            WHEN @CurrentBackupType = 'LOG' THEN 'xp_backup_log'
+            END
 
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_restore_verifyonly'
+            SELECT @CurrentCommand = CASE
+            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_backup_database @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
+            WHEN @CurrentBackupType = 'LOG' THEN 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_backup_log @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
+            END
 
-            SELECT @CurrentCommand += ' @filename = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
+            SELECT @CurrentCommand += ', @filename = N''' + REPLACE(FilePath,'''','''''') + ''''
             FROM @CurrentFiles
-            WHERE Mirror = @CurrentIsMirror
+            WHERE Mirror = 0
             ORDER BY FilePath ASC
+
+            IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
+            BEGIN
+              SELECT @CurrentCommand += ', @mirror = N''' + REPLACE(FilePath,'''','''''') + ''''
+              FROM @CurrentFiles
+              WHERE Mirror = 1
+              ORDER BY FilePath ASC
+            END
 
             SET @CurrentCommand += ', @with = '''
             IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
             IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+            IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
+            IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
+            IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
+            IF @BlockSize IS NOT NULL SET @CurrentCommand += ', BLOCKSIZE = ' + CAST(@BlockSize AS nvarchar)
             SET @CurrentCommand += ''''
-            IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptionkey = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ', @read_write_filegroups = 1'
+            IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', @compressionlevel = ' + CAST(@CompressionLevelNumeric AS nvarchar)
+            IF @AdaptiveCompression IS NOT NULL SET @CurrentCommand += ', @adaptivecompression = ''' + CASE WHEN @AdaptiveCompression = 'SIZE' THEN 'Size' WHEN @AdaptiveCompression = 'SPEED' THEN 'Speed' END + ''''
+            IF @BufferCount IS NOT NULL SET @CurrentCommand += ', @buffercount = ' + CAST(@BufferCount AS nvarchar)
+            IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', @maxtransfersize = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
+            IF @Threads IS NOT NULL SET @CurrentCommand += ', @threads = ' + CAST(@Threads AS nvarchar)
+            IF @Init = 'Y' SET @CurrentCommand += ', @init = 1'
+            IF @Format = 'Y' SET @CurrentCommand += ', @format = 1'
+            IF @Throttle IS NOT NULL SET @CurrentCommand += ', @throttle = ' + CAST(@Throttle AS nvarchar)
+            IF @Description IS NOT NULL SET @CurrentCommand += ', @desc = N''' + REPLACE(@Description,'''','''''') + ''''
+            IF @ObjectLevelRecoveryMap = 'Y' SET @CurrentCommand += ', @olrmap = 1'
+            IF @ExpireDate IS NOT NULL SET @CurrentCommand += ', @expiration = ''' + CONVERT(nvarchar, @ExpireDate, 21) + ''''
+            IF @RetainDays IS NOT NULL SET @CurrentCommand += ', @retaindays = ' + CAST(@RetainDays AS nvarchar)
 
-            SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error verifying LiteSpeed backup.'', 16, 1)'
+            IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', @cryptlevel = ' + CASE
+            WHEN @EncryptionAlgorithm = 'RC2_40' THEN '0'
+            WHEN @EncryptionAlgorithm = 'RC2_56' THEN '1'
+            WHEN @EncryptionAlgorithm = 'RC2_112' THEN '2'
+            WHEN @EncryptionAlgorithm = 'RC2_128' THEN '3'
+            WHEN @EncryptionAlgorithm = 'TRIPLE_DES_3KEY' THEN '4'
+            WHEN @EncryptionAlgorithm = 'RC4_128' THEN '5'
+            WHEN @EncryptionAlgorithm = 'AES_128' THEN '6'
+            WHEN @EncryptionAlgorithm = 'AES_192' THEN '7'
+            WHEN @EncryptionAlgorithm = 'AES_256' THEN '8'
+            END
+
+            IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptionkey = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+            SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing LiteSpeed backup.'', 16, 1)'
           END
 
           IF @BackupSoftware = 'SQLBACKUP'
@@ -4630,167 +4493,365 @@ BEGIN
 
             SET @CurrentCommandType = 'sqlbackup'
 
-            SET @CurrentCommand = 'RESTORE VERIFYONLY FROM'
+            SELECT @CurrentCommand = CASE
+            WHEN @CurrentBackupType IN('DIFF','FULL') THEN 'BACKUP DATABASE ' + QUOTENAME(@CurrentDatabaseName)
+            WHEN @CurrentBackupType = 'LOG' THEN 'BACKUP LOG ' + QUOTENAME(@CurrentDatabaseName)
+            END
+
+            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' READ_WRITE_FILEGROUPS'
+
+            SET @CurrentCommand += ' TO'
 
             SELECT @CurrentCommand += ' DISK = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
             FROM @CurrentFiles
-            WHERE Mirror = @CurrentIsMirror
+            WHERE Mirror = 0
             ORDER BY FilePath ASC
 
             SET @CurrentCommand += ' WITH '
+
+            IF EXISTS(SELECT * FROM @CurrentFiles WHERE Mirror = 1)
+            BEGIN
+              SET @CurrentCommand += ' MIRRORFILE' + ' = N''' + REPLACE((SELECT FilePath FROM @CurrentFiles WHERE Mirror = 1),'''','''''') + ''', '
+            END
+
             IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
             IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
-            IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', PASSWORD = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+            IF @CurrentBackupType = 'DIFF' SET @CurrentCommand += ', DIFFERENTIAL'
+            IF @CopyOnly = 'Y' SET @CurrentCommand += ', COPY_ONLY'
+            IF @NoRecovery = 'Y' AND @CurrentBackupType = 'LOG' SET @CurrentCommand += ', NORECOVERY'
+            IF @Init = 'Y' SET @CurrentCommand += ', INIT'
+            IF @Format = 'Y' SET @CurrentCommand += ', FORMAT'
+            IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', COMPRESSION = ' + CAST(@CompressionLevelNumeric AS nvarchar)
+            IF @Threads IS NOT NULL SET @CurrentCommand += ', THREADCOUNT = ' + CAST(@Threads AS nvarchar)
+            IF @CurrentMaxTransferSize IS NOT NULL SET @CurrentCommand += ', MAXTRANSFERSIZE = ' + CAST(@CurrentMaxTransferSize AS nvarchar)
+            IF @Description IS NOT NULL SET @CurrentCommand += ', DESCRIPTION = N''' + REPLACE(@Description,'''','''''') + ''''
 
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqlbackup N''-SQL "' + REPLACE(@CurrentCommand,'''','''''') + '"''' + ' IF @ReturnCode <> 0 RAISERROR(''Error verifying SQLBackup backup.'', 16, 1)'
+            IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', KEYSIZE = ' + CASE
+            WHEN @EncryptionAlgorithm = 'AES_128' THEN '128'
+            WHEN @EncryptionAlgorithm = 'AES_256' THEN '256'
+            END
+
+            IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', PASSWORD = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqlbackup N''-SQL "' + REPLACE(@CurrentCommand,'''','''''') + '"''' + ' IF @ReturnCode <> 0 RAISERROR(''Error performing SQLBackup backup.'', 16, 1)'
           END
 
           IF @BackupSoftware = 'SQLSAFE'
           BEGIN
             SET @CurrentDatabaseContext = 'master'
 
-            SET @CurrentCommandType = 'xp_ss_verify'
+            SET @CurrentCommandType = 'xp_ss_backup'
 
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_verify @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
+            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_backup @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
 
             SELECT @CurrentCommand += ', ' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) = 1 THEN '@filename' ELSE '@backupfile' END + ' = N''' + REPLACE(FilePath,'''','''''') + ''''
             FROM @CurrentFiles
-            WHERE Mirror = @CurrentIsMirror
+            WHERE Mirror = 0
             ORDER BY FilePath ASC
 
-            SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error verifying SQLsafe backup.'', 16, 1)'
+            SELECT @CurrentCommand += ', @mirrorfile = N''' + REPLACE(FilePath,'''','''''') + ''''
+            FROM @CurrentFiles
+            WHERE Mirror = 1
+            ORDER BY FilePath ASC
+
+            SET @CurrentCommand += ', @backuptype = ' + CASE WHEN @CurrentBackupType = 'FULL' THEN '''Full''' WHEN @CurrentBackupType = 'DIFF' THEN '''Differential''' WHEN @CurrentBackupType = 'LOG' THEN '''Log''' END
+            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ', @readwritefilegroups = 1'
+            SET @CurrentCommand += ', @checksum = ' + CASE WHEN @Checksum = 'Y' THEN '1' WHEN @Checksum = 'N' THEN '0' END
+            SET @CurrentCommand += ', @copyonly = ' + CASE WHEN @CopyOnly = 'Y' THEN '1' WHEN @CopyOnly = 'N' THEN '0' END
+            IF @CompressionLevelNumeric IS NOT NULL SET @CurrentCommand += ', @compressionlevel = ' + CAST(@CompressionLevelNumeric AS nvarchar)
+            IF @Threads IS NOT NULL SET @CurrentCommand += ', @threads = ' + CAST(@Threads AS nvarchar)
+            IF @Init = 'Y' SET @CurrentCommand += ', @overwrite = 1'
+            IF @Description IS NOT NULL SET @CurrentCommand += ', @desc = N''' + REPLACE(@Description,'''','''''') + ''''
+
+            IF @EncryptionAlgorithm IS NOT NULL SET @CurrentCommand += ', @encryptiontype = N''' + CASE
+            WHEN @EncryptionAlgorithm = 'AES_128' THEN 'AES128'
+            WHEN @EncryptionAlgorithm = 'AES_256' THEN 'AES256'
+            END + ''''
+
+            IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptedbackuppassword = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+            SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing SQLsafe backup.'', 16, 1)'
+          END
+
+          IF @BackupSoftware = 'DATA_DOMAIN_BOOST'
+          BEGIN
+            SET @CurrentDatabaseContext = 'master'
+
+            SET @CurrentCommandType = 'emc_run_backup'
+
+            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.emc_run_backup '''
+
+            SET @CurrentCommand += ' -c ' + CASE WHEN @Cluster IS NOT NULL AND @CurrentAvailabilityGroup IS NOT NULL THEN @Cluster ELSE CAST(SERVERPROPERTY('MachineName') AS nvarchar) END
+
+            SET @CurrentCommand += ' -l ' + CASE
+            WHEN @CurrentBackupType = 'FULL' THEN 'full'
+            WHEN @CurrentBackupType = 'DIFF' THEN 'diff'
+            WHEN @CurrentBackupType = 'LOG' THEN 'incr'
+            END
+
+            IF @NoRecovery = 'Y' SET @CurrentCommand += ' -H'
+
+            IF @CleanupTime IS NOT NULL SET @CurrentCommand += ' -y +' + CAST(@CleanupTime/24 + CASE WHEN @CleanupTime%24 > 0 THEN 1 ELSE 0 END AS nvarchar) + 'd'
+
+            IF @Checksum = 'Y' SET @CurrentCommand += ' -k'
+
+            SET @CurrentCommand += ' -S ' + CAST(@CurrentNumberOfFiles AS nvarchar)
+
+            IF @Description IS NOT NULL SET @CurrentCommand += ' -b "' + REPLACE(@Description,'''','''''') + '"'
+
+            IF @BufferCount IS NOT NULL SET @CurrentCommand += ' -O "BUFFERCOUNT=' + CAST(@BufferCount AS nvarchar) + '"'
+
+            IF @ReadWriteFileGroups = 'Y' AND @CurrentDatabaseName <> 'master' SET @CurrentCommand += ' -O "READ_WRITE_FILEGROUPS"'
+
+            IF @DataDomainBoostHost IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_HOST=' + REPLACE(@DataDomainBoostHost,'''','''''') + '"'
+            IF @DataDomainBoostUser IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_USER=' + REPLACE(@DataDomainBoostUser,'''','''''') + '"'
+            IF @DataDomainBoostDevicePath IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DEVICE_PATH=' + REPLACE(@DataDomainBoostDevicePath,'''','''''') + '"'
+            IF @DataDomainBoostLockboxPath IS NOT NULL SET @CurrentCommand += ' -a "NSR_DFA_SI_DD_LOCKBOX_PATH=' + REPLACE(@DataDomainBoostLockboxPath,'''','''''') + '"'
+            SET @CurrentCommand += ' -a "NSR_SKIP_NON_BACKUPABLE_STATE_DB=TRUE"'
+            SET @CurrentCommand += ' -a "BACKUP_PROMOTION=NONE"'
+            IF @CopyOnly = 'Y' SET @CurrentCommand += ' -a "NSR_COPY_ONLY=TRUE"'
+            IF @BackupSetName IS NOT NULL SET @CurrentCommand += ' -N "' + REPLACE(@BackupSetName,'''','''''') + '"'
+
+            IF SERVERPROPERTY('InstanceName') IS NULL SET @CurrentCommand += ' "MSSQL'
+            IF SERVERPROPERTY('InstanceName') IS NOT NULL SET @CurrentCommand += ' "MSSQL$' + CAST(SERVERPROPERTY('InstanceName') AS nvarchar)
+            SET @CurrentCommand += ':' + REPLACE(REPLACE(@CurrentDatabaseName,'''',''''''),'.','\.') + '"'
+
+            SET @CurrentCommand += ''''
+
+            SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error performing Data Domain Boost backup.'', 16, 1)'
           END
 
           EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
           SET @Error = @@ERROR
           IF @Error <> 0 SET @CurrentCommandOutput = @Error
           IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
-
-          UPDATE @CurrentBackupSet
-          SET VerifyCompleted = 1,
-              VerifyOutput = @CurrentCommandOutput
-          WHERE ID = @CurrentBackupSetID
-
-          SET @CurrentBackupSetID = NULL
-          SET @CurrentIsMirror = NULL
-
-          SET @CurrentDatabaseContext = NULL
-          SET @CurrentCommand = NULL
-          SET @CurrentCommandOutput = NULL
-          SET @CurrentCommandType = NULL
+          SET @CurrentBackupOutput = @CurrentCommandOutput
         END
-      END
 
-      IF @CleanupMode = 'AFTER_BACKUP'
-      BEGIN
-        INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
-        SELECT DATEADD(hh,-(@CleanupTime),SYSDATETIME()), 0
-
-        IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 0 OR Mirror IS NULL) AND CleanupDate IS NULL)
+        -- Verify the backup
+        IF @CurrentBackupOutput = 0 AND @Verify = 'Y'
         BEGIN
-          UPDATE @CurrentDirectories
-          SET CleanupDate = (SELECT MIN(CleanupDate)
-                             FROM @CurrentCleanupDates
-                             WHERE (Mirror = 0 OR Mirror IS NULL)),
-              CleanupMode = 'AFTER_BACKUP'
-          WHERE Mirror = 0
+          WHILE (1 = 1)
+          BEGIN
+            SELECT TOP 1 @CurrentBackupSetID = ID,
+                         @CurrentIsMirror = Mirror
+            FROM @CurrentBackupSet
+            WHERE VerifyCompleted = 0
+            ORDER BY ID ASC
+
+            IF @@ROWCOUNT = 0
+            BEGIN
+              BREAK
+            END
+
+            IF @BackupSoftware IS NULL
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'RESTORE_VERIFYONLY'
+
+              SET @CurrentCommand = 'RESTORE VERIFYONLY FROM'
+
+              SELECT @CurrentCommand += ' ' + [Type] + ' = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
+              FROM @CurrentFiles
+              WHERE Mirror = @CurrentIsMirror
+              ORDER BY FilePath ASC
+
+              SET @CurrentCommand += ' WITH '
+              IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
+              IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+              IF @Stats IS NOT NULL SET @CurrentCommand += ', STATS = ' + CAST(@Stats AS nvarchar)
+              IF @BackupOptions IS NOT NULL SET @CurrentCommand += ', RESTORE_OPTIONS = N''' + REPLACE(@BackupOptions,'''','''''') + ''''
+              IF @URL IS NOT NULL AND @Credential IS NOT NULL SET @CurrentCommand += ', CREDENTIAL = N''' + REPLACE(@Credential,'''','''''') + ''''
+            END
+
+            IF @BackupSoftware = 'LITESPEED'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_restore_verifyonly'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_restore_verifyonly'
+
+              SELECT @CurrentCommand += ' @filename = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
+              FROM @CurrentFiles
+              WHERE Mirror = @CurrentIsMirror
+              ORDER BY FilePath ASC
+
+              SET @CurrentCommand += ', @with = '''
+              IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
+              IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+              SET @CurrentCommand += ''''
+              IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', @encryptionkey = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+
+              SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error verifying LiteSpeed backup.'', 16, 1)'
+            END
+
+            IF @BackupSoftware = 'SQLBACKUP'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'sqlbackup'
+
+              SET @CurrentCommand = 'RESTORE VERIFYONLY FROM'
+
+              SELECT @CurrentCommand += ' DISK = N''' + REPLACE(FilePath,'''','''''') + '''' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) <> @CurrentNumberOfFiles THEN ',' ELSE '' END
+              FROM @CurrentFiles
+              WHERE Mirror = @CurrentIsMirror
+              ORDER BY FilePath ASC
+
+              SET @CurrentCommand += ' WITH '
+              IF @Checksum = 'Y' SET @CurrentCommand += 'CHECKSUM'
+              IF @Checksum = 'N' SET @CurrentCommand += 'NO_CHECKSUM'
+              IF @EncryptionKey IS NOT NULL SET @CurrentCommand += ', PASSWORD = N''' + REPLACE(@EncryptionKey,'''','''''') + ''''
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqlbackup N''-SQL "' + REPLACE(@CurrentCommand,'''','''''') + '"''' + ' IF @ReturnCode <> 0 RAISERROR(''Error verifying SQLBackup backup.'', 16, 1)'
+            END
+
+            IF @BackupSoftware = 'SQLSAFE'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_ss_verify'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_verify @database = N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''''
+
+              SELECT @CurrentCommand += ', ' + CASE WHEN ROW_NUMBER() OVER (ORDER BY FilePath ASC) = 1 THEN '@filename' ELSE '@backupfile' END + ' = N''' + REPLACE(FilePath,'''','''''') + ''''
+              FROM @CurrentFiles
+              WHERE Mirror = @CurrentIsMirror
+              ORDER BY FilePath ASC
+
+              SET @CurrentCommand += ' IF @ReturnCode <> 0 RAISERROR(''Error verifying SQLsafe backup.'', 16, 1)'
+            END
+
+            EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
+            SET @Error = @@ERROR
+            IF @Error <> 0 SET @CurrentCommandOutput = @Error
+            IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
+
+            UPDATE @CurrentBackupSet
+            SET VerifyCompleted = 1,
+                VerifyOutput = @CurrentCommandOutput
+            WHERE ID = @CurrentBackupSetID
+
+            SET @CurrentBackupSetID = NULL
+            SET @CurrentIsMirror = NULL
+
+            SET @CurrentDatabaseContext = NULL
+            SET @CurrentCommand = NULL
+            SET @CurrentCommandOutput = NULL
+            SET @CurrentCommandType = NULL
+          END
         END
-      END
 
-      IF @MirrorCleanupMode = 'AFTER_BACKUP'
-      BEGIN
-        INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
-        SELECT DATEADD(hh,-(@MirrorCleanupTime),SYSDATETIME()), 1
-
-        IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 1 OR Mirror IS NULL) AND CleanupDate IS NULL)
+        IF @CleanupMode = 'AFTER_BACKUP'
         BEGIN
-          UPDATE @CurrentDirectories
-          SET CleanupDate = (SELECT MIN(CleanupDate)
-                             FROM @CurrentCleanupDates
-                             WHERE (Mirror = 1 OR Mirror IS NULL)),
-              CleanupMode = 'AFTER_BACKUP'
-          WHERE Mirror = 1
-        END
-      END
+          INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
+          SELECT DATEADD(hh,-(@CleanupTime),SYSDATETIME()), 0
 
-      -- Delete old backup files, after backup
-      IF ((@CurrentBackupOutput = 0 AND @Verify = 'N')
-      OR (@CurrentBackupOutput = 0 AND @Verify = 'Y' AND NOT EXISTS (SELECT * FROM @CurrentBackupSet WHERE VerifyOutput <> 0 OR VerifyOutput IS NULL)))
-      AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
-      AND @CurrentBackupType = @BackupType
-      BEGIN
-        WHILE (1 = 1)
+          IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 0 OR Mirror IS NULL) AND CleanupDate IS NULL)
+          BEGIN
+            UPDATE @CurrentDirectories
+            SET CleanupDate = (SELECT MIN(CleanupDate)
+                               FROM @CurrentCleanupDates
+                               WHERE (Mirror = 0 OR Mirror IS NULL)),
+                CleanupMode = 'AFTER_BACKUP'
+            WHERE Mirror = 0
+          END
+        END
+
+        IF @MirrorCleanupMode = 'AFTER_BACKUP'
         BEGIN
-          SELECT TOP 1 @CurrentDirectoryID = ID,
-                       @CurrentDirectoryPath = DirectoryPath,
-                       @CurrentCleanupDate = CleanupDate
-          FROM @CurrentDirectories
-          WHERE CleanupDate IS NOT NULL
-          AND CleanupMode = 'AFTER_BACKUP'
-          AND CleanupCompleted = 0
-          ORDER BY ID ASC
+          INSERT INTO @CurrentCleanupDates (CleanupDate, Mirror)
+          SELECT DATEADD(hh,-(@MirrorCleanupTime),SYSDATETIME()), 1
 
-          IF @@ROWCOUNT = 0
+          IF NOT EXISTS(SELECT * FROM @CurrentCleanupDates WHERE (Mirror = 1 OR Mirror IS NULL) AND CleanupDate IS NULL)
           BEGIN
-            BREAK
+            UPDATE @CurrentDirectories
+            SET CleanupDate = (SELECT MIN(CleanupDate)
+                               FROM @CurrentCleanupDates
+                               WHERE (Mirror = 1 OR Mirror IS NULL)),
+                CleanupMode = 'AFTER_BACKUP'
+            WHERE Mirror = 1
           END
-
-          IF @BackupSoftware IS NULL
-          BEGIN
-            SET @CurrentDatabaseContext = 'master'
-
-            SET @CurrentCommandType = 'xp_delete_file'
-
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_delete_file 0, N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + @CurrentFileExtension + ''', ''' + CONVERT(nvarchar(19),@CurrentCleanupDate,126) + ''' IF @ReturnCode <> 0 RAISERROR(''Error deleting files.'', 16, 1)'
-          END
-
-          IF @BackupSoftware = 'LITESPEED'
-          BEGIN
-            SET @CurrentDatabaseContext = 'master'
-
-            SET @CurrentCommandType = 'xp_slssqlmaint'
-
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_slssqlmaint N''-MAINTDEL -DELFOLDER "' + REPLACE(@CurrentDirectoryPath,'''','''''') + '" -DELEXTENSION "' + @CurrentFileExtension + '" -DELUNIT "' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + '" -DELUNITTYPE "minutes" -DELUSEAGE'' IF @ReturnCode <> 0 RAISERROR(''Error deleting LiteSpeed backup files.'', 16, 1)'
-          END
-
-          IF @BackupSoftware = 'SQLBACKUP'
-          BEGIN
-            SET @CurrentDatabaseContext = 'master'
-
-            SET @CurrentCommandType = 'sqbutility'
-
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqbutility 1032, N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''', N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + CASE WHEN @CurrentBackupType = 'FULL' THEN 'D' WHEN @CurrentBackupType = 'DIFF' THEN 'I' WHEN @CurrentBackupType = 'LOG' THEN 'L' END + ''', ''' + CAST(DATEDIFF(hh,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'h'', ' + ISNULL('''' + REPLACE(@EncryptionKey,'''','''''') + '''','NULL') + ' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLBackup backup files.'', 16, 1)'
-          END
-
-          IF @BackupSoftware = 'SQLSAFE'
-          BEGIN
-            SET @CurrentDatabaseContext = 'master'
-
-            SET @CurrentCommandType = 'xp_ss_delete'
-
-            SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_delete @filename = N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + '\*.' + @CurrentFileExtension + ''', @age = ''' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'Minutes'' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLsafe backup files.'', 16, 1)'
-          END
-
-          EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
-          SET @Error = @@ERROR
-          IF @Error <> 0 SET @CurrentCommandOutput = @Error
-          IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
-
-          UPDATE @CurrentDirectories
-          SET CleanupCompleted = 1,
-              CleanupOutput = @CurrentCommandOutput
-          WHERE ID = @CurrentDirectoryID
-
-          SET @CurrentDirectoryID = NULL
-          SET @CurrentDirectoryPath = NULL
-          SET @CurrentCleanupDate = NULL
-
-          SET @CurrentDatabaseContext = NULL
-          SET @CurrentCommand = NULL
-          SET @CurrentCommandOutput = NULL
-          SET @CurrentCommandType = NULL
         END
-      END
+
+        -- Delete old backup files, after backup
+        IF ((@CurrentBackupOutput = 0 AND @Verify = 'N')
+        OR (@CurrentBackupOutput = 0 AND @Verify = 'Y' AND NOT EXISTS (SELECT * FROM @CurrentBackupSet WHERE VerifyOutput <> 0 OR VerifyOutput IS NULL)))
+        AND (@BackupSoftware <> 'DATA_DOMAIN_BOOST' OR @BackupSoftware IS NULL)
+        AND @CurrentBackupType = @BackupType
+        BEGIN
+          WHILE (1 = 1)
+          BEGIN
+            SELECT TOP 1 @CurrentDirectoryID = ID,
+                         @CurrentDirectoryPath = DirectoryPath,
+                         @CurrentCleanupDate = CleanupDate
+            FROM @CurrentDirectories
+            WHERE CleanupDate IS NOT NULL
+            AND CleanupMode = 'AFTER_BACKUP'
+            AND CleanupCompleted = 0
+            ORDER BY ID ASC
+
+            IF @@ROWCOUNT = 0
+            BEGIN
+              BREAK
+            END
+
+            IF @BackupSoftware IS NULL
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_delete_file'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_delete_file 0, N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + @CurrentFileExtension + ''', ''' + CONVERT(nvarchar(19),@CurrentCleanupDate,126) + ''' IF @ReturnCode <> 0 RAISERROR(''Error deleting files.'', 16, 1)'
+            END
+
+            IF @BackupSoftware = 'LITESPEED'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_slssqlmaint'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_slssqlmaint N''-MAINTDEL -DELFOLDER "' + REPLACE(@CurrentDirectoryPath,'''','''''') + '" -DELEXTENSION "' + @CurrentFileExtension + '" -DELUNIT "' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + '" -DELUNITTYPE "minutes" -DELUSEAGE'' IF @ReturnCode <> 0 RAISERROR(''Error deleting LiteSpeed backup files.'', 16, 1)'
+            END
+
+            IF @BackupSoftware = 'SQLBACKUP'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'sqbutility'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.sqbutility 1032, N''' + REPLACE(@CurrentDatabaseName,'''','''''') + ''', N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + ''', ''' + CASE WHEN @CurrentBackupType = 'FULL' THEN 'D' WHEN @CurrentBackupType = 'DIFF' THEN 'I' WHEN @CurrentBackupType = 'LOG' THEN 'L' END + ''', ''' + CAST(DATEDIFF(hh,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'h'', ' + ISNULL('''' + REPLACE(@EncryptionKey,'''','''''') + '''','NULL') + ' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLBackup backup files.'', 16, 1)'
+            END
+
+            IF @BackupSoftware = 'SQLSAFE'
+            BEGIN
+              SET @CurrentDatabaseContext = 'master'
+
+              SET @CurrentCommandType = 'xp_ss_delete'
+
+              SET @CurrentCommand = 'DECLARE @ReturnCode int EXECUTE @ReturnCode = dbo.xp_ss_delete @filename = N''' + REPLACE(@CurrentDirectoryPath,'''','''''') + '\*.' + @CurrentFileExtension + ''', @age = ''' + CAST(DATEDIFF(mi,@CurrentCleanupDate,SYSDATETIME()) + 1 AS nvarchar) + 'Minutes'' IF @ReturnCode <> 0 RAISERROR(''Error deleting SQLsafe backup files.'', 16, 1)'
+            END
+
+            EXECUTE @CurrentCommandOutput = dbo.CommandExecute @DatabaseContext = @CurrentDatabaseContext, @Command = @CurrentCommand, @CommandType = @CurrentCommandType, @Mode = 1, @DatabaseName = @CurrentDatabaseName, @LogToTable = @LogToTable, @Execute = @Execute
+            SET @Error = @@ERROR
+            IF @Error <> 0 SET @CurrentCommandOutput = @Error
+            IF @CurrentCommandOutput <> 0 SET @ReturnCode = @CurrentCommandOutput
+
+            UPDATE @CurrentDirectories
+            SET CleanupCompleted = 1,
+                CleanupOutput = @CurrentCommandOutput
+            WHERE ID = @CurrentDirectoryID
+
+            SET @CurrentDirectoryID = NULL
+            SET @CurrentDirectoryPath = NULL
+            SET @CurrentCleanupDate = NULL
+
+            SET @CurrentDatabaseContext = NULL
+            SET @CurrentCommand = NULL
+            SET @CurrentCommandOutput = NULL
+            SET @CurrentCommandType = NULL
+          END
+        END
 
         UPDATE @tmpFileGroups
         SET Completed = 1
@@ -4816,9 +4877,9 @@ BEGIN
           BREAK
         END
 
-    END
+      END -- End of file group while loop
 
-    END
+    END -- End of database backup check
 
     IF @CurrentDatabaseState = 'SUSPECT'
     BEGIN
@@ -4888,7 +4949,7 @@ BEGIN
     SET @CurrentAllocatedExtentPageCount = NULL
     SET @CurrentModifiedExtentPageCount = NULL
 
-  END
+  END -- End of database while loop
 
   ----------------------------------------------------------------------------------------------------
   --// Log completing information                                                                 //--
@@ -4951,7 +5012,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-08 12:16:23                                                               //--
+  --// Version: 2025-06-08 20:41:55                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON
@@ -6850,7 +6911,7 @@ BEGIN
   --// Source:  https://ola.hallengren.com                                                        //--
   --// License: https://ola.hallengren.com/license.html                                           //--
   --// GitHub:  https://github.com/olahallengren/sql-server-maintenance-solution                  //--
-  --// Version: 2025-06-08 12:16:23                                                               //--
+  --// Version: 2025-06-08 20:41:55                                                               //--
   ----------------------------------------------------------------------------------------------------
 
   SET NOCOUNT ON


### PR DESCRIPTION
I'm working on adding support for file group backup.

**Usage:**

```
EXECUTE dbo.DatabaseBackup
@Databases = 'WideWorldImporters',
@Directory = 'C:\Backup',
@BackupType = 'FULL',
@Verify = 'Y',
@FileGroups = 'WideWorldImporters.USERDATA, WideWorldImporters.USERDATA2',
@NumberOfFiles = 4
```

**Outstanding issues:**

* The primary filegroup cannot be backed up if the database is in the SIMPLE recovery model.
* The primary filegroup and any memory-optimized filegroup must be backed up together.

I need to add handling of these cases.