### PR TITLE
Enhance JobCursor declaration to filter job steps by database name

### DIFF
--- a/MaintenanceSolution.sql
+++ b/MaintenanceSolution.sql
@@ -9492,7 +9492,7 @@ DECLARE @AmazonRDS bit = CASE WHEN SERVERPROPERTY('EngineEdition') IN (5, 8) THE
 IF @AmazonRDS = 0
 BEGIN
 
-  DECLARE JobCursor CURSOR FAST_FORWARD FOR SELECT job_id, step_id, command FROM msdb.dbo.sysjobsteps WHERE command LIKE '%DatabaseBackup%@CheckSum%' COLLATE SQL_Latin1_General_CP1_CS_AS
+  DECLARE JobCursor CURSOR FAST_FORWARD FOR SELECT js.job_id, js.step_id, js.command FROM msdb.dbo.sysjobsteps js WHERE js.command LIKE '%DatabaseBackup%@CheckSum%' COLLATE SQL_Latin1_General_CP1_CS_AS AND (js.database_name IS NULL OR js.database_name = '' OR EXISTS (SELECT 1 FROM sys.databases d WHERE d.[name] = js.database_name))
 
   OPEN JobCursor
 


### PR DESCRIPTION
https://github.com/olahallengren/sql-server-maintenance-solution/issues/993 


Root cause: The last block of the updated Hallengren SQLServerMaintenance.sql script (lines 9487–9514) runs unconditionally — it is not guarded by the @CreateJobs = 'N' check. This block cursors through msdb.dbo.sysjobsteps looking for existing job steps that use the old @CheckSum casing, and calls sp_update_jobstep to fix them to @Checksum.
When sp_update_jobstep is called, SQL Server Agent internally calls sp_verify_jobstep, which re-validates the database_name field of the existing job step. Orphaned SQL Agent job steps from a previous deployment test still reference 