### PR TITLE
feat: get default credential if not set

### DIFF
--- a/MaintenanceSolution.sql
+++ b/MaintenanceSolution.sql
@@ -1596,6 +1596,18 @@ BEGIN
   END
 
   ----------------------------------------------------------------------------------------------------
+  --// Get default credential for S3/Azure backup                                                 //--
+  ----------------------------------------------------------------------------------------------------
+
+  IF @URL IS NOT NULL AND @Credential IS NULL
+  BEGIN
+    SELECT TOP 1 @Credential = name
+    FROM sys.credentials
+    WHERE UPPER(credential_identity) IN ('SHARED ACCESS SIGNATURE','MANAGED IDENTITY','S3 ACCESS KEY')
+    ORDER BY name ASC
+  END
+
+  ----------------------------------------------------------------------------------------------------
   --// Check input parameters                                                                     //--
   ----------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Added logic that automatically populates @Credential with the first matching S3/Azure credential if:

@URL is specified (cloud backup)
@Credential is NOT explicitly provided

This is useful when the credential is not explicitly defined.